### PR TITLE
V2 API Service, TeamContext Model, and Auth Stubs

### DIFF
--- a/src/app/models/process.interface.ts
+++ b/src/app/models/process.interface.ts
@@ -1,4 +1,34 @@
-// libs/akgentic/akgentic/core/akgent_address_impl.py -> serialize()
+/**
+ * @deprecated Use TeamContext from './team.interface' instead.
+ * This file is kept temporarily for backward compatibility with components
+ * that still reference ProcessContext (Story 1.2 will migrate them).
+ */
+
+import { TeamContext } from './team.interface';
+
+/**
+ * Backward-compatible alias for TeamContext.
+ * Adds V1 fields (id, running, description, params) so that
+ * un-migrated components continue to compile and work at runtime.
+ * Story 1.2 will remove this file entirely.
+ */
+export interface ProcessContext extends TeamContext {
+  /** @deprecated Use team_id */
+  id: string;
+  /** @deprecated Use isRunning(team) helper */
+  running: boolean;
+  /** @deprecated Removed in V2 */
+  params: ProcessParams;
+}
+
+export type ProcessContextArray = ProcessContext[];
+
+// Legacy stub -- no V2 equivalent
+export interface ProcessParams {
+  workspace: boolean;
+  knowledge_graph: boolean;
+}
+
 export interface ActorAddress {
   __actor_address__: boolean;
   address: string;
@@ -7,26 +37,3 @@ export interface ActorAddress {
   agent_id: string;
   squad_id?: string;
 }
-
-// backend/server/models/process.py
-export interface ProcessContext {
-  id: string;
-  name: string;
-  description?: string | null;
-  created_at: string;
-  orchestrator: ActorAddress;
-  user_proxy: ActorAddress | null;
-  user_proxy_class: string | null;
-  user_id: string;
-  user_email: string;
-  config_name: string;
-  params: ProcessParams;
-  running: boolean; // Added dynamically in /processes endpoint only
-}
-
-export interface ProcessParams {
-  workspace: boolean;
-  knowledge_graph: boolean;
-}
-
-export type ProcessContextArray = ProcessContext[];

--- a/src/app/models/team.interface.ts
+++ b/src/app/models/team.interface.ts
@@ -79,8 +79,10 @@ export function toTeamContext(response: TeamResponse): TeamContext {
     status: response.status,
     created_at: response.created_at,
     updated_at: response.updated_at,
+    // config_name is not in TeamResponse -- V2 does not return it.
+    // Use team name as placeholder; Story 1.2 will populate from catalog.
     config_name: response.name,
-    description: undefined,
+    description: null,
     // Backward-compatible V1 fields (Story 1.2 will remove)
     id: response.team_id,
     running: response.status === 'running',

--- a/src/app/models/team.interface.ts
+++ b/src/app/models/team.interface.ts
@@ -1,0 +1,89 @@
+/**
+ * V2 Team data model — replaces ProcessContext from V1.
+ * Maps to Python TeamResponse, EventResponse from akgentic.infra.server.models.
+ */
+
+// Maps to Python TeamResponse (from akgentic.infra.server.models)
+export interface TeamResponse {
+  team_id: string;
+  name: string;
+  status: string;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// Maps to Python TeamListResponse
+export interface TeamListResponse {
+  teams: TeamResponse[];
+}
+
+// Maps to Python EventResponse
+export interface EventResponse {
+  team_id: string;
+  sequence: number;
+  event: any;
+  timestamp: string;
+}
+
+// Maps to Python EventListResponse
+export interface EventListResponse {
+  events: EventResponse[];
+}
+
+// Maps to Python CreateTeamRequest
+export interface CreateTeamRequest {
+  catalog_entry_id: string;
+  params?: Record<string, string>;
+}
+
+// Maps to Python SendMessageRequest
+export interface SendMessageRequest {
+  content: string;
+}
+
+// Maps to Python HumanInputRequest
+export interface HumanInputRequest {
+  content: string;
+  message_id: string;
+}
+
+/**
+ * Frontend-facing team model — slimmed down from V1 ProcessContext.
+ * Only includes fields actually used by frontend components.
+ */
+export interface TeamContext {
+  team_id: string;
+  name: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  config_name: string;
+  description?: string | null;
+}
+
+/** Check if a team is currently running. */
+export function isRunning(team: TeamContext): boolean {
+  return team.status === 'running';
+}
+
+/**
+ * Map a V2 TeamResponse to the frontend TeamContext model.
+ * Also populates backward-compatible V1 fields (id, running, params)
+ * so that un-migrated components work at runtime. Story 1.2 will remove these.
+ */
+export function toTeamContext(response: TeamResponse): TeamContext {
+  return {
+    team_id: response.team_id,
+    name: response.name,
+    status: response.status,
+    created_at: response.created_at,
+    updated_at: response.updated_at,
+    config_name: response.name,
+    description: undefined,
+    // Backward-compatible V1 fields (Story 1.2 will remove)
+    id: response.team_id,
+    running: response.status === 'running',
+    params: { workspace: false, knowledge_graph: false },
+  } as TeamContext;
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -111,27 +111,32 @@ export class ApiService {
     });
   }
 
+  /**
+   * V2 signature: processHumanInput(teamId, content, messageId).
+   * Also accepts V1 signature: processHumanInput(userInput, sentMessage)
+   * for backward compatibility with un-migrated components (Story 1.2 will remove V1 path).
+   */
   async processHumanInput(
     teamIdOrContent: string,
-    contentOrMessage: any,
+    contentOrMessage: string | { team_id: string; message_id?: string; id?: string },
     messageId?: string
   ): Promise<void> {
     let teamId: string;
     let content: string;
     let msgId: string;
 
-    if (messageId !== undefined) {
-      // New V2 signature: processHumanInput(teamId, content, messageId)
+    if (typeof contentOrMessage === 'string' && messageId !== undefined) {
+      // V2 signature: processHumanInput(teamId, content, messageId)
       teamId = teamIdOrContent;
-      content = contentOrMessage as string;
+      content = contentOrMessage;
       msgId = messageId;
-    } else if (typeof contentOrMessage === 'object' && contentOrMessage.team_id) {
-      // Old V1 signature: processHumanInput(userInput, message: SentMessage)
+    } else if (typeof contentOrMessage === 'object' && contentOrMessage?.team_id) {
+      // V1 signature: processHumanInput(userInput, sentMessage)
       teamId = contentOrMessage.team_id;
       content = teamIdOrContent;
       msgId = contentOrMessage.message_id ?? contentOrMessage.id ?? '';
     } else {
-      console.warn('processHumanInput: unrecognized call signature');
+      console.warn('processHumanInput: unrecognized call signature, skipping');
       return;
     }
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,10 +1,17 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, from, map, Observable, take } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
 import { FetchService } from './fetch.service';
-import { SentMessage } from '../models/message.types';
+import {
+  TeamContext,
+  TeamResponse,
+  TeamListResponse,
+  EventResponse,
+  EventListResponse,
+  toTeamContext,
+} from '../models/team.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -17,220 +24,240 @@ export class ApiService {
   private apiUrl = environment.api;
   webSocketTicket$ = new BehaviorSubject<string | null>(null);
 
-  async getContext(): Promise<Array<any>> {
-    const response = await this.fetchService.fetch({
-      url: `${this.apiUrl}/processes`,
+  // --- Team CRUD (AC1) ---
+
+  async getTeams(): Promise<TeamContext[]> {
+    const response: TeamListResponse = await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams`,
     });
-    return response ?? [];
+    const teams = response?.teams ?? [];
+    return teams.map(toTeamContext);
   }
 
-  async getProcess(processId: string): Promise<any> {
-    const response = await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${processId}`,
+  async getTeam(teamId: string): Promise<TeamContext> {
+    const response: TeamResponse = await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams/${teamId}`,
     });
-    return response;
+    return toTeamContext(response);
   }
 
-  async getConfig(
-    processType: string,
-    full: boolean = true
-  ): Promise<Array<any>> {
-    const response = await this.fetchService.fetch({
-      url: `${this.apiUrl}/config/${processType}?full=${full}`,
-    });
-    return response ?? [];
-  }
-
-  async saveConfig(
-    processType: string,
-    configId: string | null,
-    name: string | null,
-    config: any,
-    dry_run: boolean = false
-  ): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/config/${processType}`,
+  async createTeam(catalogEntryId: string): Promise<TeamResponse> {
+    return await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams`,
       options: {
-        method: 'PUT',
-        body: JSON.stringify({
-          id: configId,
-          name,
-          config,
-          dry_run,
-        }),
+        method: 'POST',
+        body: JSON.stringify({ catalog_entry_id: catalogEntryId }),
         headers: { 'Content-Type': 'application/json' },
       },
-      successMessage: dry_run
-        ? 'Configuration validated successfully'
-        : 'Configuration saved successfully',
     });
   }
 
-  async deleteConfig(processType: string, configId: string): Promise<void> {
+  async deleteTeam(teamId: string): Promise<void> {
     await this.fetchService.fetch({
-      url: `${this.apiUrl}/config/${processType}/${configId}`,
-      options: {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-      },
-      successMessage: 'Configuration deleted successfully',
-    });
-  }
-
-  async createProcess(teamId: string, config: string): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}?config=${config}`,
-      options: { method: 'POST' },
-    });
-  }
-
-  async deleteProcess(teamId: string): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}`,
+      url: `${this.apiUrl}/teams/${teamId}`,
       options: { method: 'DELETE' },
-      successMessage: 'Process delete successful',
+      successMessage: 'Team deleted successfully',
     });
   }
 
-  async archiveProcess(teamId: string): Promise<void> {
+  async stopTeam(teamId: string): Promise<void> {
     await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}/archive`,
-      options: { method: 'DELETE' },
-      successMessage: 'Process stopped successfully',
-    });
-  }
-
-  async restoreProcess(teamId: string): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}/restore`,
+      url: `${this.apiUrl}/teams/${teamId}/stop`,
       options: { method: 'POST' },
-      successMessage: 'Process restored successfully',
+      successMessage: 'Team stopped successfully',
     });
   }
 
-  async updateTeamDescription(
-    teamId: string,
-    description: string | null
-  ): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}/description`,
-      options: {
-        method: 'PATCH',
-        body: JSON.stringify({ description }),
-        headers: { 'Content-Type': 'application/json' },
-      },
-      successMessage: 'Description updated successfully',
+  async restoreTeam(teamId: string): Promise<TeamResponse> {
+    return await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams/${teamId}/restore`,
+      options: { method: 'POST' },
+      successMessage: 'Team restored successfully',
     });
   }
+
+  // --- Messaging (AC2) ---
 
   async sendMessage(
     teamId: string,
-    userInput: string,
-    agent_id: string | null
+    content: string,
+    agentName?: string | null
   ): Promise<void> {
+    if (agentName) {
+      return this.sendMessageTo(teamId, content, agentName);
+    }
     await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}`,
+      url: `${this.apiUrl}/teams/${teamId}/message`,
       options: {
-        method: 'PATCH',
-        body: JSON.stringify({ content: userInput, send_to: agent_id }),
+        method: 'POST',
+        body: JSON.stringify({ content }),
         headers: { 'Content-Type': 'application/json' },
       },
     });
   }
 
-  async getMessages(team_id: string): Promise<Array<any>> {
-    const response = await this.fetchService.fetch({
-      url: `${this.apiUrl}/messages/${team_id}`,
+  async sendMessageTo(
+    teamId: string,
+    content: string,
+    agentName: string
+  ): Promise<void> {
+    await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams/${teamId}/message/${agentName}`,
+      options: {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+        headers: { 'Content-Type': 'application/json' },
+      },
     });
-    return response ?? [];
   }
 
   async processHumanInput(
-    userInput: string,
-    message: SentMessage
+    teamIdOrContent: string,
+    contentOrMessage: any,
+    messageId?: string
   ): Promise<void> {
-    const team_id = message.team_id;
-    const humanProxy = message.recipient.agent_id;
+    let teamId: string;
+    let content: string;
+    let msgId: string;
+
+    if (messageId !== undefined) {
+      // New V2 signature: processHumanInput(teamId, content, messageId)
+      teamId = teamIdOrContent;
+      content = contentOrMessage as string;
+      msgId = messageId;
+    } else if (typeof contentOrMessage === 'object' && contentOrMessage.team_id) {
+      // Old V1 signature: processHumanInput(userInput, message: SentMessage)
+      teamId = contentOrMessage.team_id;
+      content = teamIdOrContent;
+      msgId = contentOrMessage.message_id ?? contentOrMessage.id ?? '';
+    } else {
+      console.warn('processHumanInput: unrecognized call signature');
+      return;
+    }
+
     await this.fetchService.fetch({
-      url: `${this.apiUrl}/process_human_input/${team_id}/human/${humanProxy}`,
+      url: `${this.apiUrl}/teams/${teamId}/human-input`,
       options: {
         method: 'POST',
-        body: JSON.stringify({
-          content: userInput,
-          message: message.message,
-        }),
+        body: JSON.stringify({ content, message_id: msgId }),
         headers: { 'Content-Type': 'application/json' },
       },
     });
   }
 
-  // If the response is null, feature not available !
-  async getAgentContext(teamId: string): Promise<Array<any>> {
+  // --- Events (AC3) ---
+
+  async getEvents(teamId: string): Promise<EventResponse[]> {
+    const response: EventListResponse = await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams/${teamId}/events`,
+    });
+    return response?.events ?? [];
+  }
+
+  // --- Catalog (AC4) ---
+
+  async getTeamConfigs(): Promise<any> {
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/llm_context/${teamId}`,
+      url: `${this.apiUrl}/catalog/api/teams/`,
     });
   }
 
-  async getAkgentStates(teamId: string): Promise<any> {
-    return await this.fetchService.fetch({
-      url: `${this.apiUrl}/states/${teamId}`,
-    });
-  }
-
-  async updateAkgentState(
-    teamId: string,
-    agentId: string,
-    partialState: any
-  ): Promise<void> {
-    await this.fetchService.fetch({
-      url: `${this.apiUrl}/state/${teamId}/of/${agentId}`,
-      options: {
-        method: 'PATCH',
-        body: JSON.stringify({ content: partialState }),
-        headers: { 'Content-Type': 'application/json' },
-      },
-    });
-  }
-
-  async chat(teamId: string, agentId: string, userInput: string): Promise<any> {
-    return await this.fetchService.fetch({
-      url: `${this.apiUrl}/chat/${teamId}/with/${agentId}`,
-      options: {
-        method: 'POST',
-        body: JSON.stringify({ content: userInput }),
-        headers: { 'Content-Type': 'application/json' },
-      },
-    });
-  }
-
-  async relaunch(teamId: string, msgId: string): Promise<Response> {
-    return fetch(`${this.apiUrl}/relaunch/${teamId}/message/${msgId}`, {
-      method: 'POST',
-    });
-  }
-
-  async getKnowledgeGraphData(teamId: string): Promise<any> {
-    const response = await this.fetchService.fetch({
-      url: `${this.apiUrl}/process/${teamId}`,
-    });
-
-    // Extract knowledge graph data from the response
-    const knowledgeGraph = response?.knowledge_graph || {
-      entities: [],
-      relations: [],
-    };
-    // Transform the data to match our component interface
-    return {
-      nodes: knowledgeGraph.entities || [],
-      edges: knowledgeGraph.relations || [],
-    };
-  }
+  // --- Auth stub (AC6 / AC12) ---
 
   getWebSocketTicket(): Observable<string> {
-    return from(
-      this.fetchService.fetch({
-        url: `${this.apiUrl}/auth/ws-ticket`,
-      })
-    ).pipe(map((response) => response.ticket));
+    return of('noauth');
+  }
+
+  // --- Backward-compatible aliases (Story 1.2 will remove these) ---
+  // These stubs prevent compilation errors in components not yet migrated.
+
+  /** @deprecated Use getTeams() */
+  async getContext(): Promise<any[]> {
+    return this.getTeams();
+  }
+
+  /** @deprecated Use getTeam() */
+  async getProcess(processId: string): Promise<any> {
+    return this.getTeam(processId);
+  }
+
+  /** @deprecated Use createTeam() */
+  async createProcess(teamId: string, _config: string): Promise<void> {
+    await this.createTeam(teamId);
+  }
+
+  /** @deprecated Use deleteTeam() */
+  async deleteProcess(teamId: string): Promise<void> {
+    await this.deleteTeam(teamId);
+  }
+
+  /** @deprecated Use stopTeam() */
+  async archiveProcess(teamId: string): Promise<void> {
+    await this.stopTeam(teamId);
+  }
+
+  /** @deprecated Use restoreTeam() */
+  async restoreProcess(teamId: string): Promise<void> {
+    await this.restoreTeam(teamId);
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub for compilation. */
+  async updateTeamDescription(
+    _teamId: string,
+    _description: string | null
+  ): Promise<void> {
+    console.warn('updateTeamDescription is removed in V2');
+  }
+
+  /** @deprecated Use getTeamConfigs() */
+  async getConfig(_processType: string, _full: boolean = true): Promise<any[]> {
+    return [];
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub. */
+  async saveConfig(..._args: any[]): Promise<void> {
+    console.warn('saveConfig is removed in V2');
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub. */
+  async deleteConfig(..._args: any[]): Promise<void> {
+    console.warn('deleteConfig is removed in V2');
+  }
+
+  /** @deprecated Use getEvents() */
+  async getMessages(teamId: string): Promise<any[]> {
+    return this.getEvents(teamId);
+  }
+
+  /** @deprecated Removed in V2 -- returns empty object. */
+  async getAgentContext(_teamId: string): Promise<any> {
+    return {};
+  }
+
+  /** @deprecated Removed in V2 -- returns empty object. */
+  async getAkgentStates(_teamId: string): Promise<any> {
+    return {};
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub. */
+  async updateAkgentState(..._args: any[]): Promise<void> {
+    console.warn('updateAkgentState is removed in V2');
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub. */
+  async chat(_teamId: string, _agentId: string, _userInput: string): Promise<any> {
+    console.warn('chat is removed in V2');
+    return null;
+  }
+
+  /** @deprecated Removed in V2 -- no-op stub. */
+  async relaunch(_teamId: string, _msgId: string): Promise<Response> {
+    console.warn('relaunch is removed in V2');
+    return new Response(null, { status: 204 });
+  }
+
+  /** @deprecated Removed in V2 -- returns empty graph. */
+  async getKnowledgeGraphData(_teamId: string): Promise<any> {
+    return { nodes: [], edges: [] };
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,132 +1,52 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { catchError, map, take, tap } from 'rxjs/operators';
-import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  httpClient: HttpClient = inject(HttpClient);
-  router: Router = inject(Router);
-  private currentUserSubject = new BehaviorSubject<any>(null);
+  private currentUserSubject = new BehaviorSubject<any>({
+    user_id: 'anonymous',
+    email: '',
+    name: 'Anonymous',
+  });
   currentUser$ = this.currentUserSubject.asObservable();
 
-  // Storage key for API key in localStorage
-  private readonly API_KEY_STORAGE_KEY = 'auth_api_key';
-
-  constructor() {
-    // Initial authentication check when the service is created
-    this.checkAuth().pipe(take(1)).subscribe();
+  /** Returns anonymous user immediately -- no server call (community tier). */
+  checkAuth(): Observable<any> {
+    return of({ user_id: 'anonymous', email: '', name: 'Anonymous' });
   }
 
-  // Get stored API key from localStorage
-  getApiKey(): string | null {
-    return localStorage.getItem(this.API_KEY_STORAGE_KEY);
-  }
-
-  // Store API key in localStorage
-  setApiKey(apiKey: string): void {
-    localStorage.setItem(this.API_KEY_STORAGE_KEY, apiKey);
-  }
-
-  // Clear stored API key
-  clearApiKey(): void {
-    localStorage.removeItem(this.API_KEY_STORAGE_KEY);
-  }
-
-  // Create HTTP headers with API key if available
-  getAuthHeaders(): HttpHeaders {
-    const apiKey = this.getApiKey();
-    let headers = new HttpHeaders();
-
-    if (apiKey) {
-      headers = headers.set('X-API-Key', apiKey);
-    }
-
-    return headers;
-  }
-
-  // Login with API key
-  loginWithApiKey(apiKey: string): Observable<any> {
-    return this.httpClient
-      .get<any>(`${environment.api}/auth/login/apikey`, {
-        params: { apikey: apiKey },
-        withCredentials: true,
-      })
-      .pipe(
-        tap((response) => {
-          if (response.success) {
-            // Store the API key for future requests
-            this.setApiKey(apiKey);
-            // Update authentication state
-            this.currentUserSubject.next(response.user);
-          }
-        })
-      );
-  }
-
-  // This method is triggered when you come back after the Microsoft login
-  checkAuth() {
-    const headers = this.getAuthHeaders();
-
-    return this.httpClient
-      .get(`${environment.api}/auth/me`, {
-        headers,
-        withCredentials: true,
-      })
-      .pipe(
-        tap((user) => {
-          if (user) {
-            this.currentUserSubject.next(user); // Update currentUserSubject with fetched user
-          } else {
-            this.currentUserSubject.next(null); // No user, set null
-          }
-        }),
-        catchError((err) => {
-          this.currentUserSubject.next(null);
-          return of(null); // In case of error, set user to null
-        })
-      );
-  }
-
-  // Logs the user out and redirects them to the login page
-  logout() {
-    const headers = this.getAuthHeaders();
-
-    this.httpClient
-      .get(`${environment.api}/auth/logout`, {
-        headers,
-        withCredentials: true,
-        observe: 'response',
-      })
-      .pipe(
-        map((response) => {
-          // Check if this was an API key auth logout
-          const body: any = response.body;
-          if (
-            body &&
-            body.auth_type === 'api_key' &&
-            body.action_required === 'clear_api_key'
-          ) {
-            this.clearApiKey();
-          }
-
-          return response;
-        })
-      )
-      .subscribe(() => {
-        this.currentUserSubject.next(null);
-        if (environment.hideLogin) {
-          this.router.navigate(['/']);
-        } else this.router.navigate(['/login']);
-      });
-  }
-
-  // Returns the current user value (user data or null)
+  /** Returns the current user value (anonymous for community tier). */
   get currentUserValue(): any {
     return this.currentUserSubject.value;
+  }
+
+  // --- Backward-compatible stubs (Story 1.2 will remove these) ---
+
+  /** @deprecated No-op in community tier. */
+  loginWithApiKey(_apiKey: string): Observable<any> {
+    return of({ success: true, user: this.currentUserValue });
+  }
+
+  /** @deprecated No-op in community tier. */
+  setApiKey(_apiKey: string): void {}
+
+  /** @deprecated No-op in community tier. */
+  clearApiKey(): void {}
+
+  /** @deprecated No-op in community tier. */
+  getApiKey(): string | null {
+    return null;
+  }
+
+  /** @deprecated No-op in community tier. */
+  getAuthHeaders(): any {
+    return {};
+  }
+
+  /** @deprecated No-op in community tier -- navigates to home. */
+  logout(): void {
+    console.warn('logout is a no-op in community tier');
   }
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -2,67 +2,83 @@ import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { ApiService } from './api.service';
-import { ProcessContext } from '../models/process.interface';
+import { TeamContext } from '../models/team.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ContextService {
-  apiService: ApiService = new ApiService();
+  apiService: ApiService = inject(ApiService);
   router: Router = inject(Router);
   currentProcessId$ = new BehaviorSubject<string>('');
 
-  _context: ProcessContext[] = [];
+  _context: TeamContext[] = [];
 
-  async getContext(): Promise<ProcessContext[]> {
-    this._context = await this.apiService.getContext();
+  async getTeams(): Promise<TeamContext[]> {
+    this._context = await this.apiService.getTeams();
     return this._context;
   }
 
-  async getCurrentProcess(
-    processId: string,
+  async getCurrentTeam(
+    teamId: string,
     useCache: boolean = true
-  ): Promise<ProcessContext | null> {
-    // Look for the process in the cache
+  ): Promise<TeamContext | null> {
     if (useCache) {
-      const cachedProcess = this._context.find(
-        (i: ProcessContext) => i.id === processId
+      const cached = this._context.find(
+        (t: TeamContext) => t.team_id === teamId
       );
-      if (cachedProcess) {
-        return cachedProcess;
+      if (cached) {
+        return cached;
       }
     }
 
-    // Get the process from the API
-    const process = await this.apiService.getProcess(processId);
+    const team = await this.apiService.getTeam(teamId);
 
-    // replace the entry in the context cache
-    this._context = this._context.map((i: ProcessContext) =>
-      i.id === processId ? process : i
+    this._context = this._context.map((t: TeamContext) =>
+      t.team_id === teamId ? team : t
     );
 
-    return process;
+    return team;
   }
 
-  async deleteCurrentProcess(team_id: string): Promise<void> {
-    await this.apiService.deleteProcess(team_id);
+  async deleteTeam(teamId: string): Promise<void> {
+    await this.apiService.deleteTeam(teamId);
   }
 
-  // Delete the current process and create a new one of the specified type
-  // Then navigate to the new process
-  async clear(processId: string) {
-    await this.deleteCurrentProcess(processId);
+  async clear(teamId: string) {
+    await this.deleteTeam(teamId);
     await this.router.navigate(['/']);
   }
 
-  async createProcessAndNavigate(processType: string) {
-    await this.apiService.createProcess(processType, 'default');
-    await this.getContext().then((context) => {
-      const len = context.length;
-      const processId = context[len - 1].id;
-      return this.router.navigate(['/process', processId]).then(() => {
-        window.location.reload();
-      });
+  async createTeamAndNavigate(catalogEntryId: string) {
+    const response = await this.apiService.createTeam(catalogEntryId);
+    await this.router.navigate(['/process', response.team_id]).then(() => {
+      window.location.reload();
     });
+  }
+
+  // --- Backward-compatible aliases (Story 1.2 will remove these) ---
+
+  /** @deprecated Use getTeams() instead. */
+  async getContext(): Promise<any[]> {
+    return this.getTeams();
+  }
+
+  /** @deprecated Use getCurrentTeam() instead. */
+  async getCurrentProcess(
+    processId: string,
+    useCache: boolean = true
+  ): Promise<any> {
+    return this.getCurrentTeam(processId, useCache);
+  }
+
+  /** @deprecated Use deleteTeam() instead. */
+  async deleteCurrentProcess(teamId: string): Promise<void> {
+    return this.deleteTeam(teamId);
+  }
+
+  /** @deprecated Use createTeamAndNavigate() instead. */
+  async createProcessAndNavigate(processType: string) {
+    return this.createTeamAndNavigate(processType);
   }
 }

--- a/src/app/services/fetch.service.ts
+++ b/src/app/services/fetch.service.ts
@@ -25,9 +25,14 @@ export class FetchService {
     const response = await fetch(url, options);
 
     if (!response.ok) {
-      const errorJson = await response.clone().json();
+      let errorDetail = '';
+      try {
+        const errorJson = await response.clone().json();
+        errorDetail = errorJson.detail || '';
+      } catch {
+        // Response body is not valid JSON -- fall back to text
+      }
       const errorBody = await response.text();
-      const errorDetail = errorJson.detail || '';
       console.error(
         `Error: ${response.status} - ${response.statusText}`,
         errorBody
@@ -40,6 +45,11 @@ export class FetchService {
       );
     } else if (successMessage) {
       this.showNotification(successMessage, 'success');
+    }
+
+    // 204 No Content (and other bodyless responses) cannot be parsed as JSON
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined;
     }
 
     return response.json();

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -60,8 +60,9 @@ export class ActorMessageService {
       // Fetch the contexts from the server
       const contexts = await this.apiService.getAgentContext(processId);
       Object.entries(contexts).forEach(([actor_id, data]) => {
+        const typed = data as { context: any[] };
         this.initDict(this.contextDict$, actor_id, []);
-        this.contextDict$[actor_id].next(data.context);
+        this.contextDict$[actor_id].next(typed.context);
       });
 
       // Fetch the states from the server


### PR DESCRIPTION
## Summary

- Rewrites ApiService to speak V2 endpoints natively (team CRUD, messaging, events, catalog)
- Creates TeamContext model replacing ProcessContext, with backward-compatible V1 aliases
- Stubs AuthService for community tier (anonymous user, no server calls)
- Fixes ContextService DI to use inject(ApiService) instead of direct instantiation
- Retains deprecated V1 method stubs for un-migrated components (Story 1.2 scope)

## Code Review Fixes Applied

- Fixed FetchService to handle 204 No Content responses (deleteTeam/stopTeam would crash)
- Fixed FetchService error path: wrapped response.clone().json() in try/catch for non-JSON error bodies
- Improved processHumanInput() type safety: typed union instead of any for V1/V2 dual-signature
- Clarified toTeamContext() config_name mapping with documentation comment

Closes #2