### PR TITLE
WebSocket V2 Native Event Parsing

### DIFF
--- a/src/app/models/message.types.ts
+++ b/src/app/models/message.types.ts
@@ -41,12 +41,6 @@ export interface BaseMessage {
 
 // Core message types from orchestrator.py
 
-export interface NotificationMessage extends BaseMessage {
-  __model__: 'akgentic.core.messages.orchestrator.NotificationMessage';
-  subject: string;
-  content: string;
-}
-
 export interface SentMessage extends BaseMessage {
   __model__: 'akgentic.core.messages.orchestrator.SentMessage';
   message: BaseMessage;
@@ -81,23 +75,15 @@ export interface ErrorMessage extends BaseMessage {
   current_message?: BaseMessage;
 }
 
-export interface ContextChangedMessage extends BaseMessage {
-  __model__: 'akgentic.core.messages.orchestrator.ContextChangedMessage';
-  messages: any[]; // LangChain AnyMessage type
-  err?: Error;
-}
-
 export interface StateChangedMessage extends BaseMessage {
   __model__: 'akgentic.core.messages.orchestrator.StateChangedMessage';
   state: BaseState | Record<string, any>;
   err?: Error;
 }
 
-export interface ToolUpdateMessage extends BaseMessage {
-  __model__: 'akgentic.core.messages.orchestrator.ToolUpdateMessage';
-  tool: string;
-  data: any;
-  metadata?: { [key: string]: any };
+export interface EventMessage extends BaseMessage {
+  __model__: string; // contains 'EventMessage'
+  event: any;
 }
 
 // Additional message types that might be used
@@ -114,25 +100,18 @@ export interface ResultMessage extends BaseMessage {
 
 // Union type for all possible messages
 export type AkgenticMessage =
-  | NotificationMessage
   | SentMessage
   | ReceivedMessage
   | ProcessedMessage
   | StartMessage
   | StopMessage
   | ErrorMessage
-  | ContextChangedMessage
   | StateChangedMessage
-  | ToolUpdateMessage
+  | EventMessage
   | UserMessage
   | ResultMessage;
 
 // Type guards for message discrimination
-export function isNotificationMessage(
-  msg: BaseMessage,
-): msg is NotificationMessage {
-  return msg.__model__.includes('NotificationMessage');
-}
 
 export function isSentMessage(msg: BaseMessage): msg is SentMessage {
   return msg.__model__.includes('SentMessage');
@@ -158,22 +137,14 @@ export function isErrorMessage(msg: BaseMessage): msg is ErrorMessage {
   return msg.__model__.includes('ErrorMessage');
 }
 
-export function isContextChangedMessage(
-  msg: BaseMessage,
-): msg is ContextChangedMessage {
-  return msg.__model__.includes('ContextChangedMessage');
-}
-
 export function isStateChangedMessage(
   msg: BaseMessage,
 ): msg is StateChangedMessage {
   return msg.__model__.includes('StateChangedMessage');
 }
 
-export function isToolUpdateMessage(
-  msg: BaseMessage,
-): msg is ToolUpdateMessage {
-  return msg.__model__.includes('ToolUpdateMessage');
+export function isEventMessage(msg: BaseMessage): msg is EventMessage {
+  return msg.__model__.includes('EventMessage');
 }
 
 export function isUserMessage(msg: BaseMessage): msg is UserMessage {

--- a/src/app/process/agent-tabs/akgent-state/akgent-state.component.html
+++ b/src/app/process/agent-tabs/akgent-state/akgent-state.component.html
@@ -33,16 +33,9 @@
   <p-button
     type="submit"
     size="small"
-    label="Submit"
-    [disabled]="dynamicForm.invalid || !dynamicForm.dirty"
+    label="Read Only (V2)"
+    [disabled]="true"
   >
-    <ng-container
-      *ngIf="akgentService.isSavingState[agentId]; else refreshIcon"
-    >
-      <i class="pi pi-spinner pi-spin"></i>
-    </ng-container>
-    <ng-template #refreshIcon>
-      <i class="pi pi-send"></i>
-    </ng-template>
+    <i class="pi pi-lock"></i>
   </p-button>
 </form>

--- a/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
+++ b/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
@@ -18,7 +18,6 @@ import { MessageService } from 'primeng/api';
 import { environment } from '../../../../environments/environment';
 import { AkgentService } from '../../../services/akgent.service';
 import { ActorMessageService } from '../../../services/message.service';
-import { FetchService } from '../../../services/fetch.service';
 
 @Component({
   selector: 'app-akgent-state',
@@ -33,7 +32,6 @@ export class AkgentStateComponent {
   akgentService: AkgentService = inject(AkgentService);
   actorMessageService: ActorMessageService = inject(ActorMessageService);
   toastService: MessageService = inject(MessageService);
-  fetchService: FetchService = inject(FetchService);
   formBuider: FormBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
@@ -42,10 +40,6 @@ export class AkgentStateComponent {
 
   ngOnInit(): void {
     this.state$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data) => {
-      if (this.akgentService.isSavingState[this.agentId]) {
-        this.fetchService.showNotification('State saved successfully');
-      }
-      this.akgentService.isSavingState[this.agentId] = false;
       this.dynamicForm = this.formBuider.group({});
       this.generateForm(data);
     });
@@ -54,6 +48,12 @@ export class AkgentStateComponent {
   generateForm(data: any): void {
     if (!data) return;
     const schema = data.schema || {};
+
+    if (!schema.properties) {
+      // V2 sends empty schema -- display raw state as JSON
+      this.schemaFields = [];
+      return;
+    }
 
     this.schemaFields = Object.keys(schema.properties).map((key) => {
       const field = schema.properties[key];

--- a/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
+++ b/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
@@ -13,9 +13,9 @@ import { BehaviorSubject } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { TextareaModule } from 'primeng/textarea';
+import { MessageService } from 'primeng/api';
 
 import { environment } from '../../../../environments/environment';
-import { ApiService } from '../../../services/api.service';
 import { AkgentService } from '../../../services/akgent.service';
 import { ActorMessageService } from '../../../services/message.service';
 import { FetchService } from '../../../services/fetch.service';
@@ -31,8 +31,8 @@ export class AkgentStateComponent {
   @Input() agentId!: string;
 
   akgentService: AkgentService = inject(AkgentService);
-  apiService: ApiService = inject(ApiService);
-  messageService: ActorMessageService = inject(ActorMessageService);
+  actorMessageService: ActorMessageService = inject(ActorMessageService);
+  toastService: MessageService = inject(MessageService);
   fetchService: FetchService = inject(FetchService);
   formBuider: FormBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
@@ -118,16 +118,12 @@ export class AkgentStateComponent {
   }
 
   onSubmit(): void {
-    this.akgentService.isSavingState[this.agentId] = true;
-    const dirtValues = this.getDirtyValues(this.dynamicForm);
-    const currentProcessId =
-      this.akgentService.contextService.currentProcessId$.value;
-
-    this.apiService.updateAkgentState(
-      currentProcessId,
-      this.agentId,
-      dirtValues
-    );
+    this.toastService.add({
+      severity: 'info',
+      summary: 'Read Only',
+      detail: 'State editing is not available in V2',
+      life: 3000,
+    });
   }
 
   getDirtyValues(form: FormGroup | FormArray): any {

--- a/src/app/process/message-list/message-list.component.html
+++ b/src/app/process/message-list/message-list.component.html
@@ -38,9 +38,9 @@
               <div>
                 <p-button
                   size="small"
-                  label="Relaunch"
+                  label="Relaunch (N/A)"
                   (click)="relaunch($event, message)"
-                  [disabled]="disableRelaunchBtn(message)"
+                  [disabled]="true"
                 />
               </div>
             </p-fieldset>

--- a/src/app/process/message-list/message-list.component.ts
+++ b/src/app/process/message-list/message-list.component.ts
@@ -115,13 +115,8 @@ export class MessageListComponent {
     });
   }
 
-  disableRelaunchBtn(message: any) {
-    // Check if a StopMessage has been received for the actor in error
-    // This happens when we relaunched the process (see orchestrator)
-    return !!this.messages.find(
-      (msg) =>
-        msg.__model__.includes('StopMessage') &&
-        msg.actor.agent_id == message.sender.agent_id
-    );
+  disableRelaunchBtn(_message: any) {
+    // V2: relaunch is not available; always disabled
+    return true;
   }
 }

--- a/src/app/process/message-list/message-list.component.ts
+++ b/src/app/process/message-list/message-list.component.ts
@@ -4,9 +4,9 @@ import { Component, inject, ViewChild } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { FieldsetModule } from 'primeng/fieldset';
 import { Table, TableModule } from 'primeng/table';
+import { MessageService } from 'primeng/api';
 
 import { CapitalizePipe } from '../../pipes/capitalise.pipe';
-import { ApiService } from '../../services/api.service';
 import { CategoryService } from '../../services/category.service';
 import { UtilService } from '../../services/utils.service';
 
@@ -31,11 +31,11 @@ import { CopyButtonComponent } from '../copy-button/copy-button.component';
 export class MessageListComponent {
   @ViewChild('dataTable') dataTable!: Table;
 
-  apiService: ApiService = inject(ApiService);
   utilService: UtilService = inject(UtilService);
   akgentService: AkgentService = inject(AkgentService);
   messageService: ActorMessageService = inject(ActorMessageService);
   categoryService: CategoryService = inject(CategoryService);
+  toastService: MessageService = inject(MessageService);
 
   selectedCategories: boolean[] | null = null;
 
@@ -106,9 +106,13 @@ export class MessageListComponent {
     return Object.keys(message).filter((k) => this.messagesKeys.includes(k));
   }
 
-  relaunch(event: any, msg: any) {
-    const processId = this.messageService.processId;
-    this.apiService.relaunch(processId, msg.id);
+  relaunch(_event: any, _msg: any) {
+    this.toastService.add({
+      severity: 'info',
+      summary: 'Not Available',
+      detail: 'Relaunch is not available in V2',
+      life: 3000,
+    });
   }
 
   disableRelaunchBtn(message: any) {

--- a/src/app/services/akgent.service.ts
+++ b/src/app/services/akgent.service.ts
@@ -36,6 +36,6 @@ export class AkgentService {
     agentId: string,
     userInput: string
   ): Promise<void> {
-    await this.apiService.chat(processId, agentId, userInput);
+    await this.apiService.sendMessage(processId, userInput, agentId);
   }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Observable, of } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
 import { FetchService } from './fetch.service';
@@ -22,7 +21,6 @@ export class ApiService {
   router: Router = inject(Router);
 
   private apiUrl = environment.api;
-  webSocketTicket$ = new BehaviorSubject<string | null>(null);
 
   // --- Team CRUD (AC1) ---
 
@@ -144,53 +142,12 @@ export class ApiService {
     });
   }
 
-  // --- Auth stub (AC6 / AC12) ---
-
-  getWebSocketTicket(): Observable<string> {
-    return of('noauth');
-  }
-
   /** No-op stub: description editing is not available in V2. */
   async updateTeamDescription(
     _teamId: string,
     _description: string | null
   ): Promise<void> {
     console.warn('updateTeamDescription is not available in V2');
-  }
-
-  // --- Stubs for Story 1.3/1.4 callers (message.service, akgent.service, etc.) ---
-  // These remain until their callers are migrated in subsequent stories.
-
-  /** @deprecated Story 1.3 will migrate callers to getEvents(). */
-  async getMessages(teamId: string): Promise<any[]> {
-    return this.getEvents(teamId);
-  }
-
-  /** @deprecated Story 1.3 will migrate callers. */
-  async getAgentContext(_teamId: string): Promise<any> {
-    return {};
-  }
-
-  /** @deprecated Story 1.3 will migrate callers. */
-  async getAkgentStates(_teamId: string): Promise<any> {
-    return {};
-  }
-
-  /** @deprecated Story 1.3 will migrate callers. */
-  async updateAkgentState(..._args: any[]): Promise<void> {
-    console.warn('updateAkgentState is removed in V2');
-  }
-
-  /** @deprecated Story 1.3 will migrate callers. */
-  async chat(_teamId: string, _agentId: string, _userInput: string): Promise<any> {
-    console.warn('chat is removed in V2');
-    return null;
-  }
-
-  /** @deprecated Story 1.3 will migrate callers. */
-  async relaunch(_teamId: string, _msgId: string): Promise<Response> {
-    console.warn('relaunch is removed in V2');
-    return new Response(null, { status: 204 });
   }
 
   /** @deprecated Story 1.4 will migrate callers. */

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -1,9 +1,10 @@
 import { inject, Injectable } from '@angular/core';
 
-import { BehaviorSubject, Subscription, switchMap } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { environment } from '../../environments/environment';
 import { AkgenticMessage } from '../models/message.types';
+import { EventResponse } from '../models/team.interface';
 
 import { ApiService } from '../services/api.service';
 import { ChatService } from './chat.service';
@@ -13,6 +14,16 @@ interface KnowledgeGraphData {
   nodes: any[];
   edges: any[];
 }
+
+/** V2 message types that feed the agent graph and message list. */
+const GRAPH_RELEVANT_MODELS = [
+  'StartMessage',
+  'SentMessage',
+  'StopMessage',
+  'ErrorMessage',
+  'UserMessage',
+  'ResultMessage',
+];
 
 @Injectable()
 export class ActorMessageService {
@@ -57,27 +68,17 @@ export class ActorMessageService {
     this.chatService.loadingProcess$.next(true);
 
     if (!running) {
-      // Fetch the contexts from the server
-      const contexts = await this.apiService.getAgentContext(processId);
-      Object.entries(contexts).forEach(([actor_id, data]) => {
-        const typed = data as { context: any[] };
-        this.initDict(this.contextDict$, actor_id, []);
-        this.contextDict$[actor_id].next(typed.context);
-      });
-
-      // Fetch the states from the server
-      const states = await this.apiService.getAkgentStates(processId);
-      Object.entries(states).forEach(([actor_id, data]) => {
-        const typedData = data as { schema: any; state: any };
-        this.initDict(this.stateDict$, actor_id, null);
-        this.stateDict$[actor_id].next({
-          schema: typedData.schema,
-          state: typedData.state,
-        });
-      });
-
-      // Fetch the messages from the server (Comes from the DB, or context if no DB)
-      messages = await this.apiService.getMessages(processId);
+      // V2: use getEvents() for stopped teams -- minimal implementation (Story 1.3)
+      const eventResponses: EventResponse[] =
+        await this.apiService.getEvents(processId);
+      messages = eventResponses
+        .map((er: EventResponse) => er.event as AkgenticMessage)
+        .filter(
+          (evt: AkgenticMessage) =>
+            evt &&
+            evt.__model__ &&
+            GRAPH_RELEVANT_MODELS.some((m) => evt.__model__.includes(m))
+        );
     }
 
     this.createAgentGraph$.next(messages);
@@ -88,64 +89,68 @@ export class ActorMessageService {
       }
     });
 
-    await this.refreshKnowledgeGraph();
-
-    // Subscribe to the webSocket to receive new messages
+    // V2: connect directly -- no ticket needed (community tier, AC8)
     const wsProtocol =
       window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-    //remove http or https from the api url
     const api = environment.api.replace(/(^\w+:|^)\/\//, '');
 
-    this.apiService
-      .getWebSocketTicket()
-      .pipe(
-        switchMap((ticket) => {
-          this.webSocket = webSocket(
-            `${wsProtocol}${api}/ws/${this.processId}?ticket=${ticket}`
-          );
-          return this.webSocket;
-        })
-      )
-      .subscribe({
-        next: (data) => {
-          if (data && data.type === 'error') {
-            this.messageService.add({
-              severity: 'error',
-              summary: 'WebSocket Authentication Failed',
-              detail:
-                data.message || 'Failed to authenticate WebSocket connection',
-              life: 5000,
+    this.webSocket = webSocket(`${wsProtocol}${api}/ws/${this.processId}`);
+    this.chatService.loadingProcess$.next(false);
+
+    this.webSocket.subscribe({
+      next: (data: any) => {
+        // V2: data is a PersistedEvent { team_id, sequence, event, timestamp }
+        const event = data?.event;
+        if (!event || !event.__model__) return;
+
+        if (event.__model__.includes('StateChangedMessage')) {
+          const agentName = event.sender?.name;
+          if (agentName) {
+            this.initDict(this.stateDict$, agentName, null);
+            this.stateDict$[agentName].next({
+              schema: {},
+              state: event.state,
             });
+          }
+        } else if (event.__model__.includes('EventMessage')) {
+          this.handleEventMessage(event);
+        } else if (event.__model__.includes('ErrorMessage')) {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: event.exception_value,
+            life: 5000,
+          });
+          this.message$.next(event);
+        } else {
+          // All other messages: forward to message$ for graph + message list
+          if (this.paused) {
+            this.messages.push(event);
             return;
           }
-          if (data && data.type === 'message') {
-            if (this.paused) {
-              this.messages.push(data.message);
-              return;
-            }
-            this.message$.next(data.message);
-          }
-          if (data && data.type === 'llm_context') {
-            this.initDict(this.contextDict$, data.agent_id, []);
-            this.contextDict$[data.agent_id].next(data.context);
-          }
-          if (data && data.type === 'state') {
-            this.initDict(this.stateDict$, data.agent_id, null);
-            this.stateDict$[data.agent_id].next({
-              schema: data.schema,
-              state: data.state,
-            });
-          }
-          if (data && data.type === 'tool_update') {
-            this.handleToolUpdate(data);
-          }
-          setTimeout(() => {
-            this.chatService.loadingProcess$.next(false);
-          }, 250);
-        },
-        error: (err) => console.log(err),
-        complete: () => console.log('webSocket - complete'),
-      });
+          this.message$.next(event);
+        }
+      },
+      error: (err: any) => console.log(err),
+      complete: () => console.log('webSocket - complete'),
+    });
+  }
+
+  /**
+   * Handle V2 EventMessage: delegates to LlmMessageEvent or ToolCallEvent handlers.
+   */
+  private handleEventMessage(event: any): void {
+    const inner = event.event;
+    if (inner?.__model__?.includes('LlmMessageEvent')) {
+      const agentName = event.sender?.name;
+      if (agentName) {
+        this.initDict(this.contextDict$, agentName, []);
+        const current = this.contextDict$[agentName].getValue();
+        this.contextDict$[agentName].next([...current, inner.message]);
+      }
+    } else if (inner?.__model__?.includes('ToolCallEvent')) {
+      this.handleToolUpdate(inner);
+    }
   }
 
   backwardClicked() {
@@ -219,7 +224,7 @@ export class ActorMessageService {
   }
 
   private handleToolUpdate(payload: any): void {
-    if (payload?.tool !== 'knowledge_graph') {
+    if (payload?.tool !== 'knowledge_graph' && payload?.tool_name !== 'knowledge_graph') {
       return;
     }
 

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -104,10 +104,10 @@ export class ActorMessageService {
         if (!event || !event.__model__) return;
 
         if (event.__model__.includes('StateChangedMessage')) {
-          const agentName = event.sender?.name;
-          if (agentName) {
-            this.initDict(this.stateDict$, agentName, null);
-            this.stateDict$[agentName].next({
+          const agentId = event.sender?.agent_id;
+          if (agentId) {
+            this.initDict(this.stateDict$, agentId, null);
+            this.stateDict$[agentId].next({
               schema: {},
               state: event.state,
             });
@@ -131,7 +131,15 @@ export class ActorMessageService {
           this.message$.next(event);
         }
       },
-      error: (err: any) => console.log(err),
+      error: (err: any) => {
+        console.error('WebSocket error:', err);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Connection Error',
+          detail: 'WebSocket connection failed. Real-time updates unavailable.',
+          life: 5000,
+        });
+      },
       complete: () => console.log('webSocket - complete'),
     });
   }
@@ -142,11 +150,11 @@ export class ActorMessageService {
   private handleEventMessage(event: any): void {
     const inner = event.event;
     if (inner?.__model__?.includes('LlmMessageEvent')) {
-      const agentName = event.sender?.name;
-      if (agentName) {
-        this.initDict(this.contextDict$, agentName, []);
-        const current = this.contextDict$[agentName].getValue();
-        this.contextDict$[agentName].next([...current, inner.message]);
+      const agentId = event.sender?.agent_id;
+      if (agentId) {
+        this.initDict(this.contextDict$, agentId, []);
+        const current = this.contextDict$[agentId].getValue();
+        this.contextDict$[agentId].next([...current, inner.message]);
       }
     } else if (inner?.__model__?.includes('ToolCallEvent')) {
       this.handleToolUpdate(inner);


### PR DESCRIPTION
## Summary

- Rewrites `ActorMessageService.init()` for V2 PersistedEvent-based WebSocket protocol: routes by `event.__model__` instead of V1 `data.type`
- Adds `handleEventMessage()` for LlmMessageEvent (context aggregation) and ToolCallEvent (knowledge graph) delegation
- Simplifies WebSocket URL to `ws://host/ws/{id}` (no auth ticket, community tier)
- Migrates stopped-team init from 3 V1 API calls to single `getEvents()` with graph-relevant filtering
- Adds `EventMessage` interface/type guard, removes 3 obsolete V1 types (`ContextChangedMessage`, `ToolUpdateMessage`, `NotificationMessage`)
- Migrates `AkgentService.sendMessage` from deprecated `chat()` to V2 `sendMessage()`
- Disables state editing and relaunch with V2-appropriate toasts
- Removes 6 deprecated stubs + `getWebSocketTicket` from `ApiService`

### Code review fixes (Rex)
- Fixed CRITICAL key mismatch: contextDict$/stateDict$ keyed by `sender.agent_id` (UUID) to match agent-tabs lookup
- Added toast for WebSocket connection errors
- Fixed `disableRelaunchBtn` referencing V1 `msg.actor` field
- Added null guard on `schema.properties` for V2 empty schemas
- Removed dead code and unused imports

Closes #6