### PR TITLE
Frontend speak-as selector wiring

### DIFF
--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -1,0 +1,173 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { ProcessUserInputComponent } from './user-input.component';
+import { ApiService } from '../../services/api.service';
+import { AkgentService, Akgent } from '../../services/akgent.service';
+import { ChatService } from '../../services/chat.service';
+import { GraphDataService } from '../../services/graph-data.service';
+import { ActorMessageService } from '../../services/message.service';
+
+describe('ProcessUserInputComponent', () => {
+  let component: ProcessUserInputComponent;
+  let fixture: ComponentFixture<ProcessUserInputComponent>;
+  let apiServiceSpy: jasmine.SpyObj<ApiService>;
+  let akgentService: { selectedAkgent$: BehaviorSubject<Akgent | null> };
+
+  beforeEach(async () => {
+    apiServiceSpy = jasmine.createSpyObj('ApiService', [
+      'sendMessage',
+      'sendMessageFromTo',
+    ]);
+    apiServiceSpy.sendMessage.and.returnValue(Promise.resolve());
+    apiServiceSpy.sendMessageFromTo.and.returnValue(Promise.resolve());
+
+    akgentService = {
+      selectedAkgent$: new BehaviorSubject<Akgent | null>(null),
+    };
+
+    const chatService = {
+      messages$: new BehaviorSubject<any[]>([]),
+    };
+
+    const graphDataService = {
+      nodes$: of([]),
+    };
+
+    const messageService = {
+      messages$: of([]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [FormsModule, ProcessUserInputComponent],
+      providers: [
+        { provide: ApiService, useValue: apiServiceSpy },
+        { provide: AkgentService, useValue: akgentService },
+        { provide: ChatService, useValue: chatService },
+        { provide: GraphDataService, useValue: graphDataService },
+        { provide: ActorMessageService, useValue: messageService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProcessUserInputComponent);
+    component = fixture.componentInstance;
+    component.processId = 'test-team-id';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('sendMessage()', () => {
+    it('should not send when input is empty', async () => {
+      component.userInput = '';
+      await component.sendMessage();
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+    });
+
+    it('should not send when input is whitespace only', async () => {
+      component.userInput = '   ';
+      await component.sendMessage();
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should broadcast via sendMessage when no targets and no speak-as', async () => {
+      component.userInput = 'hello everyone';
+      component.selectedAgents = [];
+      akgentService.selectedAkgent$.next(null);
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'hello everyone',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+    });
+
+    it('should broadcast via sendMessage when no targets even if speak-as is set', async () => {
+      component.userInput = 'broadcast msg';
+      component.selectedAgents = [];
+      akgentService.selectedAkgent$.next({ name: '@Developer', agentId: 'dev-1' });
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'broadcast msg',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+    });
+
+    it('should call sendMessageFromTo when speak-as is set and targets exist', async () => {
+      component.userInput = 'do this task';
+      component.selectedAgents = [
+        { name: 'Manager', actorName: '@Manager', agentId: 'mgr-1' },
+      ];
+      akgentService.selectedAkgent$.next({ name: '@Developer', agentId: 'dev-1' });
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        '@Developer',
+        '@Manager',
+        'do this task',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should call sendMessageFromTo for each target when speak-as is set', async () => {
+      component.userInput = 'multi-target';
+      component.selectedAgents = [
+        { name: 'Manager', actorName: '@Manager', agentId: 'mgr-1' },
+        { name: 'Designer', actorName: '@Designer', agentId: 'des-1' },
+      ];
+      akgentService.selectedAkgent$.next({ name: '@Developer', agentId: 'dev-1' });
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledTimes(2);
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledWith(
+        'test-team-id',
+        '@Developer',
+        '@Manager',
+        'multi-target',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledWith(
+        'test-team-id',
+        '@Developer',
+        '@Designer',
+        'multi-target',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should call sendMessage per target when no speak-as and targets exist', async () => {
+      component.userInput = 'no impersonation';
+      component.selectedAgents = [
+        { name: 'Manager', actorName: '@Manager', agentId: 'mgr-1' },
+      ];
+      akgentService.selectedAkgent$.next(null);
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'no impersonation',
+        '@Manager',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+    });
+
+    it('should clear userInput after sending', async () => {
+      component.userInput = 'will be cleared';
+      component.selectedAgents = [];
+      await component.sendMessage();
+      expect(component.userInput).toBe('');
+    });
+  });
+});

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -13,6 +13,7 @@ import { Message } from '../../models/types';
 import { makeAgentNameUserFriendly } from '../../lib/util';
 
 import { ApiService } from '../../services/api.service';
+import { AkgentService } from '../../services/akgent.service';
 import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorMessageService } from '../../services/message.service';
@@ -39,6 +40,7 @@ export class ProcessUserInputComponent implements OnInit {
   @Input() processId!: string;
 
   apiService: ApiService = inject(ApiService);
+  akgentService: AkgentService = inject(AkgentService);
   chatService: ChatService = inject(ChatService);
   messageService: ActorMessageService = inject(ActorMessageService);
   graphDataService: GraphDataService = inject(GraphDataService);
@@ -144,21 +146,27 @@ export class ProcessUserInputComponent implements OnInit {
   }
 
   async sendMessage() {
-    // selectedAgents now contains both mentioned and manually selected agents
-    // thanks to the auto-detection logic
-
     if (!this.userInput || this.userInput.trim() === '') {
       return;
     }
 
-    // If no agents specified, broadcast to entire team
+    const speakAs = this.akgentService.selectedAkgent$.value;
+
     if (!this.selectedAgents || this.selectedAgents.length === 0) {
-      await this.apiService.sendMessage(
-        this.processId,
-        this.userInput,
-      );
+      // No targets → broadcast (speak-as not applicable without explicit target)
+      await this.apiService.sendMessage(this.processId, this.userInput);
+    } else if (speakAs) {
+      // Speak-as IS set AND targets exist → use sendMessageFromTo
+      for (const agent of this.selectedAgents) {
+        await this.apiService.sendMessageFromTo(
+          this.processId,
+          speakAs.name,
+          agent.actorName,
+          this.userInput,
+        );
+      }
     } else {
-      // Send message to each target agent
+      // No speak-as → existing behavior
       for (const agent of this.selectedAgents) {
         await this.apiService.sendMessage(
           this.processId,

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { ApiService } from './api.service';
+import { FetchService } from './fetch.service';
+import { AuthService } from './auth.service';
+import { Router } from '@angular/router';
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let fetchServiceSpy: jasmine.SpyObj<FetchService>;
+
+  beforeEach(() => {
+    fetchServiceSpy = jasmine.createSpyObj('FetchService', ['fetch']);
+    fetchServiceSpy.fetch.and.returnValue(Promise.resolve(undefined));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ApiService,
+        { provide: FetchService, useValue: fetchServiceSpy },
+        { provide: AuthService, useValue: {} },
+        { provide: Router, useValue: {} },
+      ],
+    });
+
+    service = TestBed.inject(ApiService);
+  });
+
+  describe('sendMessageFromTo', () => {
+    it('should call fetch with correct URL and body', async () => {
+      await service.sendMessageFromTo('team-1', '@Developer', '@Manager', 'hello');
+
+      expect(fetchServiceSpy.fetch).toHaveBeenCalledTimes(1);
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toContain('/teams/team-1/message/from/@Developer/to/@Manager');
+      expect(callArgs.options?.method).toBe('POST');
+      expect(callArgs.options?.body).toBe(JSON.stringify({ content: 'hello' }));
+      expect(callArgs.options?.headers).toEqual({ 'Content-Type': 'application/json' });
+    });
+
+    it('should return void (resolves to undefined)', async () => {
+      const result = await service.sendMessageFromTo('t1', '@A', '@B', 'msg');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('sendMessage (existing)', () => {
+    it('should broadcast when no agentName provided', async () => {
+      await service.sendMessage('team-1', 'broadcast msg');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toContain('/teams/team-1/message');
+      expect(callArgs.url).not.toContain('/teams/team-1/message/');
+    });
+
+    it('should delegate to sendMessageTo when agentName provided', async () => {
+      await service.sendMessage('team-1', 'targeted msg', '@Manager');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toContain('/teams/team-1/message/@Manager');
+    });
+  });
+});

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -47,8 +47,7 @@ describe('ApiService', () => {
       await service.sendMessage('team-1', 'broadcast msg');
 
       const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
-      expect(callArgs.url).toContain('/teams/team-1/message');
-      expect(callArgs.url).not.toContain('/teams/team-1/message/');
+      expect(callArgs.url).toMatch(/\/teams\/team-1\/message$/);
     });
 
     it('should delegate to sendMessageTo when agentName provided', async () => {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -109,6 +109,22 @@ export class ApiService {
     });
   }
 
+  async sendMessageFromTo(
+    teamId: string,
+    senderName: string,
+    recipientName: string,
+    content: string
+  ): Promise<void> {
+    await this.fetchService.fetch({
+      url: `${this.apiUrl}/teams/${teamId}/message/from/${senderName}/to/${recipientName}`,
+      options: {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    });
+  }
+
   /** V2 processHumanInput: sends human input for a specific message in a team. */
   async processHumanInput(
     teamId: string,


### PR DESCRIPTION
## Summary

- Add `sendMessageFromTo(teamId, senderName, recipientName, content)` to `ApiService` calling `POST /teams/{id}/message/from/{sender}/to/{recipient}`
- Wire `AkgentService.selectedAkgent$` into `ProcessUserInputComponent.sendMessage()` with three-way branching: no targets (broadcast), speak-as + targets (`sendMessageFromTo`), no speak-as + targets (existing `sendMessage`)
- Add 13 unit tests across `api.service.spec.ts` and `user-input.component.spec.ts` covering all branching scenarios

Closes #13