### PR TITLE
Bubble selection reply context

### DIFF
--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -18,7 +18,7 @@
   [class.right]="message().alignment === 'right'"
   [class.left]="message().alignment === 'left'"
   (click)="onBubbleClick($event)"
-  [class.clickable]="message().rule === 4 || message().rule === 1 || message().rule === 2 || message().rule === 3"
+  [class.clickable]="true"
 >
   <div
     class="message-bubble"

--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -17,11 +17,12 @@
   class="message"
   [class.right]="message().alignment === 'right'"
   [class.left]="message().alignment === 'left'"
-  (click)="message().rule === 4 ? onToggleCollapse() : null"
-  [class.clickable]="message().rule === 4"
+  (click)="onBubbleClick($event)"
+  [class.clickable]="message().rule === 4 || message().rule === 1 || message().rule === 2 || message().rule === 3"
 >
   <div
     class="message-bubble"
+    [class.selected]="selected()"
     [style.background-color]="message().color"
   >
     <div class="bubble-header">

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -61,6 +61,7 @@
   font-size: 1rem;
   line-height: 1.5;
   border-radius: 10px;
+  border: 2px solid transparent;
   word-wrap: break-word;
   color: black;
 

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -71,6 +71,10 @@
   .left & {
     border-bottom-left-radius: 0;
   }
+
+  &.selected {
+    border: 2px solid var(--primary-color);
+  }
 }
 
 .bubble-header {

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -184,6 +184,110 @@ describe('ChatMessageComponent', () => {
     });
   });
 
+  describe('bubbleClicked output', () => {
+    it('should emit bubbleClicked for Rule 1 bubble click', () => {
+      const msg = makeChatMessage({
+        rule: 1,
+        alignment: 'right',
+        color: '#efeeee',
+        label: 'You -> Manager',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.bubbleClicked, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.bubbleClicked.emit).toHaveBeenCalledWith(msg);
+    });
+
+    it('should emit bubbleClicked for Rule 2 bubble click', () => {
+      const msg = makeChatMessage({ rule: 2, alignment: 'left' });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.bubbleClicked, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.bubbleClicked.emit).toHaveBeenCalledWith(msg);
+    });
+
+    it('should NOT emit bubbleClicked for Rule 4 bubble click', () => {
+      const msg = makeChatMessage({ rule: 4, collapsed: false });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.bubbleClicked, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.bubbleClicked.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rule3Clicked output', () => {
+    it('should emit rule3Clicked for Rule 3 bubble click', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        alignment: 'left',
+        label: 'Agent -> OtherHuman',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.rule3Clicked, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.rule3Clicked.emit).toHaveBeenCalledWith(msg);
+    });
+
+    it('should NOT emit bubbleClicked for Rule 3', () => {
+      const msg = makeChatMessage({ rule: 3, alignment: 'left' });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.bubbleClicked, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.bubbleClicked.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('selected input', () => {
+    it('should apply .selected class when selected is true', () => {
+      const msg = makeChatMessage({ rule: 2 });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('selected', true);
+      fixture.detectChanges();
+
+      const bubble = fixture.nativeElement.querySelector('.message-bubble');
+      expect(bubble.classList.contains('selected')).toBe(true);
+    });
+
+    it('should NOT apply .selected class when selected is false', () => {
+      const msg = makeChatMessage({ rule: 2 });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('selected', false);
+      fixture.detectChanges();
+
+      const bubble = fixture.nativeElement.querySelector('.message-bubble');
+      expect(bubble.classList.contains('selected')).toBe(false);
+    });
+
+    it('should default selected to false', () => {
+      const msg = makeChatMessage({ rule: 2 });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const bubble = fixture.nativeElement.querySelector('.message-bubble');
+      expect(bubble.classList.contains('selected')).toBe(false);
+    });
+  });
+
   describe('messageSelected output', () => {
     it('should emit on label click for non-Rule-1 messages', () => {
       const msg = makeChatMessage({ rule: 2 });

--- a/src/app/chat/chat-message.component.ts
+++ b/src/app/chat/chat-message.component.ts
@@ -13,7 +13,10 @@ import { ChatMessage } from '../models/chat-message.model';
 export class ChatMessageComponent {
   @Output() messageSelected = new EventEmitter<ChatMessage>();
   @Output() toggleCollapse = new EventEmitter<ChatMessage>();
+  @Output() bubbleClicked = new EventEmitter<ChatMessage>();
+  @Output() rule3Clicked = new EventEmitter<ChatMessage>();
   message = input.required<ChatMessage>();
+  selected = input<boolean>(false);
 
   onToggleCollapse(): void {
     const msg = this.message();
@@ -26,6 +29,23 @@ export class ChatMessageComponent {
     const msg = this.message();
     if (msg.rule !== 1) {
       this.messageSelected.emit(msg);
+    }
+  }
+
+  onBubbleClick(event: Event): void {
+    event.stopPropagation();
+    const msg = this.message();
+    switch (msg.rule) {
+      case 1:
+      case 2:
+        this.bubbleClicked.emit(msg);
+        break;
+      case 3:
+        this.rule3Clicked.emit(msg);
+        break;
+      case 4:
+        this.onToggleCollapse();
+        break;
     }
   }
 }

--- a/src/app/chat/chat-panel.component.html
+++ b/src/app/chat/chat-panel.component.html
@@ -1,11 +1,14 @@
 <div class="chat-container">
   <ng-container *ngIf="chatMessages.length > 0; else noMessagesPlaceholder">
-    <div class="message-list" #scrollContainer>
+    <div class="message-list" #scrollContainer (click)="onBackgroundClick()">
       <app-chat-message
         *ngFor="let msg of chatMessages; trackBy: trackById"
         [message]="msg"
+        [selected]="msg.id === selectedMessageId"
         (messageSelected)="onMessageSelected($event)"
         (toggleCollapse)="onToggleCollapse($event)"
+        (bubbleClicked)="onBubbleClicked($event)"
+        (rule3Clicked)="onRule3Clicked($event)"
       ></app-chat-message>
 
       <div *ngIf="loading$ | async">

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -65,6 +65,13 @@ describe('ChatPanelComponent', () => {
     const chatService = {
       messages$: new BehaviorSubject<any[]>([]),
       loadingProcess$: new BehaviorSubject<boolean>(false),
+      replyContext$: new BehaviorSubject<any>(null),
+      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
+        function(this: any, msg: any) { this.replyContext$.next(msg); }
+      ),
+      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
+        function(this: any) { this.replyContext$.next(null); }
+      ),
     };
 
     const messageService = {
@@ -236,6 +243,115 @@ describe('ChatPanelComponent', () => {
 
     expect(chatService.messages$.value.length).toBe(1);
     expect(chatService.messages$.value[0].rule).toBe(1);
+  });
+
+  describe('reply context (bubble selection)', () => {
+    it('onBubbleClicked should call chatService.setReplyContext', () => {
+      const chatMsg: ChatMessage = {
+        id: 'msg-reply',
+        content: 'test',
+        sender: makeAddress({ name: '@Manager', agent_id: 'mgr-1' }),
+        recipient: makeAddress({ name: '@Human' }),
+        timestamp: new Date(),
+        rule: 2,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'Manager',
+      };
+      component.onBubbleClicked(chatMsg);
+      const svc = TestBed.inject(ChatService) as any;
+      expect(svc.setReplyContext).toHaveBeenCalledWith(chatMsg);
+    });
+
+    it('onBackgroundClick should call chatService.clearReplyContext', () => {
+      component.onBackgroundClick();
+      const svc = TestBed.inject(ChatService) as any;
+      expect(svc.clearReplyContext).toHaveBeenCalled();
+    });
+
+    it('onEscapePress should call chatService.clearReplyContext', () => {
+      component.onEscapePress();
+      const svc = TestBed.inject(ChatService) as any;
+      expect(svc.clearReplyContext).toHaveBeenCalled();
+    });
+
+    it('selectedMessageId should track replyContext$ value', () => {
+      const svc = TestBed.inject(ChatService) as any;
+      expect(component.selectedMessageId).toBeNull();
+
+      svc.replyContext$.next({
+        id: 'msg-selected',
+        content: 'test',
+        sender: makeAddress({ name: '@Manager' }),
+        recipient: makeAddress({ name: '@Human' }),
+        timestamp: new Date(),
+        rule: 2,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'Manager',
+      });
+      fixture.detectChanges();
+
+      expect(component.selectedMessageId).toBe('msg-selected');
+
+      svc.replyContext$.next(null);
+      fixture.detectChanges();
+      expect(component.selectedMessageId).toBeNull();
+    });
+
+    it('clicking different bubble should switch reply context', () => {
+      const msg1: ChatMessage = {
+        id: 'msg-1',
+        content: 'first',
+        sender: makeAddress({ name: '@Agent1' }),
+        recipient: makeAddress({ name: '@Human' }),
+        timestamp: new Date(),
+        rule: 2,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'Agent1',
+      };
+      const msg2: ChatMessage = {
+        id: 'msg-2',
+        content: 'second',
+        sender: makeAddress({ name: '@Agent2' }),
+        recipient: makeAddress({ name: '@Human' }),
+        timestamp: new Date(),
+        rule: 2,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'Agent2',
+      };
+
+      component.onBubbleClicked(msg1);
+      expect(component.selectedMessageId).toBe('msg-1');
+
+      component.onBubbleClicked(msg2);
+      expect(component.selectedMessageId).toBe('msg-2');
+    });
+
+    it('onRule3Clicked should NOT set reply context', () => {
+      const chatMsg: ChatMessage = {
+        id: 'msg-rule3',
+        content: 'test',
+        sender: makeAddress({ name: '@Agent' }),
+        recipient: makeAddress({ name: '@OtherHuman', role: 'Human' }),
+        timestamp: new Date(),
+        rule: 3,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'Agent -> OtherHuman',
+      };
+      component.onRule3Clicked(chatMsg);
+      const svc = TestBed.inject(ChatService) as any;
+      expect(svc.setReplyContext).not.toHaveBeenCalled();
+      expect(component.selectedMessageId).toBeNull();
+    });
   });
 
   it('onToggleCollapse should toggle collapsed state and preserve across re-classification', () => {

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -46,9 +46,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private lastScrollHeight = 0;
   private expandedMessageIds = new Set<string>();
   selectedMessageId: string | null = null;
+  private replyContextSubscription!: Subscription;
 
   ngOnInit(): void {
-    this.chatService.replyContext$.subscribe((ctx) => {
+    this.replyContextSubscription = this.chatService.replyContext$.subscribe((ctx) => {
       this.selectedMessageId = ctx ? ctx.id : null;
     });
     this.subscription = this.messageService.messages$.subscribe((messages) => {
@@ -91,14 +92,18 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
+    if (this.replyContextSubscription) {
+      this.replyContextSubscription.unsubscribe();
+    }
   }
 
   onBubbleClicked(chatMsg: ChatMessage): void {
     this.chatService.setReplyContext(chatMsg);
   }
 
-  onRule3Clicked(chatMsg: ChatMessage): void {
-    console.log('Rule 3 modal requested for:', chatMsg);
+  // TODO(story-2.3): replace placeholder with notification modal dialog
+  onRule3Clicked(_chatMsg: ChatMessage): void {
+    // no-op until Story 2.3 implements the Rule 3 notification modal
   }
 
   onBackgroundClick(): void {

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -3,6 +3,7 @@ import {
   AfterViewChecked,
   Component,
   ElementRef,
+  HostListener,
   inject,
   Input,
   OnDestroy,
@@ -44,8 +45,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private shouldScrollToBottom = true;
   private lastScrollHeight = 0;
   private expandedMessageIds = new Set<string>();
+  selectedMessageId: string | null = null;
 
   ngOnInit(): void {
+    this.chatService.replyContext$.subscribe((ctx) => {
+      this.selectedMessageId = ctx ? ctx.id : null;
+    });
     this.subscription = this.messageService.messages$.subscribe((messages) => {
       this.checkShouldAutoScroll();
 
@@ -86,6 +91,23 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
+  }
+
+  onBubbleClicked(chatMsg: ChatMessage): void {
+    this.chatService.setReplyContext(chatMsg);
+  }
+
+  onRule3Clicked(chatMsg: ChatMessage): void {
+    console.log('Rule 3 modal requested for:', chatMsg);
+  }
+
+  onBackgroundClick(): void {
+    this.chatService.clearReplyContext();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscapePress(): void {
+    this.chatService.clearReplyContext();
   }
 
   onMessageSelected(chatMsg: ChatMessage): void {

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -1,4 +1,8 @@
 <div class="input-container">
+  <div *ngIf="replyContext" class="reply-indicator">
+    <span>Reply to {{ replyContextDisplayName }}</span>
+    <i class="pi pi-times reply-indicator-close" (click)="clearReplyContext()"></i>
+  </div>
   <p-floatlabel variant="in">
     <div class="input-row">
       <textarea

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -1,7 +1,7 @@
 <div class="input-container">
   <div *ngIf="replyContext" class="reply-indicator">
     <span>Reply to {{ replyContextDisplayName }}</span>
-    <i class="pi pi-times reply-indicator-close" (click)="clearReplyContext()"></i>
+    <i class="pi pi-times reply-indicator-close" role="button" aria-label="Clear reply context" (click)="clearReplyContext()"></i>
   </div>
   <p-floatlabel variant="in">
     <div class="input-row">

--- a/src/app/process/user-input/user-input.component.scss
+++ b/src/app/process/user-input/user-input.component.scss
@@ -4,6 +4,28 @@
   }
 }
 
+.reply-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background-color: #e0f2fe;
+  border-left: 3px solid var(--primary-color);
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: #0c4a6e;
+  margin-bottom: 0.5rem;
+
+  .reply-indicator-close {
+    cursor: pointer;
+    font-size: 0.75rem;
+    color: #64748b;
+    &:hover {
+      color: #334155;
+    }
+  }
+}
+
 .button-group {
   display: flex;
   align-items: center;

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -1,22 +1,67 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { ProcessUserInputComponent } from './user-input.component';
 import { ApiService } from '../../services/api.service';
+import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorMessageService } from '../../services/message.service';
+import { ChatMessage } from '../../models/chat-message.model';
+import { ActorAddress } from '../../models/message.types';
+
+function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
+  return {
+    __actor_address__: true,
+    address: 'addr',
+    name: '@Agent',
+    role: 'Worker',
+    agent_id: 'agent-1',
+    squad_id: 'squad-1',
+    user_message: false,
+    ...overrides,
+  };
+}
+
+function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    content: 'Hello world',
+    sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+    recipient: makeAddress({ name: '@Human', role: 'Human' }),
+    timestamp: new Date('2026-04-08T10:00:00Z'),
+    rule: 2,
+    alignment: 'left',
+    color: '#9ebbcb',
+    collapsed: false,
+    label: 'Manager [Manager]',
+    ...overrides,
+  };
+}
 
 describe('ProcessUserInputComponent', () => {
   let component: ProcessUserInputComponent;
   let fixture: ComponentFixture<ProcessUserInputComponent>;
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
+  let chatServiceMock: any;
 
   beforeEach(async () => {
     apiServiceSpy = jasmine.createSpyObj('ApiService', [
       'sendMessage',
     ]);
     apiServiceSpy.sendMessage.and.returnValue(Promise.resolve());
+
+    chatServiceMock = {
+      messages$: new BehaviorSubject<any[]>([]),
+      loadingProcess$: new BehaviorSubject<boolean>(false),
+      replyContext$: new BehaviorSubject<ChatMessage | null>(null),
+      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
+        function(this: any, msg: any) { this.replyContext$.next(msg); }
+      ),
+      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
+        function(this: any) { this.replyContext$.next(null); }
+      ),
+    };
 
     const graphDataService = {
       nodes$: of([]),
@@ -37,6 +82,7 @@ describe('ProcessUserInputComponent', () => {
       imports: [FormsModule, ProcessUserInputComponent],
       providers: [
         { provide: ApiService, useValue: apiServiceSpy },
+        { provide: ChatService, useValue: chatServiceMock },
         { provide: GraphDataService, useValue: graphDataService },
         { provide: ActorMessageService, useValue: messageService },
       ],
@@ -111,6 +157,114 @@ describe('ProcessUserInputComponent', () => {
       component.mentionItems = [];
       await component.sendMessage();
       expect(component.userInput).toBe('');
+    });
+  });
+
+  describe('reply context', () => {
+    it('should show reply context display name when replyContext is set', () => {
+      const msg = makeChatMessage({
+        sender: makeAddress({ name: '@Manager-Manager_agent' }),
+      });
+      chatServiceMock.replyContext$.next(msg);
+      fixture.detectChanges();
+
+      expect(component.replyContext).toBe(msg);
+      expect(component.replyContextDisplayName).toBeTruthy();
+    });
+
+    it('should clear display name when replyContext is null', () => {
+      chatServiceMock.replyContext$.next(null);
+      fixture.detectChanges();
+
+      expect(component.replyContext).toBeNull();
+      expect(component.replyContextDisplayName).toBe('');
+    });
+
+    it('should show reply indicator in template when replyContext is set', () => {
+      const msg = makeChatMessage();
+      chatServiceMock.replyContext$.next(msg);
+      fixture.detectChanges();
+
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeTruthy();
+    });
+
+    it('should NOT show reply indicator when replyContext is null', () => {
+      chatServiceMock.replyContext$.next(null);
+      fixture.detectChanges();
+
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeNull();
+    });
+
+    it('should send to reply context sender when replyContext is active', async () => {
+      const msg = makeChatMessage({
+        sender: makeAddress({ name: '@Manager' }),
+      });
+      chatServiceMock.replyContext$.next(msg);
+      fixture.detectChanges();
+
+      component.userInput = 'reply message';
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'reply message',
+        '@Manager',
+      );
+    });
+
+    it('should clear reply context after sending with reply context', async () => {
+      const msg = makeChatMessage({
+        sender: makeAddress({ name: '@Manager' }),
+      });
+      chatServiceMock.replyContext$.next(msg);
+      fixture.detectChanges();
+
+      component.userInput = 'reply message';
+      await component.sendMessage();
+
+      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
+    });
+
+    it('reply context should take priority over @mention', async () => {
+      const msg = makeChatMessage({
+        sender: makeAddress({ name: '@Developer' }),
+      });
+      chatServiceMock.replyContext$.next(msg);
+      fixture.detectChanges();
+
+      component.mentionItems = [
+        { name: 'Manager [Manager]', actorName: '@Manager', agentId: 'mgr-1' },
+      ];
+      component.userInput = 'hey Manager [Manager] do this';
+      await component.sendMessage();
+
+      // Should use reply context sender, not the @mention
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'hey Manager [Manager] do this',
+        '@Developer',
+      );
+    });
+
+    it('should broadcast when no reply context and no @mention', async () => {
+      chatServiceMock.replyContext$.next(null);
+      fixture.detectChanges();
+
+      component.userInput = 'hello everyone';
+      component.mentionItems = [];
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        'hello everyone',
+      );
+    });
+
+    it('clearReplyContext should call chatService.clearReplyContext', () => {
+      component.clearReplyContext();
+      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component, inject, Input, OnInit, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
@@ -11,13 +12,16 @@ import { environment } from '../../../environments/environment';
 import { makeAgentNameUserFriendly } from '../../lib/util';
 
 import { ApiService } from '../../services/api.service';
+import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 
+import { ChatMessage } from '../../models/chat-message.model';
 import { ProcessControlsComponent } from '../../process-controls/process-controls.component';
 
 @Component({
   selector: 'app-user-input',
   imports: [
+    CommonModule,
     FormsModule,
     TextareaModule,
     FloatLabelModule,
@@ -32,15 +36,28 @@ export class ProcessUserInputComponent implements OnInit {
   @Input() processId!: string;
 
   apiService: ApiService = inject(ApiService);
+  chatService: ChatService = inject(ChatService);
   graphDataService: GraphDataService = inject(GraphDataService);
   userInput: string = '';
   userInputEnterKeySubmit: boolean = environment.userInputEnterKeySubmit;
+  replyContext: ChatMessage | null = null;
+  replyContextDisplayName: string = '';
 
   // Mention configuration
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];
   private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
+    // Subscribe to reply context changes
+    this.chatService.replyContext$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((ctx) => {
+        this.replyContext = ctx;
+        this.replyContextDisplayName = ctx
+          ? makeAgentNameUserFriendly(ctx.sender.name)
+          : '';
+      });
+
     // Subscribe to nodes to populate mention items
     this.graphDataService.nodes$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -81,24 +98,40 @@ export class ProcessUserInputComponent implements OnInit {
       });
   }
 
+  clearReplyContext(): void {
+    this.chatService.clearReplyContext();
+  }
+
   async sendMessage() {
     if (!this.userInput || this.userInput.trim() === '') {
       return;
     }
 
-    // Extract first @mention from text matching a known agent
-    const mentionedAgent = this.mentionItems.find((item) =>
-      this.userInput.includes(item.name),
-    );
+    const replyCtx = this.chatService.replyContext$.value;
 
-    if (mentionedAgent) {
+    if (replyCtx) {
+      // Reply context takes priority -- directed send to selected bubble's sender
       await this.apiService.sendMessage(
         this.processId,
         this.userInput,
-        mentionedAgent.actorName,
+        replyCtx.sender.name,
       );
+      this.chatService.clearReplyContext();
     } else {
-      await this.apiService.sendMessage(this.processId, this.userInput);
+      // Existing logic: @mention or broadcast
+      const mentionedAgent = this.mentionItems.find((item) =>
+        this.userInput.includes(item.name),
+      );
+
+      if (mentionedAgent) {
+        await this.apiService.sendMessage(
+          this.processId,
+          this.userInput,
+          mentionedAgent.actorName,
+        );
+      } else {
+        await this.apiService.sendMessage(this.processId, this.userInput);
+      }
     }
 
     this.userInput = '';

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -1,0 +1,90 @@
+import { ChatService } from './chat.service';
+import { ChatMessage } from '../models/chat-message.model';
+import { ActorAddress } from '../models/message.types';
+
+function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
+  return {
+    __actor_address__: true,
+    address: 'addr',
+    name: '@Agent',
+    role: 'Worker',
+    agent_id: 'agent-1',
+    squad_id: 'squad-1',
+    user_message: false,
+    ...overrides,
+  };
+}
+
+function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    content: 'Hello world',
+    sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+    recipient: makeAddress({ name: '@Human', role: 'Human' }),
+    timestamp: new Date('2026-04-08T10:00:00Z'),
+    rule: 2,
+    alignment: 'left',
+    color: '#9ebbcb',
+    collapsed: false,
+    label: 'Manager [Manager]',
+    ...overrides,
+  };
+}
+
+describe('ChatService', () => {
+  let service: ChatService;
+
+  beforeEach(() => {
+    service = new ChatService();
+  });
+
+  describe('replyContext$', () => {
+    it('should initialize to null', () => {
+      expect(service.replyContext$.value).toBeNull();
+    });
+
+    it('should set reply context via setReplyContext', () => {
+      const msg = makeChatMessage();
+      service.setReplyContext(msg);
+      expect(service.replyContext$.value).toBe(msg);
+    });
+
+    it('should clear reply context via clearReplyContext', () => {
+      const msg = makeChatMessage();
+      service.setReplyContext(msg);
+      expect(service.replyContext$.value).toBe(msg);
+
+      service.clearReplyContext();
+      expect(service.replyContext$.value).toBeNull();
+    });
+
+    it('should emit values to subscribers', () => {
+      const emitted: (ChatMessage | null)[] = [];
+      service.replyContext$.subscribe((val) => emitted.push(val));
+
+      const msg = makeChatMessage({ id: 'msg-2' });
+      service.setReplyContext(msg);
+      service.clearReplyContext();
+
+      expect(emitted).toEqual([null, msg, null]);
+    });
+
+    it('should replace previous reply context when setting a new one', () => {
+      const msg1 = makeChatMessage({ id: 'msg-1' });
+      const msg2 = makeChatMessage({ id: 'msg-2' });
+
+      service.setReplyContext(msg1);
+      expect(service.replyContext$.value).toBe(msg1);
+
+      service.setReplyContext(msg2);
+      expect(service.replyContext$.value).toBe(msg2);
+    });
+
+    it('should accept null via setReplyContext', () => {
+      const msg = makeChatMessage();
+      service.setReplyContext(msg);
+      service.setReplyContext(null);
+      expect(service.replyContext$.value).toBeNull();
+    });
+  });
+});

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -23,4 +23,14 @@ export class ChatService {
   loadingProcess$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     false
   );
+  replyContext$: BehaviorSubject<ChatMessage | null> =
+    new BehaviorSubject<ChatMessage | null>(null);
+
+  setReplyContext(message: ChatMessage | null): void {
+    this.replyContext$.next(message);
+  }
+
+  clearReplyContext(): void {
+    this.replyContext$.next(null);
+  }
 }


### PR DESCRIPTION
## Summary

- Add reply context feature: clicking a Rule 1/2 message bubble sets it as the reply target for the next message
- Escape key and click-away clear the reply context; clicking a different bubble switches it
- Rule 3 bubbles delegate to notification modal (placeholder); Rule 4 bubbles toggle collapse as before
- Reply context observable on ChatService shared between chat-panel and user-input components
- Reply-to indicator above textarea shows selected agent name with close button

Closes #17