### PR TITLE
Notification bell and modal for non-entry-point human agents

### DIFF
--- a/src/app/chat/chat-human-modal.component.html
+++ b/src/app/chat/chat-human-modal.component.html
@@ -1,0 +1,31 @@
+<p-dialog
+  [header]="headerText"
+  [modal]="true"
+  [visible]="visible()"
+  (visibleChange)="onVisibleChange($event)"
+  [style]="{ width: '50rem' }"
+  [contentStyle]="{ 'max-height': '60vh', overflow: 'auto' }"
+>
+  <div class="pending-messages">
+    <div *ngFor="let msg of pendingMessages()" class="pending-message-item">
+      <span class="message-time">[{{ msg.timestamp | date : 'HH:mm' }}]</span>
+      <div class="message-content">
+        <markdown [data]="msg.content"></markdown>
+      </div>
+    </div>
+  </div>
+  <div class="reply-section">
+    <textarea
+      pTextarea
+      style="width: 100%; min-height: 80px; max-height: 200px"
+      [autoResize]="true"
+      [(ngModel)]="replyText"
+      placeholder="Type your reply..."
+      (keydown.meta.enter)="onSend()"
+      (keydown.control.enter)="onSend()"
+    ></textarea>
+    <div class="reply-actions">
+      <p-button label="Send" size="small" (click)="onSend()" />
+    </div>
+  </div>
+</p-dialog>

--- a/src/app/chat/chat-human-modal.component.scss
+++ b/src/app/chat/chat-human-modal.component.scss
@@ -1,0 +1,39 @@
+.pending-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.pending-message-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.5rem;
+  border-radius: 6px;
+  background-color: #f8fafc;
+}
+
+.message-time {
+  font-size: 0.85rem;
+  color: #64748b;
+  white-space: nowrap;
+  padding-top: 2px;
+}
+
+.message-content {
+  flex: 1;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.reply-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reply-actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/app/chat/chat-human-modal.component.spec.ts
+++ b/src/app/chat/chat-human-modal.component.spec.ts
@@ -1,0 +1,176 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideMarkdown } from 'ngx-markdown';
+
+import {
+  ChatHumanModalComponent,
+  HumanModalReply,
+} from './chat-human-modal.component';
+import { ChatMessage } from '../models/chat-message.model';
+import { ActorAddress } from '../models/message.types';
+
+function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
+  return {
+    __actor_address__: true,
+    address: 'addr',
+    name: '@Agent',
+    role: 'Worker',
+    agent_id: 'agent-1',
+    squad_id: 'squad-1',
+    user_message: false,
+    ...overrides,
+  };
+}
+
+function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    content: 'Hello world',
+    sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+    recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+    timestamp: new Date('2026-04-08T10:00:00Z'),
+    rule: 3,
+    alignment: 'left',
+    color: '#9ebbcb',
+    collapsed: false,
+    label: 'Manager -> QATester',
+    ...overrides,
+  };
+}
+
+describe('ChatHumanModalComponent', () => {
+  let component: ChatHumanModalComponent;
+  let fixture: ComponentFixture<ChatHumanModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatHumanModalComponent, NoopAnimationsModule],
+      providers: [provideMarkdown()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatHumanModalComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  describe('headerText', () => {
+    it('should return default header when no agentPair', () => {
+      fixture.detectChanges();
+      expect(component.headerText).toBe('Human Input');
+    });
+
+    it('should format header with agent names', () => {
+      fixture.componentRef.setInput('agentPair', {
+        sender: makeAddress({ name: '@Manager-manager' }),
+        recipient: makeAddress({ name: '@QATester-qa_tester' }),
+      });
+      fixture.detectChanges();
+
+      expect(component.headerText).toContain('Manager');
+      expect(component.headerText).toContain('->');
+      expect(component.headerText).toContain('QATester');
+    });
+  });
+
+  describe('onSend', () => {
+    it('should emit reply with last message id and content', () => {
+      const msgs = [
+        makeChatMessage({ id: 'msg-1' }),
+        makeChatMessage({ id: 'msg-2' }),
+        makeChatMessage({ id: 'msg-3' }),
+      ];
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', msgs);
+      fixture.detectChanges();
+
+      const emitted: HumanModalReply[] = [];
+      component.reply.subscribe((r: HumanModalReply) => emitted.push(r));
+
+      component.replyText = 'Approved!';
+      component.onSend();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].content).toBe('Approved!');
+      expect(emitted[0].messageId).toBe('msg-3');
+    });
+
+    it('should not emit if reply text is empty', () => {
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', [makeChatMessage()]);
+      fixture.detectChanges();
+
+      const emitted: HumanModalReply[] = [];
+      component.reply.subscribe((r: HumanModalReply) => emitted.push(r));
+
+      component.replyText = '   ';
+      component.onSend();
+
+      expect(emitted.length).toBe(0);
+    });
+
+    it('should not emit if no pending messages', () => {
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', []);
+      fixture.detectChanges();
+
+      const emitted: HumanModalReply[] = [];
+      component.reply.subscribe((r: HumanModalReply) => emitted.push(r));
+
+      component.replyText = 'reply';
+      component.onSend();
+
+      expect(emitted.length).toBe(0);
+    });
+
+    it('should clear reply text after sending', () => {
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', [makeChatMessage()]);
+      fixture.detectChanges();
+
+      component.replyText = 'test reply';
+      component.onSend();
+
+      expect(component.replyText).toBe('');
+    });
+
+    it('should emit visibleChange(false) after sending', () => {
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', [makeChatMessage()]);
+      fixture.detectChanges();
+
+      const visibleChanges: boolean[] = [];
+      component.visibleChange.subscribe((v: boolean) => visibleChanges.push(v));
+
+      component.replyText = 'done';
+      component.onSend();
+
+      expect(visibleChanges).toContain(false);
+    });
+  });
+
+  describe('onVisibleChange', () => {
+    it('should emit false when dialog is closed', () => {
+      fixture.detectChanges();
+      const emitted: boolean[] = [];
+      component.visibleChange.subscribe((v: boolean) => emitted.push(v));
+
+      component.onVisibleChange(false);
+
+      expect(emitted).toEqual([false]);
+    });
+
+    it('should NOT emit when value is true (dialog opens)', () => {
+      fixture.detectChanges();
+      const emitted: boolean[] = [];
+      component.visibleChange.subscribe((v: boolean) => emitted.push(v));
+
+      component.onVisibleChange(true);
+
+      expect(emitted.length).toBe(0);
+    });
+  });
+});

--- a/src/app/chat/chat-human-modal.component.ts
+++ b/src/app/chat/chat-human-modal.component.ts
@@ -1,0 +1,70 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, EventEmitter, input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { TextareaModule } from 'primeng/textarea';
+import { MarkdownModule } from 'ngx-markdown';
+
+import { ChatMessage } from '../models/chat-message.model';
+import { ActorAddress } from '../models/message.types';
+import { makeAgentNameUserFriendly } from '../lib/util';
+
+export interface HumanModalReply {
+  content: string;
+  messageId: string;
+}
+
+@Component({
+  selector: 'app-chat-human-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    DialogModule,
+    TextareaModule,
+    ButtonModule,
+    MarkdownModule,
+    DatePipe,
+  ],
+  templateUrl: './chat-human-modal.component.html',
+  styleUrl: './chat-human-modal.component.scss',
+})
+export class ChatHumanModalComponent {
+  visible = input<boolean>(false);
+  agentPair = input<{ sender: ActorAddress; recipient: ActorAddress } | null>(null);
+  pendingMessages = input<ChatMessage[]>([]);
+
+  @Output() visibleChange = new EventEmitter<boolean>();
+  @Output() reply = new EventEmitter<HumanModalReply>();
+
+  replyText = '';
+
+  get headerText(): string {
+    const pair = this.agentPair();
+    if (!pair) return 'Human Input';
+    const sender = makeAgentNameUserFriendly(pair.sender.name);
+    const recipient = makeAgentNameUserFriendly(pair.recipient.name);
+    return `${sender} -> ${recipient}`;
+  }
+
+  onVisibleChange(value: boolean): void {
+    if (!value) {
+      this.visibleChange.emit(false);
+    }
+  }
+
+  onSend(): void {
+    if (!this.replyText.trim()) return;
+    const messages = this.pendingMessages();
+    if (messages.length === 0) return;
+
+    const lastMessage = messages[messages.length - 1];
+    this.reply.emit({
+      content: this.replyText.trim(),
+      messageId: lastMessage.id,
+    });
+    this.replyText = '';
+    this.visibleChange.emit(false);
+  }
+}

--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -34,7 +34,7 @@
         {{ message().label }}
       </button>
       <span *ngIf="message().rule === 4" class="collapse-indicator-bubble">v</span>
-      <span *ngIf="message().rule === 3" class="notification-placeholder">
+      <span *ngIf="notification()" class="notification-icon">
         <i class="pi pi-bell"></i>
       </span>
     </div>

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -117,9 +117,15 @@
   color: #64748b;
 }
 
-.notification-placeholder {
-  color: #6a9bb6;
+.notification-icon {
+  color: #38bdf8;
   font-size: 0.9rem;
+  animation: bell-pulse 2s ease-in-out infinite;
+}
+
+@keyframes bell-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
 .markdown-content {

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -105,7 +105,37 @@ describe('ChatMessageComponent', () => {
   });
 
   describe('Rule 3 (notification)', () => {
-    it('should show notification placeholder', () => {
+    it('should show notification icon when notification input is true', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        alignment: 'left',
+        label: 'Agent -> OtherHuman',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.notification-icon')).toBeTruthy();
+      expect(el.querySelector('.pi-bell')).toBeTruthy();
+    });
+
+    it('should NOT show notification icon when notification input is false', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        alignment: 'left',
+        label: 'Agent -> OtherHuman',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.notification-icon')).toBeNull();
+      expect(el.querySelector('.pi-bell')).toBeNull();
+    });
+
+    it('should default notification to false (no bell icon)', () => {
       const msg = makeChatMessage({
         rule: 3,
         alignment: 'left',
@@ -115,8 +145,7 @@ describe('ChatMessageComponent', () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement;
-      expect(el.querySelector('.notification-placeholder')).toBeTruthy();
-      expect(el.querySelector('.pi-bell')).toBeTruthy();
+      expect(el.querySelector('.notification-icon')).toBeNull();
     });
   });
 

--- a/src/app/chat/chat-message.component.ts
+++ b/src/app/chat/chat-message.component.ts
@@ -17,6 +17,7 @@ export class ChatMessageComponent {
   @Output() rule3Clicked = new EventEmitter<ChatMessage>();
   message = input.required<ChatMessage>();
   selected = input<boolean>(false);
+  notification = input<boolean>(false);
 
   onToggleCollapse(): void {
     const msg = this.message();

--- a/src/app/chat/chat-panel.component.html
+++ b/src/app/chat/chat-panel.component.html
@@ -5,6 +5,7 @@
         *ngFor="let msg of chatMessages; trackBy: trackById"
         [message]="msg"
         [selected]="msg.id === selectedMessageId"
+        [notification]="hasNotification(msg)"
         (messageSelected)="onMessageSelected($event)"
         (toggleCollapse)="onToggleCollapse($event)"
         (bubbleClicked)="onBubbleClicked($event)"
@@ -45,4 +46,11 @@
     </ng-template>
   </ng-template>
   <app-user-input [processId]="processId"></app-user-input>
+  <app-chat-human-modal
+    [visible]="modalVisible"
+    [agentPair]="modalAgentPair"
+    [pendingMessages]="modalPendingMessages"
+    (visibleChange)="onModalVisibleChange($event)"
+    (reply)="onModalReply($event)"
+  ></app-chat-human-modal>
 </div>

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { provideMarkdown } from 'ngx-markdown';
 
 import { ChatPanelComponent } from './chat-panel.component';
-import { ChatService } from '../services/chat.service';
+import { ChatService, computePendingNotifications } from '../services/chat.service';
 import { ActorMessageService } from '../services/message.service';
 import { SelectionService } from '../services/selection.service';
 import { ActorAddress, SentMessage, BaseMessage, AkgenticMessage, StartMessage } from '../models/message.types';
@@ -62,10 +64,12 @@ describe('ChatPanelComponent', () => {
   beforeEach(async () => {
     messagesSubject = new BehaviorSubject<AkgenticMessage[]>([]);
 
+    const messagesSubj = new BehaviorSubject<any[]>([]);
     const chatService = {
-      messages$: new BehaviorSubject<any[]>([]),
+      messages$: messagesSubj,
       loadingProcess$: new BehaviorSubject<boolean>(false),
       replyContext$: new BehaviorSubject<any>(null),
+      pendingNotifications$: messagesSubj.pipe(map(computePendingNotifications)),
       setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
         function(this: any, msg: any) { this.replyContext$.next(msg); }
       ),
@@ -82,8 +86,9 @@ describe('ChatPanelComponent', () => {
       'handleSelection',
     ]);
 
-    const apiService = jasmine.createSpyObj('ApiService', ['sendMessage']);
+    const apiService = jasmine.createSpyObj('ApiService', ['sendMessage', 'processHumanInput']);
     apiService.sendMessage.and.returnValue(Promise.resolve());
+    apiService.processHumanInput.and.returnValue(Promise.resolve());
 
     const akgentService = {
       selectedAkgent$: new BehaviorSubject<any>(null),
@@ -94,7 +99,7 @@ describe('ChatPanelComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [ChatPanelComponent],
+      imports: [ChatPanelComponent, NoopAnimationsModule],
       providers: [
         provideMarkdown(),
         { provide: ChatService, useValue: chatService },
@@ -334,23 +339,173 @@ describe('ChatPanelComponent', () => {
       expect(component.selectedMessageId).toBe('msg-2');
     });
 
-    it('onRule3Clicked should NOT set reply context', () => {
-      const chatMsg: ChatMessage = {
-        id: 'msg-rule3',
-        content: 'test',
-        sender: makeAddress({ name: '@Agent' }),
-        recipient: makeAddress({ name: '@OtherHuman', role: 'Human' }),
-        timestamp: new Date(),
-        rule: 3,
-        alignment: 'left',
-        color: '#9ebbcb',
-        collapsed: false,
-        label: 'Agent -> OtherHuman',
-      };
+    it('onRule3Clicked should open modal with pending messages', () => {
+      // Set up a Rule 3 message
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-modal',
+      );
+      messagesSubject.next([rule3Msg]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages[0];
+      expect(chatMsg.rule).toBe(3);
+
       component.onRule3Clicked(chatMsg);
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.setReplyContext).not.toHaveBeenCalled();
-      expect(component.selectedMessageId).toBeNull();
+
+      expect(component.modalVisible).toBe(true);
+      expect(component.modalAgentPair?.sender.name).toBe('@Manager');
+      expect(component.modalAgentPair?.recipient.name).toBe('@QATester');
+      expect(component.modalPendingMessages.length).toBe(1);
+    });
+
+    it('onRule3Clicked should not open modal when no pending notifications', () => {
+      // A Rule 3 message that has been replied to
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-1',
+      );
+      const replyMsg = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'approved',
+        'reply-1',
+      );
+      messagesSubject.next([rule3Msg, replyMsg]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages.find(m => m.id === 'r3-1')!;
+      component.onRule3Clicked(chatMsg);
+
+      expect(component.modalVisible).toBe(false);
+    });
+
+    it('onModalReply should call processHumanInput and close modal', () => {
+      component.processId = 'team-42';
+      component.modalVisible = true;
+
+      component.onModalReply({ content: 'approved', messageId: 'msg-123' });
+
+      const api = TestBed.inject(ApiService) as any;
+      expect(api.processHumanInput).toHaveBeenCalledWith('team-42', 'approved', 'msg-123');
+      expect(component.modalVisible).toBe(false);
+    });
+
+    it('onModalVisibleChange should update modalVisible', () => {
+      component.modalVisible = true;
+      component.onModalVisibleChange(false);
+      expect(component.modalVisible).toBe(false);
+    });
+  });
+
+  describe('notification wiring (Task 2)', () => {
+    it('hasNotification should return true for Rule 3 messages with pending notifications', () => {
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-1',
+      );
+      messagesSubject.next([rule3Msg]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages[0];
+      expect(chatMsg.rule).toBe(3);
+      expect(component.hasNotification(chatMsg)).toBe(true);
+    });
+
+    it('hasNotification should return false for Rule 3 messages after reply clears notification', () => {
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-1',
+      );
+      const replyMsg = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'approved',
+        'reply-1',
+      );
+      messagesSubject.next([rule3Msg, replyMsg]);
+      fixture.detectChanges();
+
+      const chatMsgR3 = component.chatMessages.find(m => m.id === 'r3-1')!;
+      expect(component.hasNotification(chatMsgR3)).toBe(false);
+    });
+
+    it('hasNotification should return false for non-Rule-3 messages', () => {
+      const msg = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'hello',
+      );
+      messagesSubject.next([msg]);
+      fixture.detectChanges();
+
+      expect(component.chatMessages[0].rule).toBe(1);
+      expect(component.hasNotification(component.chatMessages[0])).toBe(false);
+    });
+  });
+
+  describe('notification clears on reply (Task 5)', () => {
+    it('notification disappears when reply message arrives via messages$', () => {
+      // 1. Rule 3 message pending
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-clear-1',
+      );
+      messagesSubject.next([rule3Msg]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages[0];
+      expect(component.hasNotification(chatMsg)).toBe(true);
+
+      // 2. Reply arrives (simulating WebSocket message)
+      const replyMsg = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'approved',
+        'reply-clear-1',
+      );
+      messagesSubject.next([rule3Msg, replyMsg]);
+      fixture.detectChanges();
+
+      // 3. Notification should be gone
+      const chatMsgAfter = component.chatMessages.find(m => m.id === 'r3-clear-1')!;
+      expect(component.hasNotification(chatMsgAfter)).toBe(false);
+    });
+
+    it('notification reappears if sender sends again after reply', () => {
+      const rule3First = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'first request',
+        'r3-reappear-1',
+      );
+      const reply = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'done',
+        'reply-reappear-1',
+      );
+      const rule3Second = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'second request',
+        'r3-reappear-2',
+      );
+      messagesSubject.next([rule3First, reply, rule3Second]);
+      fixture.detectChanges();
+
+      const secondMsg = component.chatMessages.find(m => m.id === 'r3-reappear-2')!;
+      expect(component.hasNotification(secondMsg)).toBe(true);
     });
   });
 

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -384,21 +384,47 @@ describe('ChatPanelComponent', () => {
       expect(component.modalVisible).toBe(false);
     });
 
-    it('onModalReply should call processHumanInput and close modal', () => {
+    it('onModalReply should call processHumanInput, close modal, and clear state', () => {
       component.processId = 'team-42';
       component.modalVisible = true;
+      component.modalAgentPair = {
+        sender: makeAddress({ name: '@Manager' }),
+        recipient: makeAddress({ name: '@QATester' }),
+      };
+      const dummyMsg: ChatMessage = {
+        id: 'msg-123', content: 'test', sender: makeAddress({ name: '@Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+        timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
+        collapsed: false, label: 'Manager -> QATester',
+      };
+      component.modalPendingMessages = [dummyMsg];
 
       component.onModalReply({ content: 'approved', messageId: 'msg-123' });
 
       const api = TestBed.inject(ApiService) as any;
       expect(api.processHumanInput).toHaveBeenCalledWith('team-42', 'approved', 'msg-123');
       expect(component.modalVisible).toBe(false);
+      expect(component.modalAgentPair).toBeNull();
+      expect(component.modalPendingMessages).toEqual([]);
     });
 
-    it('onModalVisibleChange should update modalVisible', () => {
+    it('onModalVisibleChange should update modalVisible and clear state when closed', () => {
       component.modalVisible = true;
+      component.modalAgentPair = {
+        sender: makeAddress({ name: '@Manager' }),
+        recipient: makeAddress({ name: '@QATester' }),
+      };
+      const dummyMsg: ChatMessage = {
+        id: 'msg-1', content: 'test', sender: makeAddress({ name: '@Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+        timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
+        collapsed: false, label: 'Manager -> QATester',
+      };
+      component.modalPendingMessages = [dummyMsg];
       component.onModalVisibleChange(false);
       expect(component.modalVisible).toBe(false);
+      expect(component.modalAgentPair).toBeNull();
+      expect(component.modalPendingMessages).toEqual([]);
     });
   });
 

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -13,17 +13,19 @@ import {
 import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { ChatMessage, classifyMessage } from '../models/chat-message.model';
-import { isSentMessage } from '../models/message.types';
+import { ActorAddress, isSentMessage } from '../models/message.types';
+import { ApiService } from '../services/api.service';
 import { ChatService } from '../services/chat.service';
 import { ActorMessageService } from '../services/message.service';
 import { Selectable, SelectionService } from '../services/selection.service';
+import { ChatHumanModalComponent, HumanModalReply } from './chat-human-modal.component';
 import { ChatMessageComponent } from './chat-message.component';
 import { ProcessUserInputComponent } from '../process/user-input/user-input.component';
 
 @Component({
   selector: 'app-chat-panel',
   standalone: true,
-  imports: [CommonModule, ChatMessageComponent, ProcessUserInputComponent],
+  imports: [CommonModule, ChatMessageComponent, ChatHumanModalComponent, ProcessUserInputComponent],
   templateUrl: './chat-panel.component.html',
   styleUrl: './chat-panel.component.scss',
 })
@@ -37,9 +39,15 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   messageService: ActorMessageService = inject(ActorMessageService);
   chatService: ChatService = inject(ChatService);
   selectionService: SelectionService = inject(SelectionService);
+  apiService: ApiService = inject(ApiService);
 
   chatMessages: ChatMessage[] = [];
   loadingProcess$ = this.chatService.loadingProcess$;
+
+  // Modal state for Rule 3 notification dialog
+  modalVisible = false;
+  modalAgentPair: { sender: ActorAddress; recipient: ActorAddress } | null = null;
+  modalPendingMessages: ChatMessage[] = [];
 
   private subscription!: Subscription;
   private shouldScrollToBottom = true;
@@ -47,11 +55,16 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private expandedMessageIds = new Set<string>();
   selectedMessageId: string | null = null;
   private replyContextSubscription!: Subscription;
+  private notificationSubscription!: Subscription;
+  pendingNotifications: Map<string, ChatMessage[]> = new Map();
 
   ngOnInit(): void {
     this.replyContextSubscription = this.chatService.replyContext$.subscribe((ctx) => {
       this.selectedMessageId = ctx ? ctx.id : null;
     });
+    this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
+      (pending) => { this.pendingNotifications = pending; }
+    );
     this.subscription = this.messageService.messages$.subscribe((messages) => {
       this.checkShouldAutoScroll();
 
@@ -88,6 +101,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
   }
 
+  hasNotification(chatMsg: ChatMessage): boolean {
+    if (chatMsg.rule !== 3) return false;
+    const pairKey = `${chatMsg.sender.name}->${chatMsg.recipient.name}`;
+    return this.pendingNotifications.has(pairKey);
+  }
+
   ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
@@ -95,15 +114,32 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.replyContextSubscription) {
       this.replyContextSubscription.unsubscribe();
     }
+    if (this.notificationSubscription) {
+      this.notificationSubscription.unsubscribe();
+    }
   }
 
   onBubbleClicked(chatMsg: ChatMessage): void {
     this.chatService.setReplyContext(chatMsg);
   }
 
-  // TODO(story-2.3): replace placeholder with notification modal dialog
-  onRule3Clicked(_chatMsg: ChatMessage): void {
-    // no-op until Story 2.3 implements the Rule 3 notification modal
+  onRule3Clicked(chatMsg: ChatMessage): void {
+    const pairKey = `${chatMsg.sender.name}->${chatMsg.recipient.name}`;
+    const pending = this.pendingNotifications.get(pairKey) ?? [];
+    if (pending.length === 0) return;
+
+    this.modalAgentPair = { sender: chatMsg.sender, recipient: chatMsg.recipient };
+    this.modalPendingMessages = pending;
+    this.modalVisible = true;
+  }
+
+  onModalReply(reply: HumanModalReply): void {
+    this.apiService.processHumanInput(this.processId, reply.content, reply.messageId);
+    this.modalVisible = false;
+  }
+
+  onModalVisibleChange(visible: boolean): void {
+    this.modalVisible = visible;
   }
 
   onBackgroundClick(): void {

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -134,12 +134,20 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   onModalReply(reply: HumanModalReply): void {
-    this.apiService.processHumanInput(this.processId, reply.content, reply.messageId);
     this.modalVisible = false;
+    this.modalAgentPair = null;
+    this.modalPendingMessages = [];
+    this.apiService
+      .processHumanInput(this.processId, reply.content, reply.messageId)
+      .catch((err) => console.error('Failed to send human input:', err));
   }
 
   onModalVisibleChange(visible: boolean): void {
     this.modalVisible = visible;
+    if (!visible) {
+      this.modalAgentPair = null;
+      this.modalPendingMessages = [];
+    }
   }
 
   onBackgroundClick(): void {

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -1,4 +1,4 @@
-import { ChatService } from './chat.service';
+import { ChatService, computePendingNotifications } from './chat.service';
 import { ChatMessage } from '../models/chat-message.model';
 import { ActorAddress } from '../models/message.types';
 
@@ -86,5 +86,233 @@ describe('ChatService', () => {
       service.setReplyContext(null);
       expect(service.replyContext$.value).toBeNull();
     });
+  });
+
+  describe('pendingNotifications$', () => {
+    it('should emit empty map initially', (done) => {
+      service.pendingNotifications$.subscribe((pending) => {
+        expect(pending.size).toBe(0);
+        done();
+      });
+    });
+
+    it('should emit pending notifications when Rule 3 messages arrive', (done) => {
+      const rule3Msg = makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      });
+      service.messages$.next([rule3Msg]);
+
+      service.pendingNotifications$.subscribe((pending) => {
+        expect(pending.size).toBe(1);
+        expect(pending.get('@Manager->@QATester')?.length).toBe(1);
+        done();
+      });
+    });
+
+    it('should reactively update when messages$ changes', () => {
+      const emitted: Map<string, ChatMessage[]>[] = [];
+      service.pendingNotifications$.subscribe((p) => emitted.push(p));
+
+      // Initially empty
+      expect(emitted[0].size).toBe(0);
+
+      // Add a Rule 3 message
+      const rule3Msg = makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      });
+      service.messages$.next([rule3Msg]);
+
+      expect(emitted[1].size).toBe(1);
+    });
+  });
+});
+
+describe('computePendingNotifications', () => {
+  it('should return empty map for empty messages', () => {
+    const result = computePendingNotifications([]);
+    expect(result.size).toBe(0);
+  });
+
+  it('should track Rule 3 messages as pending', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(1);
+    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+  });
+
+  it('should accumulate multiple messages for same agent pair', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-2',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-3',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.get('@Manager->@QATester')?.length).toBe(3);
+  });
+
+  it('should clear all pending when human replies (AC #2, #3)', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-2',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      // QATester replies to Manager
+      makeChatMessage({
+        id: 'reply-1',
+        rule: 1,
+        sender: makeAddress({ name: '@QATester', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.has('@Manager->@QATester')).toBe(false);
+    expect(result.size).toBe(0);
+  });
+
+  it('should re-add notifications after reply if new messages arrive (AC #2)', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      // QATester replies
+      makeChatMessage({
+        id: 'reply-1',
+        rule: 1,
+        sender: makeAddress({ name: '@QATester', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+      // Manager sends again
+      makeChatMessage({
+        id: 'r3-new',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(1);
+    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+  });
+
+  it('should handle multiple agent pairs independently', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-a',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-b',
+        rule: 3,
+        sender: makeAddress({ name: '@Worker', role: 'Worker' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(2);
+    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+    expect(result.get('@Worker->@QATester')?.length).toBe(1);
+  });
+
+  it('should NOT track messages to @Human entry point', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r2-1',
+        rule: 2,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@Human', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(0);
+  });
+
+  it('should NOT clear when @Human entry point replies', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      // @Human sends a message (entry point user) - should NOT clear QATester notifications
+      makeChatMessage({
+        id: 'user-1',
+        rule: 1,
+        sender: makeAddress({ name: '@Human', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(1);
+    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+  });
+
+  it('reply clears only the specific agent pair, not others', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-a',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-b',
+        rule: 3,
+        sender: makeAddress({ name: '@Worker', role: 'Worker' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      // QATester replies to Manager only
+      makeChatMessage({
+        id: 'reply-1',
+        rule: 1,
+        sender: makeAddress({ name: '@QATester', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.has('@Manager->@QATester')).toBe(false);
+    expect(result.has('@Worker->@QATester')).toBe(true);
+    expect(result.get('@Worker->@QATester')?.length).toBe(1);
   });
 });

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -34,8 +34,8 @@ export function computePendingNotifications(
   for (const msg of messages) {
     // Rule 3 messages: requests to non-entry-point humans
     if (
-      msg.recipient?.role === HUMAN_ROLE &&
-      msg.recipient?.name !== ENTRY_POINT_NAME
+      msg.recipient.role === HUMAN_ROLE &&
+      msg.recipient.name !== ENTRY_POINT_NAME
     ) {
       const pairKey = `${msg.sender.name}->${msg.recipient.name}`;
       const existing = pending.get(pairKey) ?? [];
@@ -45,8 +45,8 @@ export function computePendingNotifications(
 
     // Reply from a non-entry-point human clears the reverse pair
     if (
-      msg.sender?.role === HUMAN_ROLE &&
-      msg.sender?.name !== ENTRY_POINT_NAME
+      msg.sender.role === HUMAN_ROLE &&
+      msg.sender.name !== ENTRY_POINT_NAME
     ) {
       const reversePairKey = `${msg.recipient.name}->${msg.sender.name}`;
       pending.delete(reversePairKey);

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import { ChatMessage } from '../models/chat-message.model';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ChatMessage, ENTRY_POINT_NAME } from '../models/chat-message.model';
+
+const HUMAN_ROLE = 'Human';
 
 // [CUSTOM] Chat body and chat answer interfaces should be customized according to your API.
 export interface ChatBody {
@@ -15,6 +18,44 @@ export interface ChatAnswer {
   }[];
 }
 
+/**
+ * Compute pending notification state from classified chat messages.
+ * Scans all messages in order. Rule 3 messages (to a non-@Human human) add
+ * to the pending map. A reply from the human recipient to the original sender
+ * clears the entire agent pair.
+ *
+ * @returns Map keyed by "senderName->recipientName" with list of unanswered messages.
+ */
+export function computePendingNotifications(
+  messages: ChatMessage[],
+): Map<string, ChatMessage[]> {
+  const pending = new Map<string, ChatMessage[]>();
+
+  for (const msg of messages) {
+    // Rule 3 messages: requests to non-entry-point humans
+    if (
+      msg.recipient?.role === HUMAN_ROLE &&
+      msg.recipient?.name !== ENTRY_POINT_NAME
+    ) {
+      const pairKey = `${msg.sender.name}->${msg.recipient.name}`;
+      const existing = pending.get(pairKey) ?? [];
+      existing.push(msg);
+      pending.set(pairKey, existing);
+    }
+
+    // Reply from a non-entry-point human clears the reverse pair
+    if (
+      msg.sender?.role === HUMAN_ROLE &&
+      msg.sender?.name !== ENTRY_POINT_NAME
+    ) {
+      const reversePairKey = `${msg.recipient.name}->${msg.sender.name}`;
+      pending.delete(reversePairKey);
+    }
+  }
+
+  return pending;
+}
+
 @Injectable()
 export class ChatService {
   messages$: BehaviorSubject<ChatMessage[]> = new BehaviorSubject<ChatMessage[]>(
@@ -25,6 +66,10 @@ export class ChatService {
   );
   replyContext$: BehaviorSubject<ChatMessage | null> =
     new BehaviorSubject<ChatMessage | null>(null);
+
+  /** Reactive map of pending notifications keyed by agent pair. */
+  pendingNotifications$: Observable<Map<string, ChatMessage[]>> =
+    this.messages$.pipe(map(computePendingNotifications));
 
   setReplyContext(message: ChatMessage | null): void {
     this.replyContext$.next(message);


### PR DESCRIPTION
## Summary
- Add reactive notification computation (`pendingNotifications$`) that tracks unanswered Rule 3 messages (requests to non-entry-point humans)
- Implement bell icon with pulse animation on Rule 3 chat bubbles that have pending notifications
- Create standalone `ChatHumanModalComponent` with p-dialog showing pending messages and reply textarea
- Wire modal into chat-panel: click Rule 3 bubble opens modal, reply calls `processHumanInput` API
- Reactive clearing: reply arriving via WebSocket automatically clears notification state
- Code review fixes: add error handling on API call, clear stale modal state, remove unnecessary optional chaining

Closes #19