### PR TITLE
feat: default-sort home teams by created_at desc (newest first)

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -39,11 +39,16 @@
       selectionMode="single"
       (onRowSelect)="onRowSelect($event)"
       [tableStyle]="{ 'min-width': '50rem' }"
+      [sortField]="'created_at'"
+      [sortOrder]="-1"
     >
       <ng-template #header>
         <tr>
           <th>Name</th>
-          <th>Creation Date</th>
+          <th pSortableColumn="created_at">
+            Creation Date
+            <p-sortIcon field="created_at"></p-sortIcon>
+          </th>
           <th>Status</th>
           <th>Team ID</th>
           <th></th>


### PR DESCRIPTION
## Summary

Presentation-layer, template-only fix on `HomeComponent` that default-sorts the home team list by `created_at` descending so the newest team appears on top. Uses PrimeNG `p-table`'s built-in sort via `[sortField]` / `[sortOrder]` with a matching sortable header and `p-sortIcon` on the 'Creation Date' column.

- `[sortField]="'created_at'"` and `[sortOrder]="-1"` on the `<p-table>`.
- `pSortableColumn="created_at"` on the 'Creation Date' `<th>` with a nested `<p-sortIcon field="created_at">`.
- No changes to `home.component.ts`, services, models, or the backend. Sort is re-applied automatically whenever `context` is re-bound (create / delete / stop / restore / refresh), so newest-first is preserved without any TS logic.
- User-driven re-sort via column headers is preserved (default PrimeNG toggle behavior, no locked headers).

## Scope Compliance

All changes are confined to `packages/akgentic-frontend/` (Golden Rule #4). One file modified: `src/app/home/home.component.html`.

## Validation

- `npx ng build`: zero errors (pre-existing unrelated lodash ESM warning only).
- `npx ng test --watch=false --browsers=ChromeHeadless`: 13/13 passing.
- No GitHub Actions workflows exist in this submodule (`no-ci`); local build and Karma suite serve as the gate.

## Review

Rex code review: APPROVE — 6/6 ACs implemented, 0 HIGH/MEDIUM findings, git File List matches story spec exactly.

Closes #23