### PR TITLE
Rule 3 Collapsable with Hand-Raised Icon and Modal Open Button

### DIFF
--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -1,19 +1,31 @@
-<!-- Rule 4 collapsed line -->
+<!-- Collapsed line for Rule 3 and Rule 4 -->
 <div
-  *ngIf="message().rule === 4 && message().collapsed"
+  *ngIf="(message().rule === 3 || message().rule === 4) && message().collapsed"
   class="collapsed-line"
   (click)="onToggleCollapse()"
 >
   <span class="collapse-indicator">&gt;</span>
-  <span class="collapsed-label">{{ message().label }}</span>
+  <span class="collapsed-label">
+    {{ message().label }}<span
+      *ngIf="message().rule === 3 && notification()"
+      class="notification-icon collapsed-notification-icon"
+    > (<span class="hand-raised">🙋</span>)</span>
+  </span>
+  <p-button
+    *ngIf="message().rule === 3"
+    size="small"
+    label="Open"
+    (click)="onOpenModal($event)"
+    class="open-button"
+  ></p-button>
   <span class="collapsed-timestamp">{{
     message().timestamp | date : "HH:mm"
   }}</span>
 </div>
 
-<!-- Expanded bubble (Rules 1/2/3, or Rule 4 expanded) -->
+<!-- Expanded bubble (Rules 1/2, or Rule 3/4 expanded) -->
 <div
-  *ngIf="message().rule !== 4 || !message().collapsed"
+  *ngIf="(message().rule !== 3 && message().rule !== 4) || !message().collapsed"
   class="message"
   [class.right]="message().alignment === 'right'"
   [class.left]="message().alignment === 'left'"
@@ -33,10 +45,26 @@
       >
         {{ message().label }}
       </button>
-      <span *ngIf="message().rule === 4" class="collapse-indicator-bubble">v</span>
-      <span *ngIf="notification()" class="notification-icon">
+      <span
+        *ngIf="message().rule === 3 && notification()"
+        class="notification-icon"
+      >
+        <span class="hand-raised">🙋</span>
+      </span>
+      <span
+        *ngIf="message().rule === 4 && notification()"
+        class="notification-icon"
+      >
         <i class="pi pi-bell"></i>
       </span>
+      <span *ngIf="message().rule === 3 || message().rule === 4" class="collapse-indicator-bubble">v</span>
+      <p-button
+        *ngIf="message().rule === 3"
+        size="small"
+        label="Open"
+        (click)="onOpenModal($event)"
+        class="open-button"
+      ></p-button>
     </div>
     <div class="markdown-content">
       <markdown [data]="message().content"></markdown>

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -34,7 +34,25 @@
   font-size: 0.8rem;
   color: #94a3b8;
   white-space: nowrap;
-  margin-left: auto;
+}
+
+.open-button {
+  flex-shrink: 0;
+}
+
+:host ::ng-deep .open-button .p-button {
+  padding: 2px 8px;
+  font-size: 0.8rem;
+}
+
+.collapsed-notification-icon {
+  display: inline;
+  margin-left: 0;
+}
+
+.hand-raised {
+  display: inline-block;
+  font-style: normal;
 }
 
 /* Expanded message */

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -1,4 +1,4 @@
-/* Collapsed line for Rule 4 */
+/* Collapsed line for Rule 3 and Rule 4 */
 .collapsed-line {
   display: flex;
   align-items: center;

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideMarkdown } from 'ngx-markdown';
 import { ChatMessageComponent } from './chat-message.component';
 import { ChatMessage } from '../models/chat-message.model';
@@ -39,7 +40,7 @@ describe('ChatMessageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ChatMessageComponent],
+      imports: [ChatMessageComponent, NoopAnimationsModule],
       providers: [provideMarkdown()],
     }).compileComponents();
 
@@ -104,11 +105,12 @@ describe('ChatMessageComponent', () => {
     });
   });
 
-  describe('Rule 3 (notification)', () => {
-    it('should show notification icon when notification input is true', () => {
+  describe('Rule 3 (notification + collapse + Open button)', () => {
+    it('should show hand-raised icon (🙋) on expanded bubble when notification is true', () => {
       const msg = makeChatMessage({
         rule: 3,
         alignment: 'left',
+        collapsed: false,
         label: 'Agent -> OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
@@ -116,14 +118,18 @@ describe('ChatMessageComponent', () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement;
-      expect(el.querySelector('.notification-icon')).toBeTruthy();
-      expect(el.querySelector('.pi-bell')).toBeTruthy();
+      const icon = el.querySelector('.notification-icon');
+      expect(icon).toBeTruthy();
+      expect(icon.textContent).toContain('🙋');
+      // Bell icon must NOT be present anywhere for Rule 3
+      expect(el.querySelector('.pi-bell')).toBeNull();
     });
 
-    it('should NOT show notification icon when notification input is false', () => {
+    it('should NOT show hand-raised icon when notification input is false', () => {
       const msg = makeChatMessage({
         rule: 3,
         alignment: 'left',
+        collapsed: false,
         label: 'Agent -> OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
@@ -135,17 +141,144 @@ describe('ChatMessageComponent', () => {
       expect(el.querySelector('.pi-bell')).toBeNull();
     });
 
-    it('should default notification to false (no bell icon)', () => {
+    it('should render collapsed line by default when Rule 3 collapsed', () => {
       const msg = makeChatMessage({
         rule: 3,
-        alignment: 'left',
+        collapsed: true,
         label: 'Agent -> OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
 
       const el = fixture.nativeElement;
-      expect(el.querySelector('.notification-icon')).toBeNull();
+      expect(el.querySelector('.collapsed-line')).toBeTruthy();
+      expect(el.querySelector('.message-bubble')).toBeNull();
+      const label = el.querySelector('.collapsed-label');
+      expect(label.textContent).toContain('Agent -> OtherHuman');
+    });
+
+    it('should append (🙋) in collapsed line when notification is true', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        collapsed: true,
+        label: 'Agent -> OtherHuman',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      expect(label.textContent).toContain('🙋');
+      expect(label.textContent).toContain('(');
+      expect(label.textContent).toContain(')');
+    });
+
+    it('should NOT append (🙋) in collapsed line when notification is false', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        collapsed: true,
+        label: 'Agent -> OtherHuman',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      expect(label.textContent).not.toContain('🙋');
+    });
+
+    it('should render Open button on collapsed Rule 3 line', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.open-button');
+      expect(btn).toBeTruthy();
+      expect(btn.textContent).toContain('Open');
+    });
+
+    it('should render Open button on expanded Rule 3 bubble header', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: false });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const header = fixture.nativeElement.querySelector('.bubble-header');
+      const btn = header.querySelector('.open-button');
+      expect(btn).toBeTruthy();
+      expect(btn.textContent).toContain('Open');
+    });
+
+    it('bubble body click on expanded Rule 3 should emit toggleCollapse and NOT rule3Clicked', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: false });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      spyOn(component.rule3Clicked, 'emit');
+
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.toggleCollapse.emit).toHaveBeenCalledWith(msg);
+      expect(component.rule3Clicked.emit).not.toHaveBeenCalled();
+    });
+
+    it('collapsed-line click on Rule 3 should emit toggleCollapse and NOT rule3Clicked', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      spyOn(component.rule3Clicked, 'emit');
+
+      const line = fixture.nativeElement.querySelector('.collapsed-line');
+      line.click();
+
+      expect(component.toggleCollapse.emit).toHaveBeenCalledWith(msg);
+      expect(component.rule3Clicked.emit).not.toHaveBeenCalled();
+    });
+
+    it('Open button click should emit rule3Clicked and NOT toggleCollapse', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      spyOn(component.rule3Clicked, 'emit');
+
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      btn.click();
+
+      expect(component.rule3Clicked.emit).toHaveBeenCalledWith(msg);
+      expect(component.toggleCollapse.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Open button visibility (Rule 3 only)', () => {
+    it('should NOT render Open button for Rule 1', () => {
+      const msg = makeChatMessage({ rule: 1, alignment: 'right' });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
+    });
+
+    it('should NOT render Open button for Rule 2', () => {
+      const msg = makeChatMessage({ rule: 2, alignment: 'left' });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
+    });
+
+    it('should NOT render Open button for Rule 4 (collapsed or expanded)', () => {
+      const collapsed = makeChatMessage({ rule: 4, collapsed: true });
+      fixture.componentRef.setInput('message', collapsed);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
+
+      const expanded = makeChatMessage({ rule: 4, collapsed: false });
+      fixture.componentRef.setInput('message', expanded);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
     });
   });
 
@@ -257,24 +390,8 @@ describe('ChatMessageComponent', () => {
   });
 
   describe('rule3Clicked output', () => {
-    it('should emit rule3Clicked for Rule 3 bubble click', () => {
-      const msg = makeChatMessage({
-        rule: 3,
-        alignment: 'left',
-        label: 'Agent -> OtherHuman',
-      });
-      fixture.componentRef.setInput('message', msg);
-      fixture.detectChanges();
-
-      spyOn(component.rule3Clicked, 'emit');
-      const messageEl = fixture.nativeElement.querySelector('.message');
-      messageEl.click();
-
-      expect(component.rule3Clicked.emit).toHaveBeenCalledWith(msg);
-    });
-
-    it('should NOT emit bubbleClicked for Rule 3', () => {
-      const msg = makeChatMessage({ rule: 3, alignment: 'left' });
+    it('should NOT emit bubbleClicked for Rule 3 bubble click', () => {
+      const msg = makeChatMessage({ rule: 3, alignment: 'left', collapsed: false });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
 

--- a/src/app/chat/chat-message.component.ts
+++ b/src/app/chat/chat-message.component.ts
@@ -1,12 +1,13 @@
 import { CommonModule, DatePipe } from '@angular/common';
 import { Component, EventEmitter, input, Output } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
 import { MarkdownModule } from 'ngx-markdown';
 import { ChatMessage } from '../models/chat-message.model';
 
 @Component({
   selector: 'app-chat-message',
   standalone: true,
-  imports: [CommonModule, MarkdownModule, DatePipe],
+  imports: [CommonModule, MarkdownModule, DatePipe, ButtonModule],
   templateUrl: './chat-message.component.html',
   styleUrl: './chat-message.component.scss',
 })
@@ -21,7 +22,7 @@ export class ChatMessageComponent {
 
   onToggleCollapse(): void {
     const msg = this.message();
-    if (msg.rule === 4) {
+    if (msg.rule === 3 || msg.rule === 4) {
       this.toggleCollapse.emit(msg);
     }
   }
@@ -42,11 +43,14 @@ export class ChatMessageComponent {
         this.bubbleClicked.emit(msg);
         break;
       case 3:
-        this.rule3Clicked.emit(msg);
-        break;
       case 4:
         this.onToggleCollapse();
         break;
     }
+  }
+
+  onOpenModal(event: Event): void {
+    event.stopPropagation();
+    this.rule3Clicked.emit(this.message());
   }
 }

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -535,6 +535,81 @@ describe('ChatPanelComponent', () => {
     });
   });
 
+  describe('Rule 3 collapse (Story 4.1)', () => {
+    it('Rule 3 messages arrive collapsed by default', () => {
+      const rule3 = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-collapsed',
+      );
+      messagesSubject.next([rule3]);
+      fixture.detectChanges();
+
+      expect(component.chatMessages[0].rule).toBe(3);
+      expect(component.chatMessages[0].collapsed).toBe(true);
+    });
+
+    it('onToggleCollapse on Rule 3 toggles state and preserves across re-emission', () => {
+      const rule3 = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-preserve',
+      );
+      messagesSubject.next([rule3]);
+      fixture.detectChanges();
+
+      expect(component.chatMessages[0].collapsed).toBe(true);
+
+      component.onToggleCollapse(component.chatMessages[0]);
+      expect(component.chatMessages[0].collapsed).toBe(false);
+
+      // Re-emit messages — Rule 3 expanded state should be preserved
+      messagesSubject.next([rule3]);
+      fixture.detectChanges();
+
+      expect(component.chatMessages[0].rule).toBe(3);
+      expect(component.chatMessages[0].collapsed).toBe(false);
+    });
+
+    it('onToggleCollapse should ignore non Rule-3/4 messages', () => {
+      const msg: ChatMessage = {
+        id: 'r1',
+        content: 'x',
+        sender: makeAddress({ name: '@Human' }),
+        recipient: makeAddress({ name: '@Manager' }),
+        timestamp: new Date(),
+        rule: 1,
+        alignment: 'right',
+        color: '#efeeee',
+        collapsed: false,
+        label: 'You -> Manager',
+      };
+      component.onToggleCollapse(msg);
+      expect(msg.collapsed).toBe(false);
+    });
+
+    it('Open button click path: onRule3Clicked still opens modal (regression)', () => {
+      const rule3Msg = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'need approval',
+        'r3-open',
+      );
+      messagesSubject.next([rule3Msg]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages[0];
+      component.onRule3Clicked(chatMsg);
+
+      expect(component.modalVisible).toBe(true);
+      component.onModalReply({ content: 'ok', messageId: chatMsg.id });
+      const api = TestBed.inject(ApiService) as any;
+      expect(api.processHumanInput).toHaveBeenCalledWith('test-team', 'ok', chatMsg.id);
+    });
+  });
+
   it('onToggleCollapse should toggle collapsed state and preserve across re-classification', () => {
     const msg4 = makeSentMessage(
       { name: '@Worker', role: 'Worker' },

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -74,7 +74,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
         .filter((m) => m.message.content != null && m.message.content !== '')
         .map((m) => {
           const chatMsg = classifyMessage(m);
-          if (chatMsg.rule === 4 && this.expandedMessageIds.has(chatMsg.id)) {
+          if (
+            (chatMsg.rule === 3 || chatMsg.rule === 4) &&
+            this.expandedMessageIds.has(chatMsg.id)
+          ) {
             chatMsg.collapsed = false;
           }
           return chatMsg;
@@ -86,7 +89,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   onToggleCollapse(chatMsg: ChatMessage): void {
-    if (chatMsg.rule !== 4) return;
+    if (chatMsg.rule !== 3 && chatMsg.rule !== 4) return;
     chatMsg.collapsed = !chatMsg.collapsed;
     if (chatMsg.collapsed) {
       this.expandedMessageIds.delete(chatMsg.id);

--- a/src/app/models/chat-message.model.spec.ts
+++ b/src/app/models/chat-message.model.spec.ts
@@ -182,6 +182,37 @@ describe('classifyMessage', () => {
     expect(result.collapsed).toBe(true);
   });
 
+  it('should return collapsed=true for Rule 3 (non-@Human human recipient)', () => {
+    const msg = makeSentMessage({
+      sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+      recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+    });
+    const result: ChatMessage = classifyMessage(msg);
+
+    expect(result.rule).toBe(3);
+    expect(result.alignment).toBe('left');
+    expect(result.collapsed).toBe(true);
+  });
+
+  it('should return collapsed=false for Rule 1 and Rule 2', () => {
+    const r1 = classifyMessage(
+      makeSentMessage({
+        sender: makeAddress({ name: '@Human', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+    );
+    const r2 = classifyMessage(
+      makeSentMessage({
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@Human', role: 'Human' }),
+      }),
+    );
+    expect(r1.rule).toBe(1);
+    expect(r1.collapsed).toBe(false);
+    expect(r2.rule).toBe(2);
+    expect(r2.collapsed).toBe(false);
+  });
+
   it('should handle null content gracefully', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Human', role: 'Human' }),

--- a/src/app/models/chat-message.model.ts
+++ b/src/app/models/chat-message.model.ts
@@ -75,7 +75,7 @@ export function classifyMessage(msg: SentMessage): ChatMessage {
     rule,
     alignment: rule === 1 ? 'right' : 'left',
     color: RULE_COLORS[rule],
-    collapsed: rule === 4,
+    collapsed: rule === 3 || rule === 4,
     label: buildLabel(msg, rule),
   };
 }


### PR DESCRIPTION
## Summary

Story 4.1 (Epic 4 — chat panel polish, ADR-002 revision 2026-04-12).

Rule 3 bubbles (messages to non-entry-point humans) now share the Rule 4 unified collapse model:

- classifyMessage sets collapsed=true for Rule 3 and Rule 4
- ChatMessageComponent renders a Rule 3 collapsed line (label + optional hand-raised marker + Open button + timestamp)
- Expanded bubble header shows the hand-raised glyph in .notification-icon plus an Open button and v indicator
- Bubble body click on Rule 3 toggles collapse; the Open button emits rule3Clicked with stopPropagation
- ChatPanelComponent.expandedMessageIds now preserves Rule 3 state across messages$ re-emissions
- Bell icon (pi-bell) replaced by the hand-raised glyph for Rule 3 (Rule 4 path left unchanged per AC7)

## Review notes

Adversarial code review (Rex) — 143/143 tests pass via ng test, ng build green. Submodule has no GitHub Actions CI; local gates are the source of truth (no-ci). One cleanup applied: refreshed stale SCSS comment (collapsed-line block now serves both Rule 3 and Rule 4).

Closes #28
Relates to #28
