### PR TITLE
Story 4.2: collapsed line preview (sender, recipient, message start)

### DIFF
--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -6,10 +6,13 @@
 >
   <span class="collapse-indicator">&gt;</span>
   <span class="collapsed-label">
-    {{ message().label }}<span
+    [{{ message().label }}<span
       *ngIf="message().rule === 3 && notification()"
       class="notification-icon collapsed-notification-icon"
-    > (<span class="hand-raised">🙋</span>)</span>
+    > (<span class="hand-raised">🙋</span>)</span>]<span
+      *ngIf="preview().length > 0"
+      class="collapsed-preview"
+    > : {{ preview() }}</span>
   </span>
   <p-button
     *ngIf="message().rule === 3"

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -30,6 +30,10 @@
   text-overflow: ellipsis;
 }
 
+.collapsed-preview {
+  color: #64748b;
+}
+
 .collapsed-timestamp {
   font-size: 0.8rem;
   color: #94a3b8;

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -434,6 +434,108 @@ describe('ChatMessageComponent', () => {
     });
   });
 
+  describe('collapsed line preview (Story 4.2)', () => {
+    it('Rule 4 collapsed line renders preview after " : " when content is non-empty', () => {
+      const msg = makeChatMessage({
+        rule: 4,
+        collapsed: true,
+        label: 'Worker -> Manager',
+        content: 'Start of the message',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      expect(label.textContent).toContain('[Worker -> Manager]');
+      expect(label.textContent).toContain(' : Start of the message');
+    });
+
+    it('Rule 4 collapsed line omits " : " and preview when content is empty', () => {
+      const msg = makeChatMessage({
+        rule: 4,
+        collapsed: true,
+        label: 'Worker -> Manager',
+        content: '',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      expect(label.textContent).toContain('[Worker -> Manager]');
+      expect(label.textContent).not.toContain(' : ');
+      expect(label.querySelector('.collapsed-preview')).toBeNull();
+    });
+
+    it('Rule 3 collapsed with notification renders (🙋) inside bracket, preview after " : "', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        collapsed: true,
+        label: 'Manager -> Support',
+        content: 'Can you verify the auth flow',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      const text = label.textContent.replace(/\s+/g, ' ');
+      // Bracket encloses label + marker, then preview follows
+      expect(text).toContain('[Manager -> Support (🙋)]');
+      expect(text).toContain(' : Can you verify the auth flow');
+    });
+
+    it('Rule 3 collapsed without notification omits (🙋) marker, preview still present', () => {
+      const msg = makeChatMessage({
+        rule: 3,
+        collapsed: true,
+        label: 'Manager -> Support',
+        content: 'Hello',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      const text = label.textContent.replace(/\s+/g, ' ');
+      expect(text).not.toContain('🙋');
+      expect(text).toContain('[Manager -> Support]');
+      expect(text).toContain(' : Hello');
+    });
+
+    it('long content is truncated with "..." in the rendered preview', () => {
+      const longContent = 'x'.repeat(80);
+      const msg = makeChatMessage({
+        rule: 4,
+        collapsed: true,
+        label: 'Worker -> Manager',
+        content: longContent,
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const label = fixture.nativeElement.querySelector('.collapsed-label');
+      expect(label.textContent).toContain('...');
+      // Preview span ends with "..."
+      const preview = label.querySelector('.collapsed-preview');
+      expect(preview.textContent.trim().endsWith('...')).toBe(true);
+    });
+
+    it('timestamp remains visible on the same collapsed row', () => {
+      const msg = makeChatMessage({
+        rule: 4,
+        collapsed: true,
+        label: 'Worker -> Manager',
+        content: 'hi',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const ts = fixture.nativeElement.querySelector('.collapsed-timestamp');
+      expect(ts).toBeTruthy();
+      expect(ts.textContent.trim().length).toBeGreaterThan(0);
+    });
+  });
+
   describe('messageSelected output', () => {
     it('should emit on label click for non-Rule-1 messages', () => {
       const msg = makeChatMessage({ rule: 2 });

--- a/src/app/chat/chat-message.component.ts
+++ b/src/app/chat/chat-message.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule, DatePipe } from '@angular/common';
-import { Component, EventEmitter, input, Output } from '@angular/core';
+import { Component, computed, EventEmitter, input, Output } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { MarkdownModule } from 'ngx-markdown';
-import { ChatMessage } from '../models/chat-message.model';
+import { buildPreview, ChatMessage } from '../models/chat-message.model';
 
 @Component({
   selector: 'app-chat-message',
@@ -19,6 +19,8 @@ export class ChatMessageComponent {
   message = input.required<ChatMessage>();
   selected = input<boolean>(false);
   notification = input<boolean>(false);
+
+  readonly preview = computed(() => buildPreview(this.message().content));
 
   onToggleCollapse(): void {
     const msg = this.message();

--- a/src/app/models/chat-message.model.spec.ts
+++ b/src/app/models/chat-message.model.spec.ts
@@ -1,4 +1,5 @@
 import {
+  buildPreview,
   classifyRule,
   buildLabel,
   classifyMessage,
@@ -149,6 +150,105 @@ describe('buildLabel', () => {
     expect(label).toContain('->');
     expect(label).toContain('Worker');
     expect(label).toContain('Manager');
+  });
+});
+
+describe('buildPreview', () => {
+  it('returns "" for null', () => {
+    expect(buildPreview(null)).toBe('');
+  });
+
+  it('returns "" for undefined', () => {
+    expect(buildPreview(undefined)).toBe('');
+  });
+
+  it('returns "" for empty string', () => {
+    expect(buildPreview('')).toBe('');
+  });
+
+  it('collapses multi-line content to a single line', () => {
+    expect(buildPreview('hello\nworld\n\n!')).toBe('hello world !');
+  });
+
+  it('collapses tabs and multiple spaces', () => {
+    expect(buildPreview('hello\t\tworld   !')).toBe('hello world !');
+  });
+
+  it('strips fenced code blocks', () => {
+    expect(buildPreview('text\n```ts\ncode here\n```\nmore')).toBe('text more');
+  });
+
+  it('strips inline code ticks but keeps inner text', () => {
+    expect(buildPreview('use `npm install` now')).toBe('use npm install now');
+  });
+
+  it('strips markdown link syntax to text', () => {
+    expect(buildPreview('see [docs](http://x) here')).toBe('see docs here');
+  });
+
+  it('strips markdown image syntax to alt', () => {
+    expect(buildPreview('![logo](x.png) ok')).toBe('logo ok');
+  });
+
+  it('strips bold (**) wrappers', () => {
+    expect(buildPreview('**bold** text')).toBe('bold text');
+  });
+
+  it('strips bold (__) wrappers', () => {
+    expect(buildPreview('__bold__ text')).toBe('bold text');
+  });
+
+  it('strips italic (_) wrappers', () => {
+    expect(buildPreview('_italic_ text')).toBe('italic text');
+  });
+
+  it('strips italic (*) wrappers', () => {
+    expect(buildPreview('*em* text')).toBe('em text');
+  });
+
+  it('strips combined emphasis wrappers', () => {
+    expect(buildPreview('**bold** and _italic_ and *em*')).toBe(
+      'bold and italic and em',
+    );
+  });
+
+  it('strips heading markers', () => {
+    expect(buildPreview('# Title')).toBe('Title');
+  });
+
+  it('strips blockquote markers', () => {
+    expect(buildPreview('> quoted')).toBe('quoted');
+  });
+
+  it('strips bullet list markers', () => {
+    expect(buildPreview('- item')).toBe('item');
+  });
+
+  it('strips numeric list markers', () => {
+    expect(buildPreview('1. first')).toBe('first');
+  });
+
+  it('does NOT truncate when content length <= maxLength', () => {
+    const forty = 'a'.repeat(40);
+    expect(buildPreview(forty)).toBe(forty);
+    expect(buildPreview(forty).endsWith('...')).toBe(false);
+  });
+
+  it('truncates with literal "..." when content > maxLength', () => {
+    const eighty = 'a'.repeat(80);
+    const result = buildPreview(eighty);
+    expect(result.length).toBe(63);
+    expect(result.endsWith('...')).toBe(true);
+    expect(result.startsWith('a'.repeat(60))).toBe(true);
+  });
+
+  it('respects custom maxLength override', () => {
+    expect(buildPreview('abcdefghijklmnop', 10)).toBe('abcdefghij...');
+  });
+
+  it('exactly maxLength boundary: no truncation at length === maxLength', () => {
+    const sixty = 'b'.repeat(60);
+    expect(buildPreview(sixty)).toBe(sixty);
   });
 });
 

--- a/src/app/models/chat-message.model.ts
+++ b/src/app/models/chat-message.model.ts
@@ -62,6 +62,57 @@ const RULE_COLORS: Record<MessageRule, string> = {
 };
 
 /**
+ * Build a single-line, markdown-stripped, ellipsised preview of message content
+ * for display in the collapsed chat line (per ADR-002 Decision 5).
+ *
+ * Rules (in order):
+ *   1. null/undefined/empty -> ""
+ *   2. Strip markdown: fenced code, inline code, images, links, bold/italic,
+ *      heading markers, blockquote markers, list markers
+ *   3. Collapse whitespace runs to single space
+ *   4. Trim
+ *   5. If length > maxLength, truncate to maxLength chars and append literal "..."
+ *
+ * Pure: no side effects, no DOM, no service calls.
+ */
+export function buildPreview(
+  content: string | null | undefined,
+  maxLength = 60,
+): string {
+  if (!content) return '';
+
+  let out = content;
+
+  // 1. Fenced code blocks: ```...``` (multi-line, non-greedy)
+  out = out.replace(/```[\s\S]*?```/g, '');
+  // 2. Inline code: `foo` -> foo
+  out = out.replace(/`([^`]*)`/g, '$1');
+  // 3. Images: ![alt](url) -> alt
+  out = out.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+  // 4. Links: [text](url) -> text
+  out = out.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+  // 5. Bold/italic wrappers (__, **, _, *)
+  out = out.replace(/__(.+?)__/g, '$1');
+  out = out.replace(/\*\*(.+?)\*\*/g, '$1');
+  out = out.replace(/_(.+?)_/g, '$1');
+  out = out.replace(/\*(.+?)\*/g, '$1');
+  // 6. Line-start markers: heading, blockquote, list markers
+  out = out.replace(/^\s{0,3}#+\s+/gm, '');
+  out = out.replace(/^\s{0,3}>\s+/gm, '');
+  out = out.replace(/^\s*\d+\.\s+/gm, '');
+  out = out.replace(/^\s*[-*+]\s+/gm, '');
+
+  // Collapse whitespace
+  out = out.replace(/\s+/g, ' ').trim();
+
+  if (out.length > maxLength) {
+    out = out.slice(0, maxLength) + '...';
+  }
+
+  return out;
+}
+
+/**
  * Convert a SentMessage into a ChatMessage with full classification.
  */
 export function classifyMessage(msg: SentMessage): ChatMessage {


### PR DESCRIPTION
## Summary

Implements Story 4.2: collapsed-line content preview for Rule 3 and Rule 4 chat messages (ADR-002 Decision 5). Produces `[ @Sender -> @Recipient ] : start of message ...` with timestamp right-aligned on the same row. Rule 3 with pending notification renders `(🙋)` inside the bracket next to the recipient.

- Adds pure `buildPreview(content, maxLength = 60)` helper in `chat-message.model.ts` (markdown-stripping + whitespace collapse + literal `...` truncation).
- Exposes a `computed` `preview` signal on `ChatMessageComponent` and composes the final collapsed-line text in the template: `[ {label}{marker?} ] : {preview}`.
- Preview span and `" : "` separator are omitted when content is empty.
- `buildLabel` is untouched and the `->` arrow is unchanged (Story 4.3 still owns the `⇒` rename). Expanded bubble and Rule 1/2 rendering are unchanged.
- +28 tests (171 total). Local gate green: `ng test --watch=false --browsers=ChromeHeadless` and `ng build` both pass.

## Review Outcome

Adversarial code review found no HIGH or MEDIUM issues. All 8 ACs met, File List accurate, scope confined to `packages/akgentic-frontend/src/app/`. Local gate: 171/171 tests green, `ng build` succeeds (only pre-existing lodash CJS warning). No CI pipeline configured — `no-ci` applicability mode per Story 4.1 precedent.

Stacked on `feat/28-rule3-collapsable-hand-raised-open-button`.

Closes #30