### PR TITLE
Header polish — unicode arrow glyph and right-aligned timestamp (Story 4.3)

### DIFF
--- a/src/app/chat/chat-human-modal.component.spec.ts
+++ b/src/app/chat/chat-human-modal.component.spec.ts
@@ -33,7 +33,7 @@ function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
     alignment: 'left',
     color: '#9ebbcb',
     collapsed: false,
-    label: 'Manager -> QATester',
+    label: 'Manager ⇒ QATester',
     ...overrides,
   };
 }
@@ -71,7 +71,7 @@ describe('ChatHumanModalComponent', () => {
       fixture.detectChanges();
 
       expect(component.headerText).toContain('Manager');
-      expect(component.headerText).toContain('->');
+      expect(component.headerText).toContain('⇒');
       expect(component.headerText).toContain('QATester');
     });
   });

--- a/src/app/chat/chat-human-modal.component.ts
+++ b/src/app/chat/chat-human-modal.component.ts
@@ -45,7 +45,7 @@ export class ChatHumanModalComponent {
     if (!pair) return 'Human Input';
     const sender = makeAgentNameUserFriendly(pair.sender.name);
     const recipient = makeAgentNameUserFriendly(pair.recipient.name);
-    return `${sender} -> ${recipient}`;
+    return `${sender} ⇒ ${recipient}`;
   }
 
   onVisibleChange(value: boolean): void {

--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -68,12 +68,12 @@
         (click)="onOpenModal($event)"
         class="open-button"
       ></p-button>
+      <span class="bubble-timestamp">{{
+        message().timestamp | date : "HH:mm"
+      }}</span>
     </div>
     <div class="markdown-content">
       <markdown [data]="message().content"></markdown>
     </div>
-    <span class="timestamp">{{
-      message().timestamp | date : "shortTime"
-    }}</span>
   </div>
 </div>

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -105,6 +105,13 @@
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 4px;
+
+  .bubble-timestamp {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: #94a3b8;
+    white-space: nowrap;
+  }
 }
 
 .label-pill {
@@ -152,12 +159,4 @@
 
 .markdown-content {
   margin-top: 4px;
-}
-
-.timestamp {
-  display: block;
-  font-size: 0.75rem;
-  color: #64748b;
-  margin-top: 4px;
-  padding-bottom: 4px;
 }

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -60,7 +60,7 @@ describe('ChatMessageComponent', () => {
         rule: 1,
         alignment: 'right',
         color: '#efeeee',
-        label: 'You -> Manager',
+        label: 'You ⇒ Manager',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -75,7 +75,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 1,
         alignment: 'right',
-        label: 'You -> Manager',
+        label: 'You ⇒ Manager',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -111,7 +111,7 @@ describe('ChatMessageComponent', () => {
         rule: 3,
         alignment: 'left',
         collapsed: false,
-        label: 'Agent -> OtherHuman',
+        label: 'Agent ⇒ OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.componentRef.setInput('notification', true);
@@ -130,7 +130,7 @@ describe('ChatMessageComponent', () => {
         rule: 3,
         alignment: 'left',
         collapsed: false,
-        label: 'Agent -> OtherHuman',
+        label: 'Agent ⇒ OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.componentRef.setInput('notification', false);
@@ -145,7 +145,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 3,
         collapsed: true,
-        label: 'Agent -> OtherHuman',
+        label: 'Agent ⇒ OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -154,14 +154,14 @@ describe('ChatMessageComponent', () => {
       expect(el.querySelector('.collapsed-line')).toBeTruthy();
       expect(el.querySelector('.message-bubble')).toBeNull();
       const label = el.querySelector('.collapsed-label');
-      expect(label.textContent).toContain('Agent -> OtherHuman');
+      expect(label.textContent).toContain('Agent ⇒ OtherHuman');
     });
 
     it('should append (🙋) in collapsed line when notification is true', () => {
       const msg = makeChatMessage({
         rule: 3,
         collapsed: true,
-        label: 'Agent -> OtherHuman',
+        label: 'Agent ⇒ OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.componentRef.setInput('notification', true);
@@ -177,7 +177,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 3,
         collapsed: true,
-        label: 'Agent -> OtherHuman',
+        label: 'Agent ⇒ OtherHuman',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.componentRef.setInput('notification', false);
@@ -287,7 +287,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 4,
         collapsed: true,
-        label: 'Worker -> Manager',
+        label: 'Worker ⇒ Manager',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -352,7 +352,7 @@ describe('ChatMessageComponent', () => {
         rule: 1,
         alignment: 'right',
         color: '#efeeee',
-        label: 'You -> Manager',
+        label: 'You ⇒ Manager',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -439,14 +439,14 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 4,
         collapsed: true,
-        label: 'Worker -> Manager',
+        label: 'Worker ⇒ Manager',
         content: 'Start of the message',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
 
       const label = fixture.nativeElement.querySelector('.collapsed-label');
-      expect(label.textContent).toContain('[Worker -> Manager]');
+      expect(label.textContent).toContain('[Worker ⇒ Manager]');
       expect(label.textContent).toContain(' : Start of the message');
     });
 
@@ -454,14 +454,14 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 4,
         collapsed: true,
-        label: 'Worker -> Manager',
+        label: 'Worker ⇒ Manager',
         content: '',
       });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
 
       const label = fixture.nativeElement.querySelector('.collapsed-label');
-      expect(label.textContent).toContain('[Worker -> Manager]');
+      expect(label.textContent).toContain('[Worker ⇒ Manager]');
       expect(label.textContent).not.toContain(' : ');
       expect(label.querySelector('.collapsed-preview')).toBeNull();
     });
@@ -470,7 +470,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 3,
         collapsed: true,
-        label: 'Manager -> Support',
+        label: 'Manager ⇒ Support',
         content: 'Can you verify the auth flow',
       });
       fixture.componentRef.setInput('message', msg);
@@ -480,7 +480,7 @@ describe('ChatMessageComponent', () => {
       const label = fixture.nativeElement.querySelector('.collapsed-label');
       const text = label.textContent.replace(/\s+/g, ' ');
       // Bracket encloses label + marker, then preview follows
-      expect(text).toContain('[Manager -> Support (🙋)]');
+      expect(text).toContain('[Manager ⇒ Support (🙋)]');
       expect(text).toContain(' : Can you verify the auth flow');
     });
 
@@ -488,7 +488,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 3,
         collapsed: true,
-        label: 'Manager -> Support',
+        label: 'Manager ⇒ Support',
         content: 'Hello',
       });
       fixture.componentRef.setInput('message', msg);
@@ -498,7 +498,7 @@ describe('ChatMessageComponent', () => {
       const label = fixture.nativeElement.querySelector('.collapsed-label');
       const text = label.textContent.replace(/\s+/g, ' ');
       expect(text).not.toContain('🙋');
-      expect(text).toContain('[Manager -> Support]');
+      expect(text).toContain('[Manager ⇒ Support]');
       expect(text).toContain(' : Hello');
     });
 
@@ -507,7 +507,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 4,
         collapsed: true,
-        label: 'Worker -> Manager',
+        label: 'Worker ⇒ Manager',
         content: longContent,
       });
       fixture.componentRef.setInput('message', msg);
@@ -524,7 +524,7 @@ describe('ChatMessageComponent', () => {
       const msg = makeChatMessage({
         rule: 4,
         collapsed: true,
-        label: 'Worker -> Manager',
+        label: 'Worker ⇒ Manager',
         content: 'hi',
       });
       fixture.componentRef.setInput('message', msg);
@@ -556,6 +556,95 @@ describe('ChatMessageComponent', () => {
       spyOn(component.messageSelected, 'emit');
       component.onLabelClick();
       expect(component.messageSelected.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Rule 2 label — @Sender ⇒ You (Story 4.3)', () => {
+    it('renders label pill ending with "⇒ You" for Rule 2', () => {
+      const msg = makeChatMessage({
+        rule: 2,
+        alignment: 'left',
+        label: '@Manager ⇒ You',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const pill = fixture.nativeElement.querySelector('.label-pill');
+      expect(pill).toBeTruthy();
+      expect(pill.textContent.trim().endsWith('⇒ You')).toBe(true);
+    });
+
+    it('Rule 2 label pill is NOT disabled (clickable for selection)', () => {
+      const msg = makeChatMessage({
+        rule: 2,
+        alignment: 'left',
+        label: '@Manager ⇒ You',
+      });
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      const pill = fixture.nativeElement.querySelector('.label-pill');
+      expect(pill.disabled).toBe(false);
+    });
+  });
+
+  describe('Expanded bubble header layout (Story 4.3)', () => {
+    function makeExpanded(rule: 1 | 2 | 3 | 4): ChatMessage {
+      return makeChatMessage({
+        rule,
+        alignment: rule === 1 ? 'right' : 'left',
+        collapsed: false,
+        label:
+          rule === 1
+            ? 'You ⇒ @Manager'
+            : rule === 2
+              ? '@Manager ⇒ You'
+              : rule === 3
+                ? '@Manager ⇒ @Support'
+                : '@Worker ⇒ @Manager',
+        timestamp: new Date('2026-04-08T10:45:00Z'),
+      });
+    }
+
+    for (const rule of [1, 2, 3, 4] as const) {
+      it(`Rule ${rule}: .bubble-header .bubble-timestamp exists and matches HH:mm`, () => {
+        fixture.componentRef.setInput('message', makeExpanded(rule));
+        fixture.detectChanges();
+
+        const ts = fixture.nativeElement.querySelector(
+          '.bubble-header .bubble-timestamp',
+        );
+        expect(ts).toBeTruthy();
+        expect(ts.textContent.trim()).toMatch(/^\d{2}:\d{2}$/);
+      });
+
+      it(`Rule ${rule}: standalone .timestamp span removed`, () => {
+        fixture.componentRef.setInput('message', makeExpanded(rule));
+        fixture.detectChanges();
+
+        const standalone = fixture.nativeElement.querySelectorAll(
+          '.message-bubble > .timestamp',
+        );
+        expect(standalone.length).toBe(0);
+      });
+    }
+
+    it('Rule 3 expanded: .bubble-timestamp is the last element child of .bubble-header', () => {
+      fixture.componentRef.setInput('message', makeExpanded(3));
+      fixture.detectChanges();
+
+      const header = fixture.nativeElement.querySelector('.bubble-header');
+      expect(header).toBeTruthy();
+      expect(header.lastElementChild.classList.contains('bubble-timestamp')).toBe(true);
+    });
+
+    it('Rule 4 expanded: .bubble-timestamp is the last element child of .bubble-header', () => {
+      fixture.componentRef.setInput('message', makeExpanded(4));
+      fixture.detectChanges();
+
+      const header = fixture.nativeElement.querySelector('.bubble-header');
+      expect(header).toBeTruthy();
+      expect(header.lastElementChild.classList.contains('bubble-timestamp')).toBe(true);
     });
   });
 });

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -395,7 +395,7 @@ describe('ChatPanelComponent', () => {
         id: 'msg-123', content: 'test', sender: makeAddress({ name: '@Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
         timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
-        collapsed: false, label: 'Manager -> QATester',
+        collapsed: false, label: 'Manager ⇒ QATester',
       };
       component.modalPendingMessages = [dummyMsg];
 
@@ -418,7 +418,7 @@ describe('ChatPanelComponent', () => {
         id: 'msg-1', content: 'test', sender: makeAddress({ name: '@Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
         timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
-        collapsed: false, label: 'Manager -> QATester',
+        collapsed: false, label: 'Manager ⇒ QATester',
       };
       component.modalPendingMessages = [dummyMsg];
       component.onModalVisibleChange(false);
@@ -584,7 +584,7 @@ describe('ChatPanelComponent', () => {
         alignment: 'right',
         color: '#efeeee',
         collapsed: false,
-        label: 'You -> Manager',
+        label: 'You ⇒ Manager',
       };
       component.onToggleCollapse(msg);
       expect(msg.collapsed).toBe(false);

--- a/src/app/models/chat-message.model.spec.ts
+++ b/src/app/models/chat-message.model.spec.ts
@@ -110,46 +110,60 @@ describe('classifyRule', () => {
 });
 
 describe('buildLabel', () => {
-  it('Rule 1: "You -> {recipient}"', () => {
+  it('Rule 1: "You ⇒ {recipient}"', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Human', role: 'Human' }),
       recipient: makeAddress({ name: '@Manager-manager', role: 'Manager' }),
     });
     const label = buildLabel(msg, 1);
-    expect(label).toContain('You ->');
+    expect(label).toContain('You ⇒');
     expect(label).toContain('Manager');
+    expect(label).not.toContain('->');
   });
 
-  it('Rule 2: just sender name', () => {
+  it('Rule 2: "{sender} ⇒ You"', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Manager-manager', role: 'Manager' }),
       recipient: makeAddress({ name: '@Human', role: 'Human' }),
     });
     const label = buildLabel(msg, 2);
-    expect(label).not.toContain('->');
+    expect(label).toContain('⇒ You');
     expect(label).toContain('Manager');
+    expect(label.endsWith('⇒ You')).toBe(true);
+    expect(label).not.toContain('->');
   });
 
-  it('Rule 3: "@{sender} -> @{recipient}"', () => {
+  it('Rule 3: "@{sender} ⇒ @{recipient}"', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Agent-worker', role: 'Worker' }),
       recipient: makeAddress({ name: '@OtherHuman-human', role: 'Human' }),
     });
     const label = buildLabel(msg, 3);
-    expect(label).toContain('->');
+    expect(label).toContain('⇒');
     expect(label).toContain('Agent');
     expect(label).toContain('OtherHuman');
+    expect(label).not.toContain('->');
   });
 
-  it('Rule 4: "@{sender} -> @{recipient}"', () => {
+  it('Rule 4: "@{sender} ⇒ @{recipient}"', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Worker-worker', role: 'Worker' }),
       recipient: makeAddress({ name: '@Manager-manager', role: 'Manager' }),
     });
     const label = buildLabel(msg, 4);
-    expect(label).toContain('->');
+    expect(label).toContain('⇒');
     expect(label).toContain('Worker');
     expect(label).toContain('Manager');
+    expect(label).not.toContain('->');
+  });
+
+  it('Rule 2 explicit: result ends with "⇒ You" (Story 4.3)', () => {
+    const msg = makeSentMessage({
+      sender: makeAddress({ name: '@Manager-manager', role: 'Manager' }),
+      recipient: makeAddress({ name: '@Human', role: 'Human' }),
+    });
+    const label = buildLabel(msg, 2);
+    expect(label.endsWith('⇒ You')).toBe(true);
   });
 });
 
@@ -266,7 +280,7 @@ describe('classifyMessage', () => {
     expect(result.alignment).toBe('right');
     expect(result.color).toBe('#efeeee');
     expect(result.collapsed).toBe(false);
-    expect(result.label).toContain('You ->');
+    expect(result.label).toContain('You ⇒');
   });
 
   it('should return a ChatMessage with correct fields for Rule 4 (collapsed)', () => {

--- a/src/app/models/chat-message.model.ts
+++ b/src/app/models/chat-message.model.ts
@@ -33,11 +33,11 @@ export function classifyRule(msg: SentMessage): MessageRule {
 }
 
 /**
- * Build a display label per ADR-002 Decision 6:
- *   Rule 1: "You -> @{recipient}" (using makeAgentNameUserFriendly)
- *   Rule 2: "@{sender}" (recipient is implicit)
- *   Rule 3: "@{sender} -> @{recipient}"
- *   Rule 4: "@{sender} -> @{recipient}"
+ * Build a display label per ADR-002 Decision 6 (revised 2026-04-12):
+ *   Rule 1: "You ⇒ @{recipient}" (using makeAgentNameUserFriendly)
+ *   Rule 2: "@{sender} ⇒ You" (recipient expanded explicitly for multi-human teams)
+ *   Rule 3: "@{sender} ⇒ @{recipient}"
+ *   Rule 4: "@{sender} ⇒ @{recipient}"
  */
 export function buildLabel(msg: SentMessage, rule: MessageRule): string {
   const senderName = makeAgentNameUserFriendly(msg.sender.name);
@@ -45,12 +45,12 @@ export function buildLabel(msg: SentMessage, rule: MessageRule): string {
 
   switch (rule) {
     case 1:
-      return `You -> ${recipientName}`;
+      return `You ⇒ ${recipientName}`;
     case 2:
-      return senderName;
+      return `${senderName} ⇒ You`;
     case 3:
     case 4:
-      return `${senderName} -> ${recipientName}`;
+      return `${senderName} ⇒ ${recipientName}`;
   }
 }
 


### PR DESCRIPTION
## Summary

Implements Story 4.3 per ADR-002 revision 2026-04-12 (Decisions 2 and 6).

- Rename label arrow `->` to `⇒` (U+21D2) in `buildLabel` and `chat-human-modal` header; test fixtures swept.
- Expand Rule 2 label from sender-only to `${sender} ⇒ You` for multi-human team disambiguation.
- Move the expanded-bubble timestamp into `.bubble-header` as the last child, right-aligned via `margin-left: auto`, using the `HH:mm` pipe for consistency with the collapsed line.
- Delete the standalone `<span class="timestamp">` (after `.markdown-content`) and its SCSS block — expanded bubble now has two visual rows (header + content).
- Tests: 184/184 green (+13 new/updated assertions). `ng build` succeeds; only pre-existing lodash CJS warning.

## Review outcome

Code review: all HIGH/MEDIUM gates clear. ACs 1–8 verified; no cross-submodule changes; one commit with DCO sign-off.

## Stacked PR

Base: `feat/30-collapsed-line-preview` (Story 4.2, not yet merged to master). Rebase/retarget to `master` once 4.2 merges.

Closes #32
Relates to #32