### PR TITLE
Hover-aware auto-scroll lock on chat panel (Story 4.4)

### DIFF
--- a/src/app/chat/chat-panel.component.html
+++ b/src/app/chat/chat-panel.component.html
@@ -1,4 +1,4 @@
-<div class="chat-container">
+<div class="chat-container" (mouseenter)="onMouseEnter()" (mouseleave)="onMouseLeave()">
   <ng-container *ngIf="chatMessages.length > 0; else noMessagesPlaceholder">
     <div class="message-list" #scrollContainer (click)="onBackgroundClick()">
       <app-chat-message

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -632,5 +632,128 @@ describe('ChatPanelComponent', () => {
 
     // Collapsed state should be preserved
     expect(component.chatMessages[0].collapsed).toBe(false);
+  });
+
+  describe('Hover-aware auto-scroll lock (Story 4.4)', () => {
+    // Helper to install a mock scrollContainer with controllable
+    // scrollTop/scrollHeight/clientHeight on the component.
+    function installMockScrollContainer(
+      initialHeight = 1000,
+      clientHeight = 400,
+    ): { scrollTop: number; scrollHeight: number; clientHeight: number } {
+      const mockEl = { scrollTop: 0, scrollHeight: initialHeight, clientHeight };
+      (component as any).scrollContainer = { nativeElement: mockEl };
+      (component as any).lastScrollHeight = initialHeight;
+      return mockEl;
+    }
+
+    it('(a) auto-scroll fires when NOT hovered and a new message arrives', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      // Not hovered (default)
+      expect((component as any).isHovered).toBe(false);
+      // Simulate DOM growth from a new message.
+      mockEl.scrollHeight = 1200;
+      component.ngAfterViewChecked();
+      expect(mockEl.scrollTop).toBe(1200);
+    });
+
+    it('(b) auto-scroll is SUSPENDED when hovered; pendingCatchUpScroll is set', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 850; // near bottom so shouldScrollToBottom will be true
+      (component as any).checkShouldAutoScroll();
+      component.onMouseEnter();
+      expect((component as any).isHovered).toBe(true);
+
+      // New message arrives while hovered.
+      const sent = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'hovered-arrival',
+        'hov-1',
+      );
+      messagesSubject.next([sent]);
+      mockEl.scrollHeight = 1200;
+      component.ngAfterViewChecked();
+
+      // scrollTop was NOT moved to bottom — hover suspends.
+      expect(mockEl.scrollTop).toBe(850);
+      expect((component as any).pendingCatchUpScroll).toBe(true);
+    });
+
+    it('(c) mouseleave performs catch-up when a message arrived during hover', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 850;
+      (component as any).checkShouldAutoScroll();
+      component.onMouseEnter();
+
+      const sent = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'catch-up',
+        'cu-1',
+      );
+      messagesSubject.next([sent]);
+      mockEl.scrollHeight = 1200;
+      component.ngAfterViewChecked();
+      expect(mockEl.scrollTop).toBe(850);
+      expect((component as any).pendingCatchUpScroll).toBe(true);
+
+      component.onMouseLeave();
+      flushMicrotasks();
+
+      expect(mockEl.scrollTop).toBe(1200);
+      expect((component as any).pendingCatchUpScroll).toBe(false);
+      expect((component as any).isHovered).toBe(false);
+    }));
+
+    it('(d) mouseleave does NOT catch-up if no message arrived during hover', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 850;
+      (component as any).checkShouldAutoScroll();
+
+      component.onMouseEnter();
+      // No message arrives — scrollHeight unchanged.
+      component.ngAfterViewChecked();
+      component.onMouseLeave();
+      flushMicrotasks();
+
+      expect(mockEl.scrollTop).toBe(850);
+      expect((component as any).pendingCatchUpScroll).toBe(false);
+    }));
+
+    it('(e) collapse toggle during hover does NOT queue a catch-up', fakeAsync(() => {
+      // Seed a Rule 4 message so we have something to toggle.
+      const r4 = makeSentMessage(
+        { name: '@Worker', role: 'Worker' },
+        { name: '@Manager', role: 'Manager' },
+        'ai msg',
+        'r4-hover',
+      );
+      messagesSubject.next([r4]);
+      fixture.detectChanges();
+
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 850;
+      (component as any).checkShouldAutoScroll();
+
+      component.onMouseEnter();
+
+      // User toggles collapse — this changes DOM height but is NOT a
+      // message-arrival event, so pendingCatchUpScroll MUST remain false.
+      component.onToggleCollapse(component.chatMessages[0]);
+      mockEl.scrollHeight = 1100; // toggle grew the bubble
+      component.ngAfterViewChecked();
+
+      // Hover still suspends the scroll.
+      expect(mockEl.scrollTop).toBe(850);
+      // CRITICAL: no catch-up queued for a collapse toggle.
+      expect((component as any).pendingCatchUpScroll).toBe(false);
+
+      component.onMouseLeave();
+      flushMicrotasks();
+
+      // No catch-up fired — scrollTop still at 850.
+      expect(mockEl.scrollTop).toBe(850);
+    }));
   });
 });

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -52,6 +52,13 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private subscription!: Subscription;
   private shouldScrollToBottom = true;
   private lastScrollHeight = 0;
+  // Story 4.4: hover-aware auto-scroll lock. `isHovered` short-circuits the
+  // scroll in ngAfterViewChecked while the user's pointer is over the panel.
+  // `pendingCatchUpScroll` is set ONLY from the messages$ subscription path
+  // (new-message arrival) — never from ngAfterViewChecked height changes —
+  // so collapse/expand toggles during hover do NOT queue a spurious catch-up.
+  private isHovered = false;
+  private pendingCatchUpScroll = false;
   private expandedMessageIds = new Set<string>();
   selectedMessageId: string | null = null;
   private replyContextSubscription!: Subscription;
@@ -68,6 +75,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.subscription = this.messageService.messages$.subscribe((messages) => {
       this.checkShouldAutoScroll();
 
+      const previousLength = this.chatMessages.length;
       const classified = messages
         .filter(isSentMessage)
         .filter((m) => m.sender.role !== 'ActorSystem')
@@ -84,6 +92,11 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
         });
 
       this.chatMessages = classified;
+      // Story 4.4: if a new message arrived while the user is hovering the
+      // panel, remember that a catch-up scroll is owed on mouseleave.
+      if (this.isHovered && classified.length > previousLength) {
+        this.pendingCatchUpScroll = true;
+      }
       this.chatService.messages$.next(classified);
     });
   }
@@ -99,8 +112,31 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    if (this.shouldScrollToBottom && this.hasContentChanged()) {
+    // Always evaluate hasContentChanged() so lastScrollHeight stays fresh —
+    // even while hovered — otherwise a collapse/expand during hover would
+    // leave a stale lastScrollHeight that spuriously fires a scroll later.
+    const contentChanged = this.hasContentChanged();
+    if (this.isHovered) return; // Story 4.4: suspended while hovering
+    if (this.shouldScrollToBottom && contentChanged) {
       this.scrollToBottom();
+    }
+  }
+
+  onMouseEnter(): void {
+    this.isHovered = true;
+  }
+
+  onMouseLeave(): void {
+    this.isHovered = false;
+    // Catch-up only if a new message arrived during hover AND the user was
+    // near the bottom at arrival time (preserve pre-existing user-intent).
+    const shouldCatchUp = this.pendingCatchUpScroll && this.shouldScrollToBottom;
+    this.pendingCatchUpScroll = false;
+    if (shouldCatchUp) {
+      // queueMicrotask defers the scroll until after the current event-loop
+      // tick so Angular can finish any change detection triggered by the
+      // isHovered = false assignment before we read scrollHeight.
+      queueMicrotask(() => this.scrollToBottom());
     }
   }
 


### PR DESCRIPTION
## Summary

Implements ADR-002 Decision 9: hover-aware auto-scroll lock. While the user's pointer is over the chat panel, `ngAfterViewChecked` skips `scrollToBottom()`. If new messages arrive during hover, a `pendingCatchUpScroll` flag is set from the `messages$` subscription path (new-message arrivals only). On `mouseleave`, if the flag is set and the user was near the bottom (`shouldScrollToBottom`), a single catch-up scroll fires via `queueMicrotask`.

Collapse/expand toggles during hover do NOT queue a catch-up (the flag is scoped to the `messages$` path, not to the `ngAfterViewChecked` height-change path).

## Changes

- `chat-panel.component.ts` — added `isHovered`, `pendingCatchUpScroll` private fields; `onMouseEnter` / `onMouseLeave` handlers; gated `ngAfterViewChecked`; set flag in `messages$` subscription only when `classified.length > previousLength && isHovered`
- `chat-panel.component.html` — `(mouseenter)` / `(mouseleave)` bound on `.chat-container`
- `chat-panel.component.spec.ts` — added `describe('Hover-aware auto-scroll lock (Story 4.4)')` with 5 cases (a)-(e)

## Gate

- `ng test --watch=false --browsers=ChromeHeadless`: 189 pass (prior 184 + 5 new)
- `ng build`: green (only pre-existing lodash CJS warning)
- No CI pipeline configured for akgentic-frontend (gate = local ng test + ng build)

## Scope

All changes confined to `packages/akgentic-frontend/src/app/chat/`. No new services, observables, inputs, or outputs. The optional '↓ New messages' pill is explicitly DEFERRED (AC8).

## Stacked PR

Base branch: `feat/32-header-polish-arrow-timestamp` (Story 4.3). This is the Epic 4 closer.

Closes #34
Relates to Epic 4