### PR TITLE
Collapsed bg, remove caret, Reply button disabled

### DIFF
--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -4,7 +4,6 @@
   class="collapsed-line"
   (click)="onToggleCollapse()"
 >
-  <span class="collapse-indicator">&gt;</span>
   <span class="collapsed-label">
     [{{ message().label }}<span
       *ngIf="message().rule === 3 && notification()"
@@ -17,7 +16,8 @@
   <p-button
     *ngIf="message().rule === 3"
     size="small"
-    label="Open"
+    label="Reply"
+    [disabled]="!notification()"
     (click)="onOpenModal($event)"
     class="open-button"
   ></p-button>
@@ -60,11 +60,11 @@
       >
         <i class="pi pi-bell"></i>
       </span>
-      <span *ngIf="message().rule === 3 || message().rule === 4" class="collapse-indicator-bubble">v</span>
       <p-button
         *ngIf="message().rule === 3"
         size="small"
-        label="Open"
+        label="Reply"
+        [disabled]="!notification()"
         (click)="onOpenModal($event)"
         class="open-button"
       ></p-button>

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -9,18 +9,11 @@
   font-size: 0.9rem;
   border-radius: 6px;
   transition: background-color 0.15s ease;
+  background-color: rgba(0, 0, 0, 0.04);
 
   &:hover {
     background-color: rgba(0, 0, 0, 0.04);
   }
-}
-
-.collapse-indicator {
-  font-family: monospace;
-  font-weight: bold;
-  font-size: 0.8rem;
-  color: #64748b;
-  flex-shrink: 0;
 }
 
 .collapsed-label {
@@ -137,13 +130,6 @@
   &:focus {
     outline: none;
   }
-}
-
-.collapse-indicator-bubble {
-  font-family: monospace;
-  font-weight: bold;
-  font-size: 0.8rem;
-  color: #64748b;
 }
 
 .notification-icon {

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -187,25 +187,27 @@ describe('ChatMessageComponent', () => {
       expect(label.textContent).not.toContain('🙋');
     });
 
-    it('should render Open button on collapsed Rule 3 line', () => {
+    it('should render Reply button on collapsed Rule 3 line', () => {
       const msg = makeChatMessage({ rule: 3, collapsed: true });
       fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
       fixture.detectChanges();
 
       const btn = fixture.nativeElement.querySelector('.open-button');
       expect(btn).toBeTruthy();
-      expect(btn.textContent).toContain('Open');
+      expect(btn.textContent).toContain('Reply');
     });
 
-    it('should render Open button on expanded Rule 3 bubble header', () => {
+    it('should render Reply button on expanded Rule 3 bubble header', () => {
       const msg = makeChatMessage({ rule: 3, collapsed: false });
       fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
       fixture.detectChanges();
 
       const header = fixture.nativeElement.querySelector('.bubble-header');
       const btn = header.querySelector('.open-button');
       expect(btn).toBeTruthy();
-      expect(btn.textContent).toContain('Open');
+      expect(btn.textContent).toContain('Reply');
     });
 
     it('bubble body click on expanded Rule 3 should emit toggleCollapse and NOT rule3Clicked', () => {
@@ -238,9 +240,10 @@ describe('ChatMessageComponent', () => {
       expect(component.rule3Clicked.emit).not.toHaveBeenCalled();
     });
 
-    it('Open button click should emit rule3Clicked and NOT toggleCollapse', () => {
+    it('Reply button click should emit rule3Clicked and NOT toggleCollapse', () => {
       const msg = makeChatMessage({ rule: 3, collapsed: true });
       fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
       fixture.detectChanges();
 
       spyOn(component.toggleCollapse, 'emit');
@@ -254,22 +257,22 @@ describe('ChatMessageComponent', () => {
     });
   });
 
-  describe('Open button visibility (Rule 3 only)', () => {
-    it('should NOT render Open button for Rule 1', () => {
+  describe('Reply button visibility (Rule 3 only)', () => {
+    it('should NOT render Reply button for Rule 1', () => {
       const msg = makeChatMessage({ rule: 1, alignment: 'right' });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
     });
 
-    it('should NOT render Open button for Rule 2', () => {
+    it('should NOT render Reply button for Rule 2', () => {
       const msg = makeChatMessage({ rule: 2, alignment: 'left' });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
     });
 
-    it('should NOT render Open button for Rule 4 (collapsed or expanded)', () => {
+    it('should NOT render Reply button for Rule 4 (collapsed or expanded)', () => {
       const collapsed = makeChatMessage({ rule: 4, collapsed: true });
       fixture.componentRef.setInput('message', collapsed);
       fixture.detectChanges();
@@ -279,6 +282,78 @@ describe('ChatMessageComponent', () => {
       fixture.componentRef.setInput('message', expanded);
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('.open-button')).toBeNull();
+    });
+  });
+
+  describe('Reply button disabled state (Story 4.5)', () => {
+    it('should disable Reply button on collapsed Rule 3 when notification is false', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      expect(btn).toBeTruthy();
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable Reply button on collapsed Rule 3 when notification is true', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      expect(btn).toBeTruthy();
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('should disable Reply button on expanded Rule 3 when notification is false', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: false });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      expect(btn).toBeTruthy();
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('should enable Reply button on expanded Rule 3 when notification is true', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: false });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      expect(btn).toBeTruthy();
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('should NOT emit rule3Clicked when Reply button is disabled and clicked', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', false);
+      fixture.detectChanges();
+
+      spyOn(component.rule3Clicked, 'emit');
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      btn.click();
+
+      expect(component.rule3Clicked.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit rule3Clicked when Reply button is enabled and clicked', () => {
+      const msg = makeChatMessage({ rule: 3, collapsed: true });
+      fixture.componentRef.setInput('message', msg);
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      spyOn(component.rule3Clicked, 'emit');
+      const btn = fixture.nativeElement.querySelector('.open-button button');
+      btn.click();
+
+      expect(component.rule3Clicked.emit).toHaveBeenCalledWith(msg);
     });
   });
 
@@ -297,13 +372,13 @@ describe('ChatMessageComponent', () => {
       expect(el.querySelector('.message-bubble')).toBeNull();
     });
 
-    it('should show > indicator when collapsed', () => {
+    it('should NOT render collapse-indicator when collapsed (caret removed)', () => {
       const msg = makeChatMessage({ rule: 4, collapsed: true });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
 
       const indicator = fixture.nativeElement.querySelector('.collapse-indicator');
-      expect(indicator.textContent.trim()).toBe('>');
+      expect(indicator).toBeNull();
     });
 
     it('should emit toggleCollapse on click', () => {
@@ -322,7 +397,7 @@ describe('ChatMessageComponent', () => {
       expect(component.toggleCollapse.emit).toHaveBeenCalledWith(msg);
     });
 
-    it('should show v indicator when expanded', () => {
+    it('should NOT render collapse-indicator-bubble when expanded (caret removed)', () => {
       const msg = makeChatMessage({ rule: 4, collapsed: false });
       fixture.componentRef.setInput('message', msg);
       fixture.detectChanges();
@@ -330,7 +405,7 @@ describe('ChatMessageComponent', () => {
       const indicator = fixture.nativeElement.querySelector(
         '.collapse-indicator-bubble',
       );
-      expect(indicator.textContent.trim()).toBe('v');
+      expect(indicator).toBeNull();
     });
 
     it('should emit toggleCollapse on click when expanded', () => {

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -105,7 +105,7 @@ describe('ChatMessageComponent', () => {
     });
   });
 
-  describe('Rule 3 (notification + collapse + Open button)', () => {
+  describe('Rule 3 (notification + collapse + Reply button)', () => {
     it('should show hand-raised icon (🙋) on expanded bubble when notification is true', () => {
       const msg = makeChatMessage({
         rule: 3,


### PR DESCRIPTION
## Summary

- Add persistent light background (`rgba(0,0,0,0.04)`) to collapsed lines (Rule 3 and Rule 4) for visual distinction from whitespace
- Remove `>` / `v` caret toggle indicators from collapsed lines and expanded bubble headers, along with their CSS classes
- Rename "Open" button to "Reply" on Rule 3 bubbles and add `[disabled]="!notification()"` binding so it is greyed-out when no pending request exists
- Update existing tests for caret removal and button rename; add 6 new tests for disabled-button state (collapsed/expanded, enabled/disabled, click emit/no-emit)
- All 195 tests pass, `ng build` succeeds with no new warnings

Closes #36
