### PR TITLE
Per-message notification tracking (Story 4-6)

### DIFF
--- a/src/app/chat/chat-human-modal.component.spec.ts
+++ b/src/app/chat/chat-human-modal.component.spec.ts
@@ -25,6 +25,7 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
 function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'msg-1',
+    parent_id: null,
     content: 'Hello world',
     sender: makeAddress({ name: '@Manager', role: 'Manager' }),
     recipient: makeAddress({ name: '@QATester', role: 'Human' }),

--- a/src/app/chat/chat-message.component.scss
+++ b/src/app/chat/chat-message.component.scss
@@ -8,11 +8,10 @@
   color: #334155;
   font-size: 0.9rem;
   border-radius: 6px;
-  transition: background-color 0.15s ease;
-  background-color: rgba(0, 0, 0, 0.04);
+  border: 1px solid rgba(158, 187, 203, 0.5);
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.04);
+    background-color: rgba(0, 0, 0, 0.02);
   }
 }
 

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -21,6 +21,7 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
 function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'msg-1',
+    parent_id: null,
     content: 'Hello world',
     sender: makeAddress({ name: '@Manager', role: 'Manager' }),
     recipient: makeAddress({ name: '@Human', role: 'Human' }),

--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -32,10 +32,11 @@ function makeSentMessage(
   recipient: Partial<ActorAddress>,
   content: string = 'test',
   id: string = 'msg-1',
+  parentId: string | null = null,
 ): SentMessage {
   return {
     id,
-    parent_id: null,
+    parent_id: parentId,
     team_id: 'team-1',
     timestamp: '2026-04-08T10:00:00Z',
     sender: makeAddress(sender),
@@ -43,8 +44,8 @@ function makeSentMessage(
     content: null,
     __model__: 'akgentic.core.messages.orchestrator.SentMessage',
     message: {
-      id: 'inner-1',
-      parent_id: null,
+      id: 'inner-' + id,
+      parent_id: parentId,
       team_id: 'team-1',
       timestamp: '2026-04-08T10:00:00Z',
       sender: makeAddress(sender),
@@ -210,6 +211,7 @@ describe('ChatPanelComponent', () => {
   it('onMessageSelected should call selectionService.handleSelection', () => {
     const chatMsg: ChatMessage = {
       id: 'msg-1',
+      parent_id: null,
       content: 'test',
       sender: makeAddress({ name: '@Manager', agent_id: 'mgr-1' }),
       recipient: makeAddress({ name: '@Human' }),
@@ -254,6 +256,7 @@ describe('ChatPanelComponent', () => {
     it('onBubbleClicked should call chatService.setReplyContext', () => {
       const chatMsg: ChatMessage = {
         id: 'msg-reply',
+        parent_id: null,
         content: 'test',
         sender: makeAddress({ name: '@Manager', agent_id: 'mgr-1' }),
         recipient: makeAddress({ name: '@Human' }),
@@ -309,6 +312,7 @@ describe('ChatPanelComponent', () => {
     it('clicking different bubble should switch reply context', () => {
       const msg1: ChatMessage = {
         id: 'msg-1',
+        parent_id: null,
         content: 'first',
         sender: makeAddress({ name: '@Agent1' }),
         recipient: makeAddress({ name: '@Human' }),
@@ -321,6 +325,7 @@ describe('ChatPanelComponent', () => {
       };
       const msg2: ChatMessage = {
         id: 'msg-2',
+        parent_id: null,
         content: 'second',
         sender: makeAddress({ name: '@Agent2' }),
         recipient: makeAddress({ name: '@Human' }),
@@ -374,6 +379,7 @@ describe('ChatPanelComponent', () => {
         { name: '@Manager', role: 'Manager' },
         'approved',
         'reply-1',
+        'r3-1',
       );
       messagesSubject.next([rule3Msg, replyMsg]);
       fixture.detectChanges();
@@ -384,6 +390,60 @@ describe('ChatPanelComponent', () => {
       expect(component.modalVisible).toBe(false);
     });
 
+    it('onRule3Clicked with two pending in the same pair opens modal with both (AC #8)', () => {
+      const r3a = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'first',
+        'r3-pair-1',
+      );
+      const r3b = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'second',
+        'r3-pair-2',
+      );
+      messagesSubject.next([r3a, r3b]);
+      fixture.detectChanges();
+
+      const chatMsg = component.chatMessages.find(m => m.id === 'r3-pair-1')!;
+      component.onRule3Clicked(chatMsg);
+
+      expect(component.modalVisible).toBe(true);
+      expect(component.modalPendingMessages.length).toBe(2);
+    });
+
+    it('onRule3Clicked after one reply opens modal with single still-pending message (AC #8)', () => {
+      const r3a = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'first',
+        'r3-after-1',
+      );
+      const r3b = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'second',
+        'r3-after-2',
+      );
+      const reply = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'answering first',
+        'reply-after-1',
+        'r3-after-1',
+      );
+      messagesSubject.next([r3a, r3b, reply]);
+      fixture.detectChanges();
+
+      const stillPending = component.chatMessages.find(m => m.id === 'r3-after-2')!;
+      component.onRule3Clicked(stillPending);
+
+      expect(component.modalVisible).toBe(true);
+      expect(component.modalPendingMessages.length).toBe(1);
+      expect(component.modalPendingMessages[0].id).toBe('r3-after-2');
+    });
+
     it('onModalReply should call processHumanInput, close modal, and clear state', () => {
       component.processId = 'team-42';
       component.modalVisible = true;
@@ -392,7 +452,7 @@ describe('ChatPanelComponent', () => {
         recipient: makeAddress({ name: '@QATester' }),
       };
       const dummyMsg: ChatMessage = {
-        id: 'msg-123', content: 'test', sender: makeAddress({ name: '@Manager' }),
+        id: 'msg-123', parent_id: null, content: 'test', sender: makeAddress({ name: '@Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
         timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
         collapsed: false, label: 'Manager ⇒ QATester',
@@ -415,7 +475,7 @@ describe('ChatPanelComponent', () => {
         recipient: makeAddress({ name: '@QATester' }),
       };
       const dummyMsg: ChatMessage = {
-        id: 'msg-1', content: 'test', sender: makeAddress({ name: '@Manager' }),
+        id: 'msg-1', parent_id: null, content: 'test', sender: makeAddress({ name: '@Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
         timestamp: new Date(), rule: 3, alignment: 'left', color: '#9ebbcb',
         collapsed: false, label: 'Manager ⇒ QATester',
@@ -451,17 +511,48 @@ describe('ChatPanelComponent', () => {
         'need approval',
         'r3-1',
       );
+      // Reply carries parent_id === r3-1 — per-message clearing requires this linkage.
       const replyMsg = makeSentMessage(
         { name: '@QATester', role: 'Human' },
         { name: '@Manager', role: 'Manager' },
         'approved',
         'reply-1',
+        'r3-1',
       );
       messagesSubject.next([rule3Msg, replyMsg]);
       fixture.detectChanges();
 
       const chatMsgR3 = component.chatMessages.find(m => m.id === 'r3-1')!;
       expect(component.hasNotification(chatMsgR3)).toBe(false);
+    });
+
+    it('two separate messages — one cleared, one still pending (AC #8)', () => {
+      const r3First = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'first',
+        'r3-1',
+      );
+      const r3Second = makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@QATester', role: 'Human' },
+        'second',
+        'r3-2',
+      );
+      const reply = makeSentMessage(
+        { name: '@QATester', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'answering first',
+        'reply-1',
+        'r3-1',
+      );
+      messagesSubject.next([r3First, r3Second, reply]);
+      fixture.detectChanges();
+
+      const msg1 = component.chatMessages.find(m => m.id === 'r3-1')!;
+      const msg2 = component.chatMessages.find(m => m.id === 'r3-2')!;
+      expect(component.hasNotification(msg1)).toBe(false);
+      expect(component.hasNotification(msg2)).toBe(true);
     });
 
     it('hasNotification should return false for non-Rule-3 messages', () => {
@@ -493,12 +584,13 @@ describe('ChatPanelComponent', () => {
       const chatMsg = component.chatMessages[0];
       expect(component.hasNotification(chatMsg)).toBe(true);
 
-      // 2. Reply arrives (simulating WebSocket message)
+      // 2. Reply arrives (simulating WebSocket message); parent_id points at r3-clear-1.
       const replyMsg = makeSentMessage(
         { name: '@QATester', role: 'Human' },
         { name: '@Manager', role: 'Manager' },
         'approved',
         'reply-clear-1',
+        'r3-clear-1',
       );
       messagesSubject.next([rule3Msg, replyMsg]);
       fixture.detectChanges();
@@ -520,6 +612,7 @@ describe('ChatPanelComponent', () => {
         { name: '@Manager', role: 'Manager' },
         'done',
         'reply-reappear-1',
+        'r3-reappear-1',
       );
       const rule3Second = makeSentMessage(
         { name: '@Manager', role: 'Manager' },
@@ -576,6 +669,7 @@ describe('ChatPanelComponent', () => {
     it('onToggleCollapse should ignore non Rule-3/4 messages', () => {
       const msg: ChatMessage = {
         id: 'r1',
+        parent_id: null,
         content: 'x',
         sender: makeAddress({ name: '@Human' }),
         recipient: makeAddress({ name: '@Manager' }),

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -63,7 +63,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   selectedMessageId: string | null = null;
   private replyContextSubscription!: Subscription;
   private notificationSubscription!: Subscription;
-  pendingNotifications: Map<string, ChatMessage[]> = new Map();
+  pendingNotifications: Set<string> = new Set();
 
   ngOnInit(): void {
     this.replyContextSubscription = this.chatService.replyContext$.subscribe((ctx) => {
@@ -141,9 +141,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   hasNotification(chatMsg: ChatMessage): boolean {
-    if (chatMsg.rule !== 3) return false;
-    const pairKey = `${chatMsg.sender.name}->${chatMsg.recipient.name}`;
-    return this.pendingNotifications.has(pairKey);
+    return chatMsg.rule === 3 && this.pendingNotifications.has(chatMsg.id);
   }
 
   ngOnDestroy(): void {
@@ -162,13 +160,25 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.chatService.setReplyContext(chatMsg);
   }
 
+  /**
+   * Open the Rule 3 modal with every still-unanswered message from the same
+   * agent pair as the clicked bubble. Story 4-7 will replace the
+   * last-message fallback (modal emits one reply per send) with per-request
+   * reply inputs; this story only changes the notification tracking data
+   * model from `Map<pairKey, ChatMessage[]>` to `Set<id>`.
+   */
   onRule3Clicked(chatMsg: ChatMessage): void {
-    const pairKey = `${chatMsg.sender.name}->${chatMsg.recipient.name}`;
-    const pending = this.pendingNotifications.get(pairKey) ?? [];
-    if (pending.length === 0) return;
+    const pendingForPair = this.chatMessages.filter(
+      (m) =>
+        m.rule === 3 &&
+        m.sender.name === chatMsg.sender.name &&
+        m.recipient.name === chatMsg.recipient.name &&
+        this.pendingNotifications.has(m.id),
+    );
+    if (pendingForPair.length === 0) return;
 
     this.modalAgentPair = { sender: chatMsg.sender, recipient: chatMsg.recipient };
-    this.modalPendingMessages = pending;
+    this.modalPendingMessages = pendingForPair;
     this.modalVisible = true;
   }
 

--- a/src/app/models/chat-message.model.spec.ts
+++ b/src/app/models/chat-message.model.spec.ts
@@ -337,6 +337,25 @@ describe('classifyMessage', () => {
     expect(result.content).toBe('');
   });
 
+  it('should propagate parent_id from inner BaseMessage (Story 4.6)', () => {
+    const msg = makeSentMessage({
+      sender: makeAddress({ name: '@QATester', role: 'Human' }),
+      recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      message: makeBaseMessage({ parent_id: 'original-r3-id', content: 'reply' }),
+    });
+    const result = classifyMessage(msg);
+    expect(result.parent_id).toBe('original-r3-id');
+  });
+
+  it('should default parent_id to null when inner BaseMessage has no parent (Story 4.6)', () => {
+    const msg = makeSentMessage({
+      sender: makeAddress({ name: '@Human', role: 'Human' }),
+      recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+    });
+    const result = classifyMessage(msg);
+    expect(result.parent_id).toBeNull();
+  });
+
   it('should set timestamp as Date object', () => {
     const msg = makeSentMessage({
       sender: makeAddress({ name: '@Human', role: 'Human' }),

--- a/src/app/models/chat-message.model.ts
+++ b/src/app/models/chat-message.model.ts
@@ -7,6 +7,7 @@ export type MessageRule = 1 | 2 | 3 | 4;
 
 export interface ChatMessage {
   id: string;
+  parent_id: string | null;
   content: string;
   sender: ActorAddress;
   recipient: ActorAddress;
@@ -119,6 +120,7 @@ export function classifyMessage(msg: SentMessage): ChatMessage {
   const rule = classifyRule(msg);
   return {
     id: msg.id,
+    parent_id: msg.message.parent_id,
     content: msg.message.content ?? '',
     sender: msg.sender,
     recipient: msg.recipient,

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -27,6 +27,7 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
 function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'msg-1',
+    parent_id: null,
     content: 'Hello world',
     sender: makeAddress({ name: '@Manager', role: 'Manager' }),
     recipient: makeAddress({ name: '@Human', role: 'Human' }),

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -18,6 +18,7 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
 function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'msg-1',
+    parent_id: null,
     content: 'Hello world',
     sender: makeAddress({ name: '@Manager', role: 'Manager' }),
     recipient: makeAddress({ name: '@Human', role: 'Human' }),
@@ -89,7 +90,7 @@ describe('ChatService', () => {
   });
 
   describe('pendingNotifications$', () => {
-    it('should emit empty map initially', (done) => {
+    it('should emit empty set initially', (done) => {
       service.pendingNotifications$.subscribe((pending) => {
         expect(pending.size).toBe(0);
         done();
@@ -107,13 +108,13 @@ describe('ChatService', () => {
 
       service.pendingNotifications$.subscribe((pending) => {
         expect(pending.size).toBe(1);
-        expect(pending.get('@Manager->@QATester')?.length).toBe(1);
+        expect(pending.has('r3-1')).toBe(true);
         done();
       });
     });
 
     it('should reactively update when messages$ changes', () => {
-      const emitted: Map<string, ChatMessage[]>[] = [];
+      const emitted: Set<string>[] = [];
       service.pendingNotifications$.subscribe((p) => emitted.push(p));
 
       // Initially empty
@@ -129,17 +130,18 @@ describe('ChatService', () => {
       service.messages$.next([rule3Msg]);
 
       expect(emitted[1].size).toBe(1);
+      expect(emitted[1].has('r3-1')).toBe(true);
     });
   });
 });
 
 describe('computePendingNotifications', () => {
-  it('should return empty map for empty messages', () => {
+  it('should return empty set for empty messages', () => {
     const result = computePendingNotifications([]);
     expect(result.size).toBe(0);
   });
 
-  it('should track Rule 3 messages as pending', () => {
+  it('should track Rule 3 message ids as pending', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-1',
@@ -150,10 +152,10 @@ describe('computePendingNotifications', () => {
     ];
     const result = computePendingNotifications(msgs);
     expect(result.size).toBe(1);
-    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+    expect(result.has('r3-1')).toBe(true);
   });
 
-  it('should accumulate multiple messages for same agent pair', () => {
+  it('should accumulate multiple messages for same agent pair (per-message)', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-1',
@@ -175,10 +177,13 @@ describe('computePendingNotifications', () => {
       }),
     ];
     const result = computePendingNotifications(msgs);
-    expect(result.get('@Manager->@QATester')?.length).toBe(3);
+    expect(result.size).toBe(3);
+    expect(result.has('r3-1')).toBe(true);
+    expect(result.has('r3-2')).toBe(true);
+    expect(result.has('r3-3')).toBe(true);
   });
 
-  it('should clear all pending when human replies (AC #2, #3)', () => {
+  it('should clear only the specific message whose id matches reply.parent_id', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-1',
@@ -192,20 +197,22 @@ describe('computePendingNotifications', () => {
         sender: makeAddress({ name: '@Manager', role: 'Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
       }),
-      // QATester replies to Manager
+      // QATester replies to r3-1 only
       makeChatMessage({
         id: 'reply-1',
+        parent_id: 'r3-1',
         rule: 1,
         sender: makeAddress({ name: '@QATester', role: 'Human' }),
         recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
       }),
     ];
     const result = computePendingNotifications(msgs);
-    expect(result.has('@Manager->@QATester')).toBe(false);
-    expect(result.size).toBe(0);
+    expect(result.size).toBe(1);
+    expect(result.has('r3-1')).toBe(false);
+    expect(result.has('r3-2')).toBe(true);
   });
 
-  it('should re-add notifications after reply if new messages arrive (AC #2)', () => {
+  it('should re-add notifications after reply if new messages arrive', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-1',
@@ -213,9 +220,10 @@ describe('computePendingNotifications', () => {
         sender: makeAddress({ name: '@Manager', role: 'Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
       }),
-      // QATester replies
+      // QATester replies to r3-1
       makeChatMessage({
         id: 'reply-1',
+        parent_id: 'r3-1',
         rule: 1,
         sender: makeAddress({ name: '@QATester', role: 'Human' }),
         recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
@@ -230,7 +238,8 @@ describe('computePendingNotifications', () => {
     ];
     const result = computePendingNotifications(msgs);
     expect(result.size).toBe(1);
-    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+    expect(result.has('r3-new')).toBe(true);
+    expect(result.has('r3-1')).toBe(false);
   });
 
   it('should handle multiple agent pairs independently', () => {
@@ -250,8 +259,8 @@ describe('computePendingNotifications', () => {
     ];
     const result = computePendingNotifications(msgs);
     expect(result.size).toBe(2);
-    expect(result.get('@Manager->@QATester')?.length).toBe(1);
-    expect(result.get('@Worker->@QATester')?.length).toBe(1);
+    expect(result.has('r3-a')).toBe(true);
+    expect(result.has('r3-b')).toBe(true);
   });
 
   it('should NOT track messages to @Human entry point', () => {
@@ -267,7 +276,7 @@ describe('computePendingNotifications', () => {
     expect(result.size).toBe(0);
   });
 
-  it('should NOT clear when @Human entry point replies', () => {
+  it('should NOT clear when @Human entry point sends a message without parent_id', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-1',
@@ -275,9 +284,10 @@ describe('computePendingNotifications', () => {
         sender: makeAddress({ name: '@Manager', role: 'Manager' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
       }),
-      // @Human sends a message (entry point user) - should NOT clear QATester notifications
+      // @Human sends a message with no parent_id — should NOT clear anything
       makeChatMessage({
         id: 'user-1',
+        parent_id: null,
         rule: 1,
         sender: makeAddress({ name: '@Human', role: 'Human' }),
         recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
@@ -285,10 +295,10 @@ describe('computePendingNotifications', () => {
     ];
     const result = computePendingNotifications(msgs);
     expect(result.size).toBe(1);
-    expect(result.get('@Manager->@QATester')?.length).toBe(1);
+    expect(result.has('r3-1')).toBe(true);
   });
 
-  it('reply clears only the specific agent pair, not others', () => {
+  it('reply clears only the specific message, not others in the same pair', () => {
     const msgs: ChatMessage[] = [
       makeChatMessage({
         id: 'r3-a',
@@ -302,17 +312,67 @@ describe('computePendingNotifications', () => {
         sender: makeAddress({ name: '@Worker', role: 'Worker' }),
         recipient: makeAddress({ name: '@QATester', role: 'Human' }),
       }),
-      // QATester replies to Manager only
+      // QATester replies to r3-a specifically
       makeChatMessage({
         id: 'reply-1',
+        parent_id: 'r3-a',
         rule: 1,
         sender: makeAddress({ name: '@QATester', role: 'Human' }),
         recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
       }),
     ];
     const result = computePendingNotifications(msgs);
-    expect(result.has('@Manager->@QATester')).toBe(false);
-    expect(result.has('@Worker->@QATester')).toBe(true);
-    expect(result.get('@Worker->@QATester')?.length).toBe(1);
+    expect(result.size).toBe(1);
+    expect(result.has('r3-a')).toBe(false);
+    expect(result.has('r3-b')).toBe(true);
+  });
+
+  it('multiple unanswered messages in the same pair are all flagged independently', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-2',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'r3-3',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(3);
+    expect(result.has('r3-1')).toBe(true);
+    expect(result.has('r3-2')).toBe(true);
+    expect(result.has('r3-3')).toBe(true);
+  });
+
+  it('a reply with an unknown parent_id clears nothing', () => {
+    const msgs: ChatMessage[] = [
+      makeChatMessage({
+        id: 'r3-1',
+        rule: 3,
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@QATester', role: 'Human' }),
+      }),
+      makeChatMessage({
+        id: 'stray-reply',
+        parent_id: 'does-not-exist',
+        rule: 1,
+        sender: makeAddress({ name: '@QATester', role: 'Human' }),
+        recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+      }),
+    ];
+    const result = computePendingNotifications(msgs);
+    expect(result.size).toBe(1);
+    expect(result.has('r3-1')).toBe(true);
   });
 });

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -19,41 +19,49 @@ export interface ChatAnswer {
 }
 
 /**
- * Compute pending notification state from classified chat messages.
- * Scans all messages in order. Rule 3 messages (to a non-@Human human) add
- * to the pending map. A reply from the human recipient to the original sender
- * clears the entire agent pair.
+ * Compute pending notification state from classified chat messages (per-message).
  *
- * @returns Map keyed by "senderName->recipientName" with list of unanswered messages.
+ * Scans all messages in order:
+ *   - Rule 3 messages (recipient.role === 'Human' and recipient.name !== @Human)
+ *     add their `id` to the unanswered set.
+ *   - Any message whose `parent_id` is non-null removes that parent id from
+ *     the unanswered set (i.e. a reply clears only the specific message it
+ *     answers — identified by `parent_id === original.id`).
+ *
+ * This aligns the chat panel with `graph-data.service.ts#unSetHumanRequest`,
+ * which already performs per-request clearing on the graph-node side by
+ * matching `reply.parent_id` against `humanRequests[*].message.id`. Prior
+ * behaviour (pair-keyed `Map<string, ChatMessage[]>`) cleared every pending
+ * bubble for an agent pair on the first reply; the per-message set preserves
+ * individual notifications so the user can see exactly which requests still
+ * need a reply — see ADR-002 Decision 4 (revision 2026-04-12).
+ *
+ * The clearing step runs for every message (any rule, any sender role) — the
+ * reply contract is "message with `parent_id === original.id`", not "reply
+ * whose sender role is Human".
+ *
+ * Pure: no side effects, no DOM, no service calls. Deterministic.
+ *
+ * @returns Set of message ids that are still unanswered.
  */
 export function computePendingNotifications(
   messages: ChatMessage[],
-): Map<string, ChatMessage[]> {
-  const pending = new Map<string, ChatMessage[]>();
+): Set<string> {
+  const unanswered = new Set<string>();
 
   for (const msg of messages) {
-    // Rule 3 messages: requests to non-entry-point humans
     if (
       msg.recipient.role === HUMAN_ROLE &&
       msg.recipient.name !== ENTRY_POINT_NAME
     ) {
-      const pairKey = `${msg.sender.name}->${msg.recipient.name}`;
-      const existing = pending.get(pairKey) ?? [];
-      existing.push(msg);
-      pending.set(pairKey, existing);
+      unanswered.add(msg.id);
     }
-
-    // Reply from a non-entry-point human clears the reverse pair
-    if (
-      msg.sender.role === HUMAN_ROLE &&
-      msg.sender.name !== ENTRY_POINT_NAME
-    ) {
-      const reversePairKey = `${msg.recipient.name}->${msg.sender.name}`;
-      pending.delete(reversePairKey);
+    if (msg.parent_id !== null) {
+      unanswered.delete(msg.parent_id);
     }
   }
 
-  return pending;
+  return unanswered;
 }
 
 @Injectable()
@@ -67,8 +75,8 @@ export class ChatService {
   replyContext$: BehaviorSubject<ChatMessage | null> =
     new BehaviorSubject<ChatMessage | null>(null);
 
-  /** Reactive map of pending notifications keyed by agent pair. */
-  pendingNotifications$: Observable<Map<string, ChatMessage[]>> =
+  /** Reactive set of unanswered Rule 3 message ids (per-message tracking). */
+  pendingNotifications$: Observable<Set<string>> =
     this.messages$.pipe(map(computePendingNotifications));
 
   setReplyContext(message: ChatMessage | null): void {


### PR DESCRIPTION
## Summary

Refactor chat-panel Rule 3 notification tracking from per-agent-pair
(`Map<pairKey, ChatMessage[]>`) to per-message (`Set<string>` of unanswered
message ids), aligning the chat panel with `graph-data.service.ts` which
already performs per-request clearing via `parent_id` matching
(ADR-002 Decision 4, revision 2026-04-12).

- `ChatMessage` gains `parent_id: string | null`, populated from the inner
  `BaseMessage.parent_id` in `classifyMessage`.
- `computePendingNotifications(messages)` now returns `Set<string>`:
  Rule 3 message ids are added, and any message carrying a non-null
  `parent_id` removes that id. Pure, deterministic, no sender-role scoping.
- `ChatPanelComponent.hasNotification` becomes a set-membership check;
  `onRule3Clicked` scans `chatMessages` for all still-pending messages in
  the same agent pair. `pairKey` removed from production code.
- Tests updated to set-shape assertions and expanded to cover:
  "clear only the specific reply target", "multiple pending in same pair",
  "unknown parent_id clears nothing", "two separate messages — one cleared,
  one still pending".

No backend or cross-submodule changes; no graph-data.service edits.

Closes #38
Relates to #38
