### PR TITLE
Remove V1 knowledge graph snapshot artefacts (Story 5-1)

### DIFF
--- a/src/app/process/knowledge-graph/knowledge-graph.component.html
+++ b/src/app/process/knowledge-graph/knowledge-graph.component.html
@@ -131,23 +131,11 @@
     <ng-template pTemplate="header">
       <div class="dialog-header-container">
         <span class="dialog-title">Knowledge Graph</span>
-        <!-- <button
-          pButton
-          type="button"
-          severity="primary"
-          size="small"
-          label="Refresh"
-          (click)="refreshModalData()"
-          [disabled]="false"
-          icon="pi pi-refresh"
-          class="dialog-refresh-button"
-        ></button> -->
       </div>
     </ng-template>
     <app-knowledge-graph
       [isModal]="true"
       [processId]="currentProcessId"
-      [refreshTrigger$]="modalRefreshTrigger$"
       class="modal-app-component"
     ></app-knowledge-graph>
   </p-dialog>

--- a/src/app/process/knowledge-graph/knowledge-graph.component.ts
+++ b/src/app/process/knowledge-graph/knowledge-graph.component.ts
@@ -42,6 +42,12 @@ echarts.use([
 ]);
 
 interface KnowledgeGraphEntity {
+  // V2 wire: uuid string, required. The projection from `KGStateReducer`
+  // always carries `id`; component keeps it optional only to tolerate any
+  // legacy fixture/test that builds entities manually without an id.
+  id?: string;
+  // V2 wire: optional flag (backend only sends it when `True`).
+  is_root?: boolean;
   name?: string;
   entity_type?: string;
   description?: string;
@@ -49,9 +55,13 @@ interface KnowledgeGraphEntity {
 }
 
 interface KnowledgeGraphRelation {
+  // V2 wire: uuid string, required (see note above on id optionality).
+  id?: string;
   from_entity?: string;
   to_entity?: string;
   relation_type?: string;
+  // V2 wire: optional, defaults to "" on the wire.
+  description?: string;
 }
 
 interface KnowledgeGraphData {

--- a/src/app/process/knowledge-graph/knowledge-graph.component.ts
+++ b/src/app/process/knowledge-graph/knowledge-graph.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { trigger, style, transition, animate } from '@angular/animations';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Subscription, Observable } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -96,7 +96,6 @@ interface KnowledgeGraphData {
 export class KnowledgeGraphComponent implements OnInit, OnDestroy {
   @Input() isModal = false;
   @Input() processId?: string; // Allow process ID to be passed as input for modal mode
-  @Input() refreshTrigger$?: Observable<void>; // Observable to trigger refresh
 
   @HostBinding('class.modal-mode') get modalMode() {
     return this.isModal;
@@ -104,15 +103,9 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
 
   isModalView = false;
   showKGModal = false;
-  modalRefreshTrigger$ = new BehaviorSubject<void>(undefined);
 
   openKGModal(): void {
     this.showKGModal = true;
-  }
-
-  refreshModalData(): void {
-    // Trigger refresh on the modal component instance
-    this.modalRefreshTrigger$.next();
   }
 
   zone: NgZone = inject(NgZone);
@@ -156,15 +149,6 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
         this.updateChart(data || { nodes: [], edges: [] });
       })
     );
-
-    // Subscribe to refresh trigger if provided (for modal instances)
-    if (this.refreshTrigger$) {
-      this.subscriptions.push(
-        this.refreshTrigger$.subscribe(() => {
-          this.refreshData();
-        })
-      );
-    }
   }
 
   ngOnDestroy(): void {
@@ -221,11 +205,6 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
       }
     });
   }
-
-  async refreshData(): Promise<void> {
-    await this.messageService.refreshKnowledgeGraph();
-  }
-
 
   private createChart(data: KnowledgeGraphData): void {
     const { nodes, links, categories } = this.processGraphData(data);

--- a/src/app/process/process.component.html
+++ b/src/app/process/process.component.html
@@ -13,7 +13,7 @@
     >
       <div class="right-header">
         <p-selectbutton
-          [options]="visualizationOptions"
+          [options]="(visualizationOptions$ | async) ?? []"
           optionLabel="label"
           optionValue="value"
           aria-labelledby="basic"
@@ -38,7 +38,7 @@
           [class.moved-offscreen]="isHidden('workspace')"
         ></app-workspace-explorer>
         <app-knowledge-graph
-          *ngIf="hasKnowledgeGraph"
+          *ngIf="hasKnowledgeGraph$ | async"
           [class.moved-offscreen]="isHidden('knowledge-graph')"
         ></app-knowledge-graph>
         <app-message-list

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -1,0 +1,218 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { BehaviorSubject } from 'rxjs';
+
+import { ProcessComponent } from './process.component';
+import { AkgentService } from '../services/akgent.service';
+import { ContextService } from '../services/context.service';
+import { ActorMessageService } from '../services/message.service';
+import { GraphDataService } from '../services/graph-data.service';
+import { ChatService } from '../services/chat.service';
+import { SelectionService } from '../services/selection.service';
+import { FeedbackService } from '../services/feedback.service';
+import { ToolPresenceService } from '../services/tool-presence.service';
+import { ViewService } from '../view.service';
+import { TeamContext } from '../models/team.interface';
+
+// --------------------------------------------------------------------
+// Fixture helpers
+// --------------------------------------------------------------------
+
+function makeTeam(overrides: Partial<TeamContext> = {}): TeamContext {
+  return {
+    team_id: 'team-1',
+    name: 'Demo Team',
+    status: 'running',
+    created_at: '2026-04-08T10:00:00Z',
+    updated_at: '2026-04-08T10:00:00Z',
+    config_name: 'demo',
+    description: null,
+    ...overrides,
+  };
+}
+
+describe('ProcessComponent', () => {
+  let component: ProcessComponent;
+  let fixture: ComponentFixture<ProcessComponent>;
+  let toolPresenceService: ToolPresenceService;
+
+  beforeEach(async () => {
+    // Fresh presence service per test so cross-test leakage is impossible.
+    const presence = new ToolPresenceService();
+
+    const contextService = {
+      currentProcessId$: new BehaviorSubject<string>(''),
+      getCurrentTeam: jasmine
+        .createSpy('getCurrentTeam')
+        .and.callFake(async () => makeTeam()),
+    };
+
+    const messageService = {
+      init: jasmine
+        .createSpy('init')
+        .and.returnValue(Promise.resolve()),
+      messages$: new BehaviorSubject<any[]>([]),
+      message$: new BehaviorSubject<any>(null),
+      createAgentGraph$: new BehaviorSubject<any>(null),
+      knowledgeGraph$: new BehaviorSubject<any>({ nodes: [], edges: [] }),
+      knowledgeGraphLoading$: new BehaviorSubject<boolean>(false),
+    };
+
+    const akgentService = {
+      unselect: jasmine.createSpy('unselect'),
+      selectedAkgent$: new BehaviorSubject<any>(null),
+    };
+
+    const graphDataService = {
+      isLoading$: new BehaviorSubject<boolean>(false),
+      nodes$: new BehaviorSubject<any[]>([]),
+    };
+
+    const chatService = {
+      messages$: new BehaviorSubject<any[]>([]),
+    };
+
+    const selectionService = {
+      handleSelection: jasmine.createSpy('handleSelection'),
+    };
+
+    const feedbackService = {};
+
+    const viewService = {
+      isRightColumnCollapsed$: new BehaviorSubject<boolean>(false),
+    };
+
+    const router = {
+      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
+    };
+
+    const activatedRoute = {
+      snapshot: { params: { id: 'team-1' } },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProcessComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ToolPresenceService, useValue: presence },
+        { provide: ContextService, useValue: contextService },
+        { provide: ActorMessageService, useValue: messageService },
+        { provide: AkgentService, useValue: akgentService },
+        { provide: GraphDataService, useValue: graphDataService },
+        { provide: ChatService, useValue: chatService },
+        { provide: SelectionService, useValue: selectionService },
+        { provide: FeedbackService, useValue: feedbackService },
+        { provide: ViewService, useValue: viewService },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    })
+      // Swap the heavy child components out for a minimal, empty-template
+      // metadata set + CUSTOM_ELEMENTS_SCHEMA so the DOM still contains the
+      // `<app-knowledge-graph>` / `<app-*>` tags (we assert on them) without
+      // needing to bootstrap the children's full dependency graphs.
+      .overrideComponent(ProcessComponent, {
+        set: {
+          imports: [CommonModule],
+          providers: [],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ProcessComponent);
+    component = fixture.componentInstance;
+    toolPresenceService = presence;
+
+    // Initial detectChanges without ngOnInit route resolution side effects
+    // would still fire `ngOnInit` — but the `getCurrentTeam` spy returns a
+    // resolved promise with a valid team so the router.navigate path is
+    // not taken.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('scenario 1 — empty init (no KG actor): KG option absent, <app-knowledge-graph> not in DOM', async () => {
+    expect(toolPresenceService.hasKnowledgeGraph$.getValue()).toBe(false);
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(false);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).toBeNull();
+  });
+
+  it('scenario 2 — KG presence flips to true: KG option appears and <app-knowledge-graph> mounts', async () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(true);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).not.toBeNull();
+  });
+
+  it('scenario 3 — KG presence flips back to false: KG option disappears and <app-knowledge-graph> unmounts', async () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    toolPresenceService.hasKnowledgeGraph$.next(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(false);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).toBeNull();
+  });
+
+  it('scenario 4 — active-mode reset: KG active then presence→false flips visualization mode back to team', () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    component.setVisualizationMode('knowledge-graph');
+    expect(component.currentVisualizationMode).toBe('knowledge-graph');
+
+    toolPresenceService.hasKnowledgeGraph$.next(false);
+    expect(component.currentVisualizationMode).toBe('team');
+  });
+
+  it('scenario 5 — no regression: Team / Member / Messages entries remain present under both presence states (order preserved)', async () => {
+    // presence=false
+    let options = await firstValue(component.visualizationOptions$);
+    let labels = options.map((o) => o.value);
+    expect(labels).toEqual(['team', 'member', 'messages']);
+
+    // presence=true
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    options = await firstValue(component.visualizationOptions$);
+    labels = options.map((o) => o.value);
+    // Team, Member, (no Workspace — hasWorkspace stays false), Knowledge
+    // graph, Messages — order preserved from allVisualizationOptions.
+    expect(labels).toEqual(['team', 'member', 'knowledge-graph', 'messages']);
+  });
+});
+
+// Small synchronous-first-emission helper for BehaviorSubject-derived
+// observables (combineLatest over BehaviorSubjects replays synchronously).
+function firstValue<T>(observable$: { subscribe: (fn: (v: T) => void) => { unsubscribe(): void } }): Promise<T> {
+  return new Promise((resolve) => {
+    const sub = observable$.subscribe((v) => {
+      resolve(v);
+      // Defer unsubscribe so we don't cancel the synchronous resolve path
+      setTimeout(() => sub.unsubscribe(), 0);
+    });
+  });
+}

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -1,11 +1,12 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { isRunning } from '../models/team.interface';
 import { AkgentService } from '../services/akgent.service';
 import { ContextService } from '../services/context.service';
 import { ActorMessageService } from '../services/message.service';
+import { ToolPresenceService } from '../services/tool-presence.service';
 
 import { AgentTabsComponent } from './agent-tabs/agent-tabs.component';
 import { TeamTabsComponent } from './team-tabs/team-tabs.component';
@@ -17,13 +18,20 @@ import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { TabsModule } from 'primeng/tabs';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ChatPanelComponent } from '../chat/chat-panel.component';
 import { ChatService } from '../services/chat.service';
 import { FeedbackService } from '../services/feedback.service';
 import { GraphDataService } from '../services/graph-data.service';
 import { SelectionService } from '../services/selection.service';
 import { ViewService } from '../view.service';
+
+interface VisualizationOption {
+  label: string;
+  value: string;
+  icon: string;
+}
 
 @Component({
   selector: 'app-process',
@@ -51,7 +59,7 @@ import { ViewService } from '../view.service';
   templateUrl: './process.component.html',
   styleUrl: './process.component.scss',
 })
-export class ProcessComponent {
+export class ProcessComponent implements OnDestroy {
   route: ActivatedRoute = inject(ActivatedRoute);
   router: Router = inject(Router);
 
@@ -60,14 +68,27 @@ export class ProcessComponent {
   messageService: ActorMessageService = inject(ActorMessageService);
   graphDataService: GraphDataService = inject(GraphDataService);
   viewService: ViewService = inject(ViewService);
+  toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   processId: string = '';
   processType: string = '';
-  hasKnowledgeGraph: boolean = false;
+  // `hasWorkspace` remains hardcoded: reactivating the workspace panel is a
+  // separate, future story (Epic 5 covers KG only). Keeping the flag in the
+  // filter predicate below so a future story can swap `of(false)` for a real
+  // observable in one line. (ADR-004 §Decision 4)
   hasWorkspace: boolean = false;
 
+  /**
+   * Reactive presence observable for the `#KnowledgeGraphTool` actor.
+   * Sourced from `ToolPresenceService.hasKnowledgeGraph$` (Story 5-2).
+   * Drives the `<app-knowledge-graph>` `*ngIf` binding via `| async`.
+   */
+  hasKnowledgeGraph$: Observable<boolean> =
+    this.toolPresenceService.hasKnowledgeGraph$;
+
   visualizationMode$ = new BehaviorSubject<string>('team');
-  visualizationOptions: { label: string; value: string; icon: string }[] = [
+
+  private readonly allVisualizationOptions: VisualizationOption[] = [
     { label: 'Team', value: 'team', icon: 'pi pi-users' },
     { label: 'Member', value: 'member', icon: 'pi pi-user' },
     { label: 'Workspace', value: 'workspace', icon: 'pi pi-folder-open' },
@@ -79,10 +100,44 @@ export class ProcessComponent {
     { label: 'Messages', value: 'messages', icon: 'pi pi-envelope' },
   ];
 
+  /**
+   * Reactive, filtered list of visualization options. Recomputed whenever
+   * `hasKnowledgeGraph$` emits; preserves the `hasWorkspace` static gate so
+   * workspace-presence reactivation is a one-line change in the future.
+   * (AC3 — reactive derivation)
+   */
+  visualizationOptions$: Observable<VisualizationOption[]> = combineLatest([
+    this.toolPresenceService.hasKnowledgeGraph$,
+    of(this.hasWorkspace),
+  ]).pipe(
+    map(([hasKG, hasWS]) =>
+      this.allVisualizationOptions.filter(
+        (option) =>
+          (option.value !== 'knowledge-graph' || hasKG) &&
+          (option.value !== 'workspace' || hasWS),
+      ),
+    ),
+  );
+
   isRightColumnCollapsed$ =
     this.viewService.isRightColumnCollapsed$.asObservable();
 
   isLoading$ = this.graphDataService.isLoading$;
+
+  private presenceSub: Subscription | null = null;
+
+  constructor() {
+    // Active-mode reset guard (AC3 last clause, AC8): if the user is viewing
+    // the KG tab when presence flips to `false`, snap back to 'team' so we
+    // never leave the user on a hidden-mode blank panel.
+    this.presenceSub = this.toolPresenceService.hasKnowledgeGraph$.subscribe(
+      (hasKG) => {
+        if (!hasKG && this.currentVisualizationMode === 'knowledge-graph') {
+          this.visualizationMode$.next('team');
+        }
+      },
+    );
+  }
 
   async ngOnInit(): Promise<void> {
     this.processId = this.route.snapshot.params['id'];
@@ -105,19 +160,18 @@ export class ProcessComponent {
     }
 
     this.processType = currentProcess.name;
-    // V2 has no params -- workspace/KG tabs default hidden (FR13)
-    this.hasKnowledgeGraph = false;
-    this.hasWorkspace = false;
-    this.visualizationOptions = this.visualizationOptions.filter(
-      (option) =>
-        (option.value !== 'knowledge-graph' || this.hasKnowledgeGraph) &&
-        (option.value !== 'workspace' || this.hasWorkspace)
-    );
+    // KG presence is reactive (Story 5-3 / ADR-004 §Decision 4): the
+    // `hasKnowledgeGraph$` observable flips based on `#KnowledgeGraphTool`
+    // `StartMessage` / `StopMessage` on the replay + live streams. Workspace
+    // presence remains static until a future story reactivates it.
 
     await this.messageService.init(this.processId, isRunning(currentProcess));
   }
+
   ngOnDestroy() {
     this.akgentService.unselect();
+    this.presenceSub?.unsubscribe();
+    this.presenceSub = null;
   }
 
   setVisualizationMode(mode: string): void {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -165,9 +165,4 @@ export class ApiService {
   ): Promise<void> {
     console.warn('updateTeamDescription is not available in V2');
   }
-
-  /** @deprecated Story 1.4 will migrate callers. */
-  async getKnowledgeGraphData(_teamId: string): Promise<any> {
-    return { nodes: [], edges: [] };
-  }
 }

--- a/src/app/services/kg-state.reducer.spec.ts
+++ b/src/app/services/kg-state.reducer.spec.ts
@@ -1,0 +1,324 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import {
+  KGStateReducer,
+  KnowledgeGraphData,
+  KnowledgeGraphEntity,
+  KnowledgeGraphRelation,
+} from './kg-state.reducer';
+
+// ---------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------
+
+function makeEntity(
+  id: string,
+  name: string,
+  entity_type = 'Concept',
+  description = '',
+  observations: any[] = []
+): KnowledgeGraphEntity {
+  return { id, name, entity_type, description, observations };
+}
+
+function makeRelation(
+  id: string,
+  from_entity: string,
+  to_entity: string,
+  relation_type = 'relates_to',
+  description = ''
+): KnowledgeGraphRelation {
+  return { id, from_entity, to_entity, relation_type, description };
+}
+
+interface KgEventOptions {
+  tool_id: string;
+  seq: number;
+  entities_added?: KnowledgeGraphEntity[];
+  entities_modified?: KnowledgeGraphEntity[];
+  entities_removed?: string[];
+  relations_added?: KnowledgeGraphRelation[];
+  relations_modified?: KnowledgeGraphRelation[];
+  relations_removed?: string[];
+  payload_model?: string;
+}
+
+function makeKgEvent(opts: KgEventOptions): any {
+  return {
+    __model__: 'akgentic.tool.messages.ToolStateEvent',
+    tool_id: opts.tool_id,
+    seq: opts.seq,
+    payload: {
+      __model__:
+        opts.payload_model ?? 'akgentic.tool.messages.KnowledgeGraphStateEvent',
+      entities_added: opts.entities_added ?? [],
+      entities_modified: opts.entities_modified ?? [],
+      entities_removed: opts.entities_removed ?? [],
+      relations_added: opts.relations_added ?? [],
+      relations_modified: opts.relations_modified ?? [],
+      relations_removed: opts.relations_removed ?? [],
+    },
+  };
+}
+
+describe('KGStateReducer', () => {
+  let reducer: KGStateReducer;
+  let emissions: KnowledgeGraphData[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [KGStateReducer] });
+    reducer = TestBed.inject(KGStateReducer);
+    emissions = [];
+    reducer.knowledgeGraph$.subscribe((p) => emissions.push(p));
+  });
+
+  it('(1) empty init — emits {nodes:[], edges:[]} before any apply', () => {
+    // The BehaviorSubject replays its initial value on subscribe.
+    expect(emissions.length).toBe(1);
+    expect(emissions[0]).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('(2) single-add — apply emits projection with the added entity', () => {
+    const e1 = makeEntity('e1', 'A');
+    reducer.apply(makeKgEvent({ tool_id: 't1', seq: 1, entities_added: [e1] }));
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj.nodes.length).toBe(1);
+    expect(proj.nodes[0].id).toBe('e1');
+    expect(proj.nodes[0].name).toBe('A');
+    expect(proj.edges).toEqual([]);
+  });
+
+  it('(3) modify replaces by id, not by name (rename reflected, no dup)', () => {
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 2,
+        entities_modified: [makeEntity('e1', 'B')],
+      })
+    );
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj.nodes.length).toBe(1);
+    expect(proj.nodes[0].id).toBe('e1');
+    expect(proj.nodes[0].name).toBe('B');
+  });
+
+  it('(4) relation add + cascade delete — both drop in one reducer tick', () => {
+    // Seed entities A, C and relation r1 (A→C).
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A'), makeEntity('e3', 'C')],
+        relations_added: [makeRelation('r1', 'A', 'C')],
+      })
+    );
+    // Cascade: remove entity e1 AND relation r1 in the same event.
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 2,
+        entities_removed: ['e1'],
+        relations_removed: ['r1'],
+      })
+    );
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj.nodes.length).toBe(1);
+    expect(proj.nodes[0].id).toBe('e3');
+    expect(proj.edges).toEqual([]);
+  });
+
+  it('(5) relations_modified forward-compat path — modify replaces by id', () => {
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        relations_added: [makeRelation('r1', 'A', 'B', 'old', '')],
+      })
+    );
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 2,
+        relations_modified: [makeRelation('r1', 'A', 'B', 'updated', 'new')],
+      })
+    );
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj.edges.length).toBe(1);
+    expect(proj.edges[0].id).toBe('r1');
+    expect(proj.edges[0].relation_type).toBe('updated');
+    expect(proj.edges[0].description).toBe('new');
+  });
+
+  it('(6) empty-collections event — seq advances, projection emitted, no console output', () => {
+    const warnSpy = spyOn(console, 'warn');
+    const debugSpy = spyOn(console, 'debug');
+    const logSpy = spyOn(console, 'log');
+
+    const before = emissions.length;
+    reducer.apply(makeKgEvent({ tool_id: 't1', seq: 1 }));
+    const after = emissions.length;
+
+    expect(after).toBe(before + 1);
+    const proj = emissions[after - 1];
+    expect(proj).toEqual({ nodes: [], edges: [] });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('(7) seq-gap log — 1 then 3 warns once with prev/event/tool_id', () => {
+    const warnSpy = spyOn(console, 'warn');
+
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 3,
+        entities_added: [makeEntity('e2', 'B')],
+      })
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const args = warnSpy.calls.first().args;
+    expect(args[0]).toContain('seq gap');
+    expect(args[1]).toEqual({ prev_seq: 1, event_seq: 3, tool_id: 't1' });
+
+    // Both events applied — projection must reflect seq=3.
+    const proj = emissions[emissions.length - 1];
+    expect(proj.nodes.length).toBe(2);
+  });
+
+  it('(8) unknown payload __model__ — debug logged, no mutation, no new emission', () => {
+    const debugSpy = spyOn(console, 'debug');
+    const warnSpy = spyOn(console, 'warn');
+    const before = emissions.length;
+
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        payload_model: 'akgentic.tool.messages.VectorStoreStateEvent',
+      })
+    );
+
+    expect(debugSpy).toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(emissions.length).toBe(before);
+    expect(emissions[emissions.length - 1]).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('(9) immutable projection — two successive applies yield distinct refs (NFR7)', () => {
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    const proj1 = emissions[emissions.length - 1];
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 2,
+        entities_added: [makeEntity('e2', 'B')],
+      })
+    );
+    const proj2 = emissions[emissions.length - 1];
+
+    expect(proj1).not.toBe(proj2);
+    expect(proj1.nodes.length).toBe(1);
+    expect(proj2.nodes.length).toBe(2);
+  });
+
+  it('(10) multiple tools isolated — deletes in one do not evict the other', () => {
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't2',
+        seq: 1,
+        entities_added: [makeEntity('e2', 'B')],
+      })
+    );
+    // Now delete e2 from t2 only — t1's e1 must survive.
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't2',
+        seq: 2,
+        entities_removed: ['e2'],
+      })
+    );
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj.nodes.length).toBe(1);
+    expect(proj.nodes[0].id).toBe('e1');
+  });
+
+  it('(11) resetForTeam() clears state and emits empty projection', () => {
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    expect(emissions[emissions.length - 1].nodes.length).toBe(1);
+
+    reducer.resetForTeam();
+
+    const proj = emissions[emissions.length - 1];
+    expect(proj).toEqual({ nodes: [], edges: [] });
+
+    // A fresh apply after reset starts from zero; seq gap from 1→1 must NOT
+    // trigger a warning because the internal lastSeq was cleared.
+    const warnSpy = spyOn(console, 'warn');
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e9', 'Z')],
+      })
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(emissions[emissions.length - 1].nodes.length).toBe(1);
+    expect(emissions[emissions.length - 1].nodes[0].id).toBe('e9');
+  });
+
+  it('(bonus) bind() pipes projections into an external subject', () => {
+    const external = new BehaviorSubject<KnowledgeGraphData>({
+      nodes: [],
+      edges: [],
+    });
+    reducer.bind(external);
+    reducer.apply(
+      makeKgEvent({
+        tool_id: 't1',
+        seq: 1,
+        entities_added: [makeEntity('e1', 'A')],
+      })
+    );
+    expect(external.getValue().nodes.length).toBe(1);
+  });
+});

--- a/src/app/services/kg-state.reducer.ts
+++ b/src/app/services/kg-state.reducer.ts
@@ -85,6 +85,8 @@ export class KGStateReducer {
   readonly knowledgeGraph$: Observable<KnowledgeGraphData> =
     this.projectionSubject$.asObservable();
 
+  private bound = false;
+
   /**
    * Bind the reducer's projection stream to an external `BehaviorSubject`
    * (typically `ActorMessageService.knowledgeGraph$`). Called once by the
@@ -93,10 +95,17 @@ export class KGStateReducer {
    *
    * Using a setter-binding (Option A from AC4) avoids introducing a circular
    * DI dependency between `ActorMessageService` and `KGStateReducer`.
+   *
+   * Idempotent — second+ calls are a no-op so test re-instantiation / HMR
+   * cannot accumulate duplicate forwarders that would double-emit into the
+   * external subject (parity with `ToolPresenceService.bindTo()`).
    */
   bind(subject$: BehaviorSubject<KnowledgeGraphData>): void {
-    // Seed with current projection so late binders still see the latest state.
-    subject$.next(this.projectionSubject$.getValue());
+    if (this.bound) return;
+    this.bound = true;
+    // `BehaviorSubject.subscribe()` replays its current value synchronously,
+    // so the callback below seeds `subject$` with the latest projection on
+    // the first tick — no explicit seeding needed.
     this.projectionSubject$.subscribe((projection) => {
       subject$.next(projection);
     });

--- a/src/app/services/kg-state.reducer.ts
+++ b/src/app/services/kg-state.reducer.ts
@@ -1,0 +1,258 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * V2 Knowledge Graph wire types.
+ *
+ * These mirror the Pydantic models on the backend (ADR-024):
+ * - Entity: keyed by `id` (uuid string), carries display fields (`name`,
+ *   `entity_type`, `description`, `observations`) and an optional `is_root`
+ *   flag the backend only sends when `True`.
+ * - Relation: keyed by `id` (uuid string), carries `from_entity` / `to_entity`
+ *   names (not ids — the existing `KnowledgeGraphComponent` keys ECharts
+ *   source/target on names), a `relation_type`, and an optional `description`.
+ *
+ * Kept local to the reducer layer (not shared with the component) to avoid
+ * reversing the `services/` → `process/` coupling. The component retains its
+ * own compatible interface definitions; the field shapes match.
+ */
+export interface KnowledgeGraphEntity {
+  id: string;
+  name?: string;
+  entity_type?: string;
+  description?: string;
+  observations?: any[];
+  is_root?: boolean;
+}
+
+export interface KnowledgeGraphRelation {
+  id: string;
+  from_entity?: string;
+  to_entity?: string;
+  relation_type?: string;
+  description?: string;
+}
+
+export interface KnowledgeGraphData {
+  nodes: KnowledgeGraphEntity[];
+  edges: KnowledgeGraphRelation[];
+}
+
+/**
+ * Per-`tool_id` reducer state. `entities` and `relations` are id-keyed Maps
+ * so every delta (add / modify / remove) is O(1). `lastSeq` starts at 0 and
+ * tracks the last successfully-applied `ToolStateEvent.seq`.
+ */
+interface KGPerToolState {
+  entities: Map<string, KnowledgeGraphEntity>;
+  relations: Map<string, KnowledgeGraphRelation>;
+  lastSeq: number;
+}
+
+/**
+ * KGStateReducer — consumes `ToolStateEvent` envelopes carrying
+ * `KnowledgeGraphStateEvent` payloads and emits immutable `KnowledgeGraphData`
+ * projections onto `knowledgeGraph$`.
+ *
+ * Single instance spans the team's lifetime (root-provided). Replay + live
+ * paths in `ActorMessageService` both call `apply(inner)` — live/replay
+ * parity is guaranteed by construction (ADR-004 §Decision 5).
+ *
+ * Projection contract: every successful `apply()` emits a NEW `KnowledgeGraphData`
+ * object (spread from the internal Maps) so downstream `OnPush` change
+ * detection fires (NFR7). Two successive `apply()` calls never yield the same
+ * projection reference.
+ *
+ * Scope: MVP emits a single combined stream across all `tool_id`s. State is
+ * per-`tool_id` internally (so deletes in one tool don't evict entries from
+ * another), but the projection flattens all tools into one graph. Multi-tool
+ * partitioning at the projection layer is out of scope (ADR-004 §Decision 3 —
+ * premature abstraction until a second stateful tool lands).
+ */
+@Injectable({ providedIn: 'root' })
+export class KGStateReducer {
+  private readonly stateByTool: Map<string, KGPerToolState> = new Map();
+
+  private readonly projectionSubject$ = new BehaviorSubject<KnowledgeGraphData>(
+    { nodes: [], edges: [] }
+  );
+
+  /**
+   * Public projection stream. Wire into `ActorMessageService.knowledgeGraph$`
+   * via `bind(subject$)` from the consumer. See `kg-state.reducer.spec.ts` for
+   * subscription-based assertions.
+   */
+  readonly knowledgeGraph$: Observable<KnowledgeGraphData> =
+    this.projectionSubject$.asObservable();
+
+  /**
+   * Bind the reducer's projection stream to an external `BehaviorSubject`
+   * (typically `ActorMessageService.knowledgeGraph$`). Called once by the
+   * message service during construction. Every future projection is piped
+   * through to the bound subject.
+   *
+   * Using a setter-binding (Option A from AC4) avoids introducing a circular
+   * DI dependency between `ActorMessageService` and `KGStateReducer`.
+   */
+  bind(subject$: BehaviorSubject<KnowledgeGraphData>): void {
+    // Seed with current projection so late binders still see the latest state.
+    subject$.next(this.projectionSubject$.getValue());
+    this.projectionSubject$.subscribe((projection) => {
+      subject$.next(projection);
+    });
+  }
+
+  /**
+   * Dispatch a `ToolStateEvent` inner payload.
+   *
+   * Event shape (envelope already stripped by `ActorMessageService`):
+   * ```
+   * {
+   *   __model__: 'akgentic.tool.messages.ToolStateEvent',
+   *   tool_id: string,
+   *   seq: number,
+   *   payload: {
+   *     __model__: 'akgentic.tool.messages.KnowledgeGraphStateEvent',
+   *     entities_added, entities_modified, entities_removed,
+   *     relations_added, relations_modified, relations_removed,
+   *   }
+   * }
+   * ```
+   *
+   * AC3 semantics:
+   * 1. Payload dispatch (FR11) — unknown `payload.__model__`s are logged via
+   *    `console.debug` and return without mutation or projection emission.
+   * 2. Seq-gap log (FR10) — if `prev !== 0 && curr !== prev + 1` emit a
+   *    `console.warn`, but APPLY the event anyway (ADR-004 §Decision 6).
+   * 3. Upserts — `entities_added ∪ entities_modified` (and the same for
+   *    relations) `set()` into the id-keyed Map.
+   * 4. Deletes — `entities_removed` (list of uuid strings) `delete()` from
+   *    the Map. Missing ids are a no-op (matches backend cascade redundancy).
+   * 5. Seq advance — `state.lastSeq = curr` unconditionally after apply.
+   * 6. Projection emission — a fresh `{nodes, edges}` object is emitted
+   *    (even for no-op empty-collections events, per the contract "every
+   *    apply emits").
+   */
+  apply(toolStateEvent: any): void {
+    const tool_id: string | undefined = toolStateEvent?.tool_id;
+    const seq: number = toolStateEvent?.seq ?? 0;
+    const payload = toolStateEvent?.payload;
+
+    // Step 1: payload dispatch (FR11).
+    if (!payload?.__model__?.includes('KnowledgeGraphStateEvent')) {
+      console.debug('[KGStateReducer] unknown payload', {
+        tool_id,
+        model: payload?.__model__,
+      });
+      return;
+    }
+
+    if (!tool_id) {
+      // Defensive: without tool_id we can't partition state. Drop quietly.
+      console.debug('[KGStateReducer] missing tool_id', { seq });
+      return;
+    }
+
+    const state = this.getOrCreateState(tool_id);
+
+    // Step 2: seq-gap log (FR10).
+    const prev = state.lastSeq;
+    if (prev !== 0 && seq !== prev + 1) {
+      console.warn('[KGStateReducer] seq gap', {
+        prev_seq: prev,
+        event_seq: seq,
+        tool_id,
+      });
+    }
+
+    // Steps 3 + 4: apply deltas.
+    this.applyEntityDeltas(state, payload);
+    this.applyRelationDeltas(state, payload);
+
+    // Step 5: seq advance (unconditional).
+    state.lastSeq = seq;
+
+    // Step 6: projection emission (new object reference on every apply).
+    this.emitProjection();
+  }
+
+  /**
+   * Clear all per-tool state. Called by `ActorMessageService.init()` on team
+   * load so a second team does not inherit the first team's KG state.
+   * Emits a fresh empty projection so downstream consumers see the reset.
+   */
+  resetForTeam(): void {
+    this.stateByTool.clear();
+    this.emitProjection();
+  }
+
+  // ---------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------
+
+  private getOrCreateState(tool_id: string): KGPerToolState {
+    let state = this.stateByTool.get(tool_id);
+    if (!state) {
+      state = {
+        entities: new Map<string, KnowledgeGraphEntity>(),
+        relations: new Map<string, KnowledgeGraphRelation>(),
+        lastSeq: 0,
+      };
+      this.stateByTool.set(tool_id, state);
+    }
+    return state;
+  }
+
+  private applyEntityDeltas(state: KGPerToolState, payload: any): void {
+    const added: KnowledgeGraphEntity[] = payload.entities_added ?? [];
+    const modified: KnowledgeGraphEntity[] = payload.entities_modified ?? [];
+    const removed: string[] = payload.entities_removed ?? [];
+
+    for (const entity of added) {
+      state.entities.set(entity.id, entity);
+    }
+    for (const entity of modified) {
+      state.entities.set(entity.id, entity);
+    }
+    for (const id of removed) {
+      state.entities.delete(id);
+    }
+  }
+
+  private applyRelationDeltas(state: KGPerToolState, payload: any): void {
+    const added: KnowledgeGraphRelation[] = payload.relations_added ?? [];
+    // `relations_modified` is always empty on the wire today (ADR-024 §1b —
+    // `ManageGraph` has no relation-update op). Code path retained for
+    // forward-compat; exercised by a unit test so it does not rot.
+    const modified: KnowledgeGraphRelation[] = payload.relations_modified ?? [];
+    const removed: string[] = payload.relations_removed ?? [];
+
+    for (const relation of added) {
+      state.relations.set(relation.id, relation);
+    }
+    for (const relation of modified) {
+      state.relations.set(relation.id, relation);
+    }
+    for (const id of removed) {
+      state.relations.delete(id);
+    }
+  }
+
+  /**
+   * Compute and emit a fresh `KnowledgeGraphData` by flattening every
+   * per-tool state Map into a single nodes/edges projection.
+   */
+  private emitProjection(): void {
+    const nodes: KnowledgeGraphEntity[] = [];
+    const edges: KnowledgeGraphRelation[] = [];
+    for (const state of this.stateByTool.values()) {
+      for (const entity of state.entities.values()) {
+        nodes.push(entity);
+      }
+      for (const relation of state.relations.values()) {
+        edges.push(relation);
+      }
+    }
+    this.projectionSubject$.next({ nodes, edges });
+  }
+}

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -61,11 +61,6 @@ export class ActorMessageService {
 
   processId: string = '';
 
-  private knowledgeGraphSnapshot: KnowledgeGraphData = {
-    nodes: [],
-    edges: [],
-  };
-
   async init(processId: string, running: boolean): Promise<void> {
     this.processId = processId;
     let messages: AkgenticMessage[] = [];
@@ -223,9 +218,6 @@ export class ActorMessageService {
         const current = this.contextDict$[agentId].getValue();
         this.contextDict$[agentId].next([...current, inner.message]);
       }
-    } else if (inner?.__model__?.includes('ToolCallEvent')) {
-      // Legacy knowledge_graph snapshot path — preserved unchanged (ADR-004).
-      this.handleToolUpdate(inner);
     }
     // Story 4-8: route tool events into ChatService for the thinking bubble.
     this.dispatchToolEventToThinking(event);
@@ -338,55 +330,6 @@ export class ActorMessageService {
   ) {
     if (dict[key]) return;
     dict[key] = new BehaviorSubject<any>(defaultValue);
-  }
-
-  async refreshKnowledgeGraph(): Promise<void> {
-    if (!this.processId) return;
-    this.knowledgeGraphLoading$.next(true);
-    try {
-      const graph = await this.apiService.getKnowledgeGraphData(this.processId);
-      this.knowledgeGraphSnapshot = this.normalizeKnowledgeGraph(graph);
-      this.knowledgeGraph$.next(this.knowledgeGraphSnapshot);
-    } catch (error) {
-      console.error('Error loading knowledge graph data:', error);
-      this.knowledgeGraph$.next({ nodes: [], edges: [] });
-    } finally {
-      this.knowledgeGraphLoading$.next(false);
-    }
-  }
-
-  private handleToolUpdate(payload: any): void {
-    if (payload?.tool !== 'knowledge_graph' && payload?.tool_name !== 'knowledge_graph') {
-      return;
-    }
-
-    if (payload.data) {
-      this.knowledgeGraphSnapshot = this.normalizeKnowledgeGraph(payload.data);
-    }
-
-    this.knowledgeGraph$.next(this.knowledgeGraphSnapshot);
-  }
-
-  private normalizeKnowledgeGraph(data: any): KnowledgeGraphData {
-    if (!data) {
-      return { nodes: [], edges: [] };
-    }
-
-    if ('nodes' in data && 'edges' in data) {
-      return {
-        nodes: Array.isArray(data.nodes) ? data.nodes : [],
-        edges: Array.isArray(data.edges) ? data.edges : [],
-      };
-    }
-
-    if ('entities' in data || 'relations' in data) {
-      return {
-        nodes: Array.isArray(data.entities) ? data.entities : [],
-        edges: Array.isArray(data.relations) ? data.relations : [],
-      };
-    }
-
-    return { nodes: [], edges: [] };
   }
 
   ngOnDestroy() {

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -13,12 +13,9 @@ import { EventResponse } from '../models/team.interface';
 
 import { ApiService } from '../services/api.service';
 import { ChatService } from './chat.service';
+import { KGStateReducer, KnowledgeGraphData } from './kg-state.reducer';
+import { ToolPresenceService } from './tool-presence.service';
 import { MessageService } from 'primeng/api';
-
-interface KnowledgeGraphData {
-  nodes: any[];
-  edges: any[];
-}
 
 /** V2 message types that feed the agent graph and message list. */
 const GRAPH_RELEVANT_MODELS = [
@@ -35,6 +32,8 @@ export class ActorMessageService {
   apiService: ApiService = inject(ApiService);
   chatService: ChatService = inject(ChatService);
   messageService: MessageService = inject(MessageService);
+  private kgReducer: KGStateReducer = inject(KGStateReducer);
+  private toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   webSocket: WebSocketSubject<any> = new WebSocketSubject({ url: '' });
 
@@ -61,9 +60,25 @@ export class ActorMessageService {
 
   processId: string = '';
 
+  constructor() {
+    // Wire the KG reducer's projection stream into `knowledgeGraph$`
+    // (AC4, Option A). One-time bind avoids a circular DI dependency —
+    // the reducer never injects back into this service.
+    this.kgReducer.bind(this.knowledgeGraph$);
+    // Bind the presence service to our replay + live message streams.
+    // Same bind-from-outside pattern (AC6) — the presence service does
+    // not `inject(ActorMessageService)`.
+    this.toolPresenceService.bindTo(this);
+  }
+
   async init(processId: string, running: boolean): Promise<void> {
     this.processId = processId;
     let messages: AkgenticMessage[] = [];
+
+    // Team switch: drop any KG state / presence carried over from a prior
+    // team load so replay rebuilds from zero (ADR-004 §Decision 5).
+    this.kgReducer.resetForTeam();
+    this.toolPresenceService.resetForTeam();
 
     this.chatService.loadingProcess$.next(true);
 
@@ -96,6 +111,10 @@ export class ActorMessageService {
               if (!contextArrays[agentId]) contextArrays[agentId] = [];
               contextArrays[agentId].push(inner.message);
             }
+          } else if (inner?.__model__?.includes('ToolStateEvent')) {
+            // Story 5-2: rebuild KG state during replay through the same
+            // reducer used by the live path (AC5 — live/replay parity).
+            this.kgReducer.apply(inner);
           }
         }
       }
@@ -218,6 +237,12 @@ export class ActorMessageService {
         const current = this.contextDict$[agentId].getValue();
         this.contextDict$[agentId].next([...current, inner.message]);
       }
+    } else if (inner?.__model__?.includes('ToolStateEvent')) {
+      // Story 5-2: live-path KG delta dispatch (AC5). Sibling to the
+      // `LlmMessageEvent` branch; falls through to
+      // `dispatchToolEventToThinking` below so unknown inner models
+      // retain today's silent-ignore behaviour.
+      this.kgReducer.apply(inner);
     }
     // Story 4-8: route tool events into ChatService for the thinking bubble.
     this.dispatchToolEventToThinking(event);

--- a/src/app/services/tool-presence.service.spec.ts
+++ b/src/app/services/tool-presence.service.spec.ts
@@ -1,0 +1,148 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  AkgenticMessage,
+  StartMessage,
+  StopMessage,
+} from '../models/message.types';
+import {
+  KG_ACTOR_NAME,
+  KGPresenceMessageSource,
+  ToolPresenceService,
+} from './tool-presence.service';
+
+// ---------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------
+
+function baseSender(name: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: 'agent-' + name,
+    name,
+    role: 'Agent',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+function makeStartMessage(senderName: string): StartMessage {
+  return {
+    id: 'start-' + senderName,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: baseSender(senderName),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+    config: {} as any,
+    parent: null,
+  };
+}
+
+function makeStopMessage(senderName: string): StopMessage {
+  return {
+    id: 'stop-' + senderName,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: baseSender(senderName),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StopMessage',
+  };
+}
+
+function makeSource(): {
+  source: KGPresenceMessageSource;
+  createAgentGraph$: BehaviorSubject<AkgenticMessage[] | null>;
+  message$: BehaviorSubject<AkgenticMessage | null>;
+} {
+  const createAgentGraph$ = new BehaviorSubject<AkgenticMessage[] | null>(null);
+  const message$ = new BehaviorSubject<AkgenticMessage | null>(null);
+  return {
+    source: { createAgentGraph$, message$ },
+    createAgentGraph$,
+    message$,
+  };
+}
+
+describe('ToolPresenceService', () => {
+  let service: ToolPresenceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [ToolPresenceService] });
+    service = TestBed.inject(ToolPresenceService);
+  });
+
+  it('(1) initial — hasKnowledgeGraph$ is false before any message', () => {
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+  });
+
+  it('(2) detection on live StartMessage for #KnowledgeGraphTool', () => {
+    const { source, message$ } = makeSource();
+    service.bindTo(source);
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+
+    message$.next(makeStartMessage(KG_ACTOR_NAME));
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(true);
+  });
+
+  it('(3) detection on replay batch via createAgentGraph$', () => {
+    const { source, createAgentGraph$ } = makeSource();
+    service.bindTo(source);
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+
+    createAgentGraph$.next([makeStartMessage(KG_ACTOR_NAME)]);
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(true);
+  });
+
+  it('(4) irrelevant sender ignored — stays false', () => {
+    const { source, message$ } = makeSource();
+    service.bindTo(source);
+
+    message$.next(makeStartMessage('@Support'));
+    message$.next(makeStartMessage('#VectorStoreTool'));
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+  });
+
+  it('(5) StopMessage for KG actor flips presence back to false', () => {
+    const { source, message$ } = makeSource();
+    service.bindTo(source);
+
+    message$.next(makeStartMessage(KG_ACTOR_NAME));
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(true);
+
+    message$.next(makeStopMessage(KG_ACTOR_NAME));
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+  });
+
+  it('(6) resetForTeam() flips presence back to false on team switch', () => {
+    const { source, message$ } = makeSource();
+    service.bindTo(source);
+
+    message$.next(makeStartMessage(KG_ACTOR_NAME));
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(true);
+
+    service.resetForTeam();
+    expect(service.hasKnowledgeGraph$.getValue()).toBe(false);
+  });
+
+  it('(7) redundant StartMessages do not emit true twice (distinct values only)', () => {
+    const { source, message$ } = makeSource();
+    service.bindTo(source);
+
+    const emissions: boolean[] = [];
+    service.hasKnowledgeGraph$.subscribe((v) => emissions.push(v));
+
+    message$.next(makeStartMessage(KG_ACTOR_NAME));
+    message$.next(makeStartMessage(KG_ACTOR_NAME));
+
+    // Expected emissions from the subscription above:
+    //   [false (initial replay), true (first KG start)]
+    // The second KG StartMessage must NOT produce a third emission.
+    expect(emissions).toEqual([false, true]);
+  });
+});

--- a/src/app/services/tool-presence.service.ts
+++ b/src/app/services/tool-presence.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  AkgenticMessage,
+  isStartMessage,
+  isStopMessage,
+} from '../models/message.types';
+
+/**
+ * Canonical name for the Knowledge Graph tool actor (ADR-004 §Decision 4).
+ * Mirrors `KG_ACTOR_NAME` from backend `kg_actor.py`.
+ */
+export const KG_ACTOR_NAME = '#KnowledgeGraphTool';
+
+/**
+ * Minimal interface the presence service needs from the message producer.
+ * Kept narrow (two streams) so the presence service does NOT depend on
+ * `ActorMessageService` directly — that would create a circular DI loop
+ * since `ActorMessageService` also wires the presence service up.
+ */
+export interface KGPresenceMessageSource {
+  createAgentGraph$: BehaviorSubject<AkgenticMessage[] | null>;
+  message$: BehaviorSubject<AkgenticMessage | null>;
+}
+
+/**
+ * ToolPresenceService — publishes `hasKnowledgeGraph$` derived from the
+ * `StartMessage` / `StopMessage` stream.
+ *
+ * Subscribes to both channels `GraphDataService` uses so presence detection
+ * works during replay (batch on `createAgentGraph$`) AND live
+ * (one-by-one on `message$`). ADR-004 §Decision 4.
+ *
+ * Wiring note: call `bindTo(messageService)` once from the message service's
+ * constructor to establish the subscriptions. The presence service does NOT
+ * `inject(ActorMessageService)` — doing so would create a circular DI graph.
+ *
+ * Story 5-2 ships this observable "dark" — no UI consumer yet. Story 5-3
+ * wires it into `ProcessComponent` to activate the KG tab reactively.
+ */
+@Injectable({ providedIn: 'root' })
+export class ToolPresenceService {
+  readonly hasKnowledgeGraph$: BehaviorSubject<boolean> =
+    new BehaviorSubject<boolean>(false);
+
+  private bound = false;
+
+  /**
+   * Establish subscriptions against the message source's replay + live
+   * streams. Idempotent — second+ calls are a no-op so `ActorMessageService`
+   * construction remains safe under HMR / test re-instantiation.
+   */
+  bindTo(source: KGPresenceMessageSource): void {
+    if (this.bound) return;
+    this.bound = true;
+
+    source.createAgentGraph$.subscribe((messages) => {
+      if (!messages) return;
+      for (const msg of messages) {
+        this.observe(msg);
+      }
+    });
+
+    source.message$.subscribe((message) => {
+      if (!message) return;
+      this.observe(message);
+    });
+  }
+
+  /**
+   * Reset presence to `false`. Called from `ActorMessageService.init()` on
+   * team switch (alongside `KGStateReducer.resetForTeam()`).
+   */
+  resetForTeam(): void {
+    this.setPresence(false);
+  }
+
+  /**
+   * Single-message observer. Exposed for tests that feed messages directly
+   * without binding to a full `ActorMessageService`. Production code uses
+   * `bindTo()` + the streams; test code may use either.
+   */
+  observe(msg: AkgenticMessage): void {
+    if (isStartMessage(msg) && msg.sender?.name === KG_ACTOR_NAME) {
+      this.setPresence(true);
+      return;
+    }
+    if (isStopMessage(msg) && msg.sender?.name === KG_ACTOR_NAME) {
+      this.setPresence(false);
+    }
+  }
+
+  /**
+   * `BehaviorSubject.next()` wrapped with an explicit value check so we
+   * never emit the same boolean twice in a row (AC8.7 — avoid redundant
+   * downstream work; cheaper than piping through `distinctUntilChanged`).
+   */
+  private setPresence(value: boolean): void {
+    if (this.hasKnowledgeGraph$.getValue() === value) return;
+    this.hasKnowledgeGraph$.next(value);
+  }
+}


### PR DESCRIPTION
## Summary

Pure deletion per ADR-004 Step 1, preparing the frontend for Story 5-2's `ToolStateEvent` delta reducer to land on a clean slate.

- **ApiService**: delete `getKnowledgeGraphData` stub
- **ActorMessageService**: delete `knowledgeGraphSnapshot` field, `refreshKnowledgeGraph`, `handleToolUpdate`, `normalizeKnowledgeGraph`, and the legacy `ToolCallEvent` branch in `handleEventMessage`
- **KnowledgeGraphComponent**: drop `refreshTrigger$` input, `modalRefreshTrigger$`, `refreshModalData`, `refreshData`, the refresh subscription in `ngOnInit`, and narrow the `rxjs` import
- **Template**: remove the commented-out Refresh button block and the `refreshTrigger$` binding on the nested `<app-knowledge-graph>`

Kept as public contracts for Story 5-2: `knowledgeGraph$`, `knowledgeGraphLoading$`, and the `KnowledgeGraphData` interfaces.

## Quality gates (frontend has no GitHub Actions CI)

- Karma: 242/242 SUCCESS
- ng build: success, zero new warnings (pre-existing lodash CJS warning only)
- ng lint: not configured (no-op per AC7)
- Zero-reference grep: 0 matches

Closes #45
