### PR TITLE
feat: activate KG panel via reactive presence (Story 5-3)

### DIFF
--- a/src/app/process/process.component.html
+++ b/src/app/process/process.component.html
@@ -13,7 +13,7 @@
     >
       <div class="right-header">
         <p-selectbutton
-          [options]="visualizationOptions"
+          [options]="(visualizationOptions$ | async) ?? []"
           optionLabel="label"
           optionValue="value"
           aria-labelledby="basic"
@@ -38,7 +38,7 @@
           [class.moved-offscreen]="isHidden('workspace')"
         ></app-workspace-explorer>
         <app-knowledge-graph
-          *ngIf="hasKnowledgeGraph"
+          *ngIf="hasKnowledgeGraph$ | async"
           [class.moved-offscreen]="isHidden('knowledge-graph')"
         ></app-knowledge-graph>
         <app-message-list

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -1,0 +1,218 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { BehaviorSubject } from 'rxjs';
+
+import { ProcessComponent } from './process.component';
+import { AkgentService } from '../services/akgent.service';
+import { ContextService } from '../services/context.service';
+import { ActorMessageService } from '../services/message.service';
+import { GraphDataService } from '../services/graph-data.service';
+import { ChatService } from '../services/chat.service';
+import { SelectionService } from '../services/selection.service';
+import { FeedbackService } from '../services/feedback.service';
+import { ToolPresenceService } from '../services/tool-presence.service';
+import { ViewService } from '../view.service';
+import { TeamContext } from '../models/team.interface';
+
+// --------------------------------------------------------------------
+// Fixture helpers
+// --------------------------------------------------------------------
+
+function makeTeam(overrides: Partial<TeamContext> = {}): TeamContext {
+  return {
+    team_id: 'team-1',
+    name: 'Demo Team',
+    status: 'running',
+    created_at: '2026-04-08T10:00:00Z',
+    updated_at: '2026-04-08T10:00:00Z',
+    config_name: 'demo',
+    description: null,
+    ...overrides,
+  };
+}
+
+describe('ProcessComponent', () => {
+  let component: ProcessComponent;
+  let fixture: ComponentFixture<ProcessComponent>;
+  let toolPresenceService: ToolPresenceService;
+
+  beforeEach(async () => {
+    // Fresh presence service per test so cross-test leakage is impossible.
+    const presence = new ToolPresenceService();
+
+    const contextService = {
+      currentProcessId$: new BehaviorSubject<string>(''),
+      getCurrentTeam: jasmine
+        .createSpy('getCurrentTeam')
+        .and.callFake(async () => makeTeam()),
+    };
+
+    const messageService = {
+      init: jasmine
+        .createSpy('init')
+        .and.returnValue(Promise.resolve()),
+      messages$: new BehaviorSubject<any[]>([]),
+      message$: new BehaviorSubject<any>(null),
+      createAgentGraph$: new BehaviorSubject<any>(null),
+      knowledgeGraph$: new BehaviorSubject<any>({ nodes: [], edges: [] }),
+      knowledgeGraphLoading$: new BehaviorSubject<boolean>(false),
+    };
+
+    const akgentService = {
+      unselect: jasmine.createSpy('unselect'),
+      selectedAkgent$: new BehaviorSubject<any>(null),
+    };
+
+    const graphDataService = {
+      isLoading$: new BehaviorSubject<boolean>(false),
+      nodes$: new BehaviorSubject<any[]>([]),
+    };
+
+    const chatService = {
+      messages$: new BehaviorSubject<any[]>([]),
+    };
+
+    const selectionService = {
+      handleSelection: jasmine.createSpy('handleSelection'),
+    };
+
+    const feedbackService = {};
+
+    const viewService = {
+      isRightColumnCollapsed$: new BehaviorSubject<boolean>(false),
+    };
+
+    const router = {
+      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
+    };
+
+    const activatedRoute = {
+      snapshot: { params: { id: 'team-1' } },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProcessComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ToolPresenceService, useValue: presence },
+        { provide: ContextService, useValue: contextService },
+        { provide: ActorMessageService, useValue: messageService },
+        { provide: AkgentService, useValue: akgentService },
+        { provide: GraphDataService, useValue: graphDataService },
+        { provide: ChatService, useValue: chatService },
+        { provide: SelectionService, useValue: selectionService },
+        { provide: FeedbackService, useValue: feedbackService },
+        { provide: ViewService, useValue: viewService },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    })
+      // Swap the heavy child components out for a minimal, empty-template
+      // metadata set + CUSTOM_ELEMENTS_SCHEMA so the DOM still contains the
+      // `<app-knowledge-graph>` / `<app-*>` tags (we assert on them) without
+      // needing to bootstrap the children's full dependency graphs.
+      .overrideComponent(ProcessComponent, {
+        set: {
+          imports: [CommonModule],
+          providers: [],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ProcessComponent);
+    component = fixture.componentInstance;
+    toolPresenceService = presence;
+
+    // Initial detectChanges without ngOnInit route resolution side effects
+    // would still fire `ngOnInit` — but the `getCurrentTeam` spy returns a
+    // resolved promise with a valid team so the router.navigate path is
+    // not taken.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('scenario 1 — empty init (no KG actor): KG option absent, <app-knowledge-graph> not in DOM', async () => {
+    expect(toolPresenceService.hasKnowledgeGraph$.getValue()).toBe(false);
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(false);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).toBeNull();
+  });
+
+  it('scenario 2 — KG presence flips to true: KG option appears and <app-knowledge-graph> mounts', async () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(true);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).not.toBeNull();
+  });
+
+  it('scenario 3 — KG presence flips back to false: KG option disappears and <app-knowledge-graph> unmounts', async () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    toolPresenceService.hasKnowledgeGraph$.next(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'knowledge-graph')).toBe(false);
+
+    const kgEl = fixture.nativeElement.querySelector('app-knowledge-graph');
+    expect(kgEl).toBeNull();
+  });
+
+  it('scenario 4 — active-mode reset: KG active then presence→false flips visualization mode back to team', () => {
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    component.setVisualizationMode('knowledge-graph');
+    expect(component.currentVisualizationMode).toBe('knowledge-graph');
+
+    toolPresenceService.hasKnowledgeGraph$.next(false);
+    expect(component.currentVisualizationMode).toBe('team');
+  });
+
+  it('scenario 5 — no regression: Team / Member / Messages entries remain present under both presence states (order preserved)', async () => {
+    // presence=false
+    let options = await firstValue(component.visualizationOptions$);
+    let labels = options.map((o) => o.value);
+    expect(labels).toEqual(['team', 'member', 'messages']);
+
+    // presence=true
+    toolPresenceService.hasKnowledgeGraph$.next(true);
+    options = await firstValue(component.visualizationOptions$);
+    labels = options.map((o) => o.value);
+    // Team, Member, (no Workspace — hasWorkspace stays false), Knowledge
+    // graph, Messages — order preserved from allVisualizationOptions.
+    expect(labels).toEqual(['team', 'member', 'knowledge-graph', 'messages']);
+  });
+});
+
+// Small synchronous-first-emission helper for BehaviorSubject-derived
+// observables (combineLatest over BehaviorSubjects replays synchronously).
+function firstValue<T>(observable$: { subscribe: (fn: (v: T) => void) => { unsubscribe(): void } }): Promise<T> {
+  return new Promise((resolve) => {
+    const sub = observable$.subscribe((v) => {
+      resolve(v);
+      // Defer unsubscribe so we don't cancel the synchronous resolve path
+      setTimeout(() => sub.unsubscribe(), 0);
+    });
+  });
+}

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -1,11 +1,12 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { isRunning } from '../models/team.interface';
 import { AkgentService } from '../services/akgent.service';
 import { ContextService } from '../services/context.service';
 import { ActorMessageService } from '../services/message.service';
+import { ToolPresenceService } from '../services/tool-presence.service';
 
 import { AgentTabsComponent } from './agent-tabs/agent-tabs.component';
 import { TeamTabsComponent } from './team-tabs/team-tabs.component';
@@ -17,13 +18,20 @@ import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { TabsModule } from 'primeng/tabs';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ChatPanelComponent } from '../chat/chat-panel.component';
 import { ChatService } from '../services/chat.service';
 import { FeedbackService } from '../services/feedback.service';
 import { GraphDataService } from '../services/graph-data.service';
 import { SelectionService } from '../services/selection.service';
 import { ViewService } from '../view.service';
+
+interface VisualizationOption {
+  label: string;
+  value: string;
+  icon: string;
+}
 
 @Component({
   selector: 'app-process',
@@ -51,7 +59,7 @@ import { ViewService } from '../view.service';
   templateUrl: './process.component.html',
   styleUrl: './process.component.scss',
 })
-export class ProcessComponent {
+export class ProcessComponent implements OnDestroy {
   route: ActivatedRoute = inject(ActivatedRoute);
   router: Router = inject(Router);
 
@@ -60,14 +68,27 @@ export class ProcessComponent {
   messageService: ActorMessageService = inject(ActorMessageService);
   graphDataService: GraphDataService = inject(GraphDataService);
   viewService: ViewService = inject(ViewService);
+  toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   processId: string = '';
   processType: string = '';
-  hasKnowledgeGraph: boolean = false;
+  // `hasWorkspace` remains hardcoded: reactivating the workspace panel is a
+  // separate, future story (Epic 5 covers KG only). Keeping the flag in the
+  // filter predicate below so a future story can swap `of(false)` for a real
+  // observable in one line. (ADR-004 §Decision 4)
   hasWorkspace: boolean = false;
 
+  /**
+   * Reactive presence observable for the `#KnowledgeGraphTool` actor.
+   * Sourced from `ToolPresenceService.hasKnowledgeGraph$` (Story 5-2).
+   * Drives the `<app-knowledge-graph>` `*ngIf` binding via `| async`.
+   */
+  hasKnowledgeGraph$: Observable<boolean> =
+    this.toolPresenceService.hasKnowledgeGraph$;
+
   visualizationMode$ = new BehaviorSubject<string>('team');
-  visualizationOptions: { label: string; value: string; icon: string }[] = [
+
+  private readonly allVisualizationOptions: VisualizationOption[] = [
     { label: 'Team', value: 'team', icon: 'pi pi-users' },
     { label: 'Member', value: 'member', icon: 'pi pi-user' },
     { label: 'Workspace', value: 'workspace', icon: 'pi pi-folder-open' },
@@ -79,10 +100,44 @@ export class ProcessComponent {
     { label: 'Messages', value: 'messages', icon: 'pi pi-envelope' },
   ];
 
+  /**
+   * Reactive, filtered list of visualization options. Recomputed whenever
+   * `hasKnowledgeGraph$` emits; preserves the `hasWorkspace` static gate so
+   * workspace-presence reactivation is a one-line change in the future.
+   * (AC3 — reactive derivation)
+   */
+  visualizationOptions$: Observable<VisualizationOption[]> = combineLatest([
+    this.toolPresenceService.hasKnowledgeGraph$,
+    of(this.hasWorkspace),
+  ]).pipe(
+    map(([hasKG, hasWS]) =>
+      this.allVisualizationOptions.filter(
+        (option) =>
+          (option.value !== 'knowledge-graph' || hasKG) &&
+          (option.value !== 'workspace' || hasWS),
+      ),
+    ),
+  );
+
   isRightColumnCollapsed$ =
     this.viewService.isRightColumnCollapsed$.asObservable();
 
   isLoading$ = this.graphDataService.isLoading$;
+
+  private presenceSub: Subscription | null = null;
+
+  constructor() {
+    // Active-mode reset guard (AC3 last clause, AC8): if the user is viewing
+    // the KG tab when presence flips to `false`, snap back to 'team' so we
+    // never leave the user on a hidden-mode blank panel.
+    this.presenceSub = this.toolPresenceService.hasKnowledgeGraph$.subscribe(
+      (hasKG) => {
+        if (!hasKG && this.currentVisualizationMode === 'knowledge-graph') {
+          this.visualizationMode$.next('team');
+        }
+      },
+    );
+  }
 
   async ngOnInit(): Promise<void> {
     this.processId = this.route.snapshot.params['id'];
@@ -105,19 +160,18 @@ export class ProcessComponent {
     }
 
     this.processType = currentProcess.name;
-    // V2 has no params -- workspace/KG tabs default hidden (FR13)
-    this.hasKnowledgeGraph = false;
-    this.hasWorkspace = false;
-    this.visualizationOptions = this.visualizationOptions.filter(
-      (option) =>
-        (option.value !== 'knowledge-graph' || this.hasKnowledgeGraph) &&
-        (option.value !== 'workspace' || this.hasWorkspace)
-    );
+    // KG presence is reactive (Story 5-3 / ADR-004 §Decision 4): the
+    // `hasKnowledgeGraph$` observable flips based on `#KnowledgeGraphTool`
+    // `StartMessage` / `StopMessage` on the replay + live streams. Workspace
+    // presence remains static until a future story reactivates it.
 
     await this.messageService.init(this.processId, isRunning(currentProcess));
   }
+
   ngOnDestroy() {
     this.akgentService.unselect();
+    this.presenceSub?.unsubscribe();
+    this.presenceSub = null;
   }
 
   setVisualizationMode(mode: string): void {


### PR DESCRIPTION
## Summary

Activates the Knowledge Graph visualization tab in `ProcessComponent` by wiring `ToolPresenceService.hasKnowledgeGraph$` (landed dark in Story 5-2) into the component's reactive template bindings. Replaces the hardcoded `hasKnowledgeGraph: boolean = false` with an `Observable<boolean>` consumed via the `async` pipe; derives `visualizationOptions$` reactively via `combineLatest([hasKG$, of(hasWorkspace)]).pipe(map(filter))` so the KG entry enters/leaves the `p-selectbutton` selector dynamically when the `#KnowledgeGraphTool` actor is hired/fired. Adds an active-mode reset guard: when presence flips to `false` while the user is viewing the KG tab, the visualization mode snaps back to `'team'` so no stuck blank panel can occur.

Per ADR-004 §Decision 4 (presence-driven `hasKnowledgeGraph`) and Epic 5 §Story 5.3 (pure UI activation — no new services, no new reducers, no backend contract change). Workspace presence stays hardcoded `false` — reactivating the workspace panel is a separate future story.

### Files changed
- `packages/akgentic-frontend/src/app/process/process.component.ts` — inject `ToolPresenceService`, replace hardcoded `hasKnowledgeGraph` with `hasKnowledgeGraph$` observable, derive `visualizationOptions$` reactively, active-mode reset subscription, `OnDestroy` hook
- `packages/akgentic-frontend/src/app/process/process.component.html` — swap `*ngIf="hasKnowledgeGraph"` → `*ngIf="hasKnowledgeGraph$ | async"`; swap `[options]="visualizationOptions"` → `[options]="(visualizationOptions$ | async) ?? []"`
- `packages/akgentic-frontend/src/app/process/process.component.spec.ts` — new spec with 6 tests covering AC10's 5 reactive-wiring scenarios + baseline `should create`

### Local quality gate (NFR2 — frontend has no GitHub Actions CI; local is authoritative)
- `npm run lint` — not configured (Angular project has no `lint` script; precedent from Stories 5-1 / 5-2)
- `npm run test -- --watch=false --browsers=ChromeHeadless` — `TOTAL: 267 SUCCESS` (261 baseline after 5-2 + 6 new tests)
- `npm run build` — `Application bundle generation complete.` in 4.575 s; zero TypeScript errors; only the pre-existing, unrelated lodash-CJS warning persists

Closes #49
Relates to Epic 5 (KG panel reconnection via ToolStateEvent)

### References
- ADR-004 §Decision 4 (presence-driven `hasKnowledgeGraph`), §Decision 1 (reuse `KnowledgeGraphComponent`), §Reconnection Plan Step 3
- Epic 5 §Story 5.3 (pure UI activation)
- Story 5-2 (baseline — reducer + presence observable, shipped dark)

Stacked on `feat/47-kg-delta-reducer-presence` (Story 5-2's branch, still open as PR #48 at 5-3 start).
