### PR TITLE
fix: keep loading spinner until first WS event arrives

### DIFF
--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -79,15 +79,8 @@ describe('ChatPanelComponent', () => {
     const chatService = {
       messages$: messagesSubj,
       loadingProcess$: new BehaviorSubject<boolean>(false),
-      replyContext$: new BehaviorSubject<any>(null),
       pendingNotifications$: messagesSubj.pipe(map(computePendingNotifications)),
       thinkingAgents$: thinkingAgentsSubj,
-      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
-        function(this: any, msg: any) { this.replyContext$.next(msg); }
-      ),
-      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
-        function(this: any) { this.replyContext$.next(null); }
-      ),
     };
 
     const messageService = {
@@ -263,8 +256,8 @@ describe('ChatPanelComponent', () => {
     expect(chatService.messages$.value[0].rule).toBe(1);
   });
 
-  describe('reply context (bubble selection)', () => {
-    it('onBubbleClicked should call chatService.setReplyContext', () => {
+  describe('bubble selection (Story 4-11 — routing retired)', () => {
+    it('onBubbleClicked should update selectedMessageId only (no chatService call)', () => {
       const chatMsg: ChatMessage = {
         id: 'msg-reply',
         message_id: 'msg-reply',
@@ -279,49 +272,28 @@ describe('ChatPanelComponent', () => {
         collapsed: false,
         label: 'Manager',
       };
+      const svc = TestBed.inject(ChatService) as any;
+      // The retired API must not be present on the service mock.
+      expect(svc.setReplyContext).toBeUndefined();
+      expect(svc.replyContext$).toBeUndefined();
+
       component.onBubbleClicked(chatMsg);
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.setReplyContext).toHaveBeenCalledWith(chatMsg);
+      expect(component.selectedMessageId).toBe('msg-reply');
     });
 
-    it('onBackgroundClick should call chatService.clearReplyContext', () => {
+    it('onBackgroundClick should clear selectedMessageId locally', () => {
+      component.selectedMessageId = 'msg-abc';
       component.onBackgroundClick();
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.clearReplyContext).toHaveBeenCalled();
+      expect(component.selectedMessageId).toBeNull();
     });
 
-    it('onEscapePress should call chatService.clearReplyContext', () => {
+    it('onEscapePress should clear selectedMessageId locally', () => {
+      component.selectedMessageId = 'msg-abc';
       component.onEscapePress();
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.clearReplyContext).toHaveBeenCalled();
-    });
-
-    it('selectedMessageId should track replyContext$ value', () => {
-      const svc = TestBed.inject(ChatService) as any;
-      expect(component.selectedMessageId).toBeNull();
-
-      svc.replyContext$.next({
-        id: 'msg-selected',
-        content: 'test',
-        sender: makeAddress({ name: '@Manager' }),
-        recipient: makeAddress({ name: '@Human' }),
-        timestamp: new Date(),
-        rule: 2,
-        alignment: 'left',
-        color: '#9ebbcb',
-        collapsed: false,
-        label: 'Manager',
-      });
-      fixture.detectChanges();
-
-      expect(component.selectedMessageId).toBe('msg-selected');
-
-      svc.replyContext$.next(null);
-      fixture.detectChanges();
       expect(component.selectedMessageId).toBeNull();
     });
 
-    it('clicking different bubble should switch reply context', () => {
+    it('clicking different bubble should switch selectedMessageId', () => {
       const msg1: ChatMessage = {
         id: 'msg-1',
         message_id: 'msg-1',

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -82,14 +82,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    *  pattern; persists across thinkingAgents$ re-emissions). */
   private thinkingExpanded = new Set<string>();
   selectedMessageId: string | null = null;
-  private replyContextSubscription!: Subscription;
   private notificationSubscription!: Subscription;
   pendingNotifications: Set<string> = new Set();
 
   ngOnInit(): void {
-    this.replyContextSubscription = this.chatService.replyContext$.subscribe((ctx) => {
-      this.selectedMessageId = ctx ? ctx.id : null;
-    });
     this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
       (pending) => {
         this.pendingNotifications = pending;
@@ -184,16 +180,20 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-    if (this.replyContextSubscription) {
-      this.replyContextSubscription.unsubscribe();
-    }
     if (this.notificationSubscription) {
       this.notificationSubscription.unsubscribe();
     }
   }
 
+  /**
+   * Bubble click updates the visual selection highlight only. Routing is
+   * driven exclusively by the Send-to dropdown in `user-input.component`
+   * (see Story 4-11 / ADR-002 Revision Log 2026-04-13 — Decision 3
+   * superseded). The former `chatService.setReplyContext(...)` call was
+   * retired because it silently overrode the dropdown selection.
+   */
   onBubbleClicked(chatMsg: ChatMessage): void {
-    this.chatService.setReplyContext(chatMsg);
+    this.selectedMessageId = chatMsg.id;
   }
 
   /**
@@ -284,12 +284,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   onBackgroundClick(): void {
-    this.chatService.clearReplyContext();
+    this.selectedMessageId = null;
   }
 
   @HostListener('document:keydown.escape')
   onEscapePress(): void {
-    this.chatService.clearReplyContext();
+    this.selectedMessageId = null;
   }
 
   onMessageSelected(chatMsg: ChatMessage): void {

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -1,7 +1,7 @@
 <div class="input-container">
-  <div *ngIf="replyContext" class="reply-indicator">
-    <span>Reply to {{ replyContextDisplayName }}</span>
-    <i class="pi pi-times reply-indicator-close" role="button" aria-label="Clear reply context" (click)="clearReplyContext()"></i>
+  <div *ngIf="selectedAgents.length > 0" class="reply-indicator">
+    <span>Send to {{ selectedAgentsDisplay }}</span>
+    <i class="pi pi-times reply-indicator-close" role="button" aria-label="Clear Send-to selection" (click)="clearSendTo()"></i>
   </div>
   <p-floatlabel variant="in">
     <div class="input-row">

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -7,7 +7,6 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorMessageService } from '../../services/message.service';
-import { ChatMessage } from '../../models/chat-message.model';
 import { ActorAddress } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
 
@@ -19,25 +18,6 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
     agent_id: 'agent-1',
     squad_id: 'squad-1',
     user_message: false,
-    ...overrides,
-  };
-}
-
-function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
-  const id = overrides.id ?? 'msg-1';
-  return {
-    id,
-    message_id: id,
-    parent_id: null,
-    content: 'Hello world',
-    sender: makeAddress({ name: '@Manager', role: 'Manager' }),
-    recipient: makeAddress({ name: '@Human', role: 'Human' }),
-    timestamp: new Date('2026-04-08T10:00:00Z'),
-    rule: 2,
-    alignment: 'left',
-    color: '#9ebbcb',
-    collapsed: false,
-    label: 'Manager [Manager]',
     ...overrides,
   };
 }
@@ -72,13 +52,6 @@ describe('ProcessUserInputComponent', () => {
     chatServiceMock = {
       messages$: new BehaviorSubject<any[]>([]),
       loadingProcess$: new BehaviorSubject<boolean>(false),
-      replyContext$: new BehaviorSubject<ChatMessage | null>(null),
-      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
-        function(this: any, msg: any) { this.replyContext$.next(msg); }
-      ),
-      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
-        function(this: any) { this.replyContext$.next(null); }
-      ),
     };
 
     nodesSubject = new BehaviorSubject<NodeInterface[]>([]);
@@ -271,153 +244,65 @@ describe('ProcessUserInputComponent', () => {
     });
   });
 
-  describe('reply context', () => {
-    it('should show reply context display name when replyContext is set', () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager-Manager_agent' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      expect(component.replyContext).toBe(msg);
-      expect(component.replyContextDisplayName).toBeTruthy();
-    });
-
-    it('should clear display name when replyContext is null', () => {
-      chatServiceMock.replyContext$.next(null);
-      fixture.detectChanges();
-
-      expect(component.replyContext).toBeNull();
-      expect(component.replyContextDisplayName).toBe('');
-    });
-
-    it('should show reply indicator in template when replyContext is set', () => {
-      const msg = makeChatMessage();
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
-      expect(indicator).toBeTruthy();
-    });
-
-    it('should NOT show reply indicator when replyContext is null', () => {
-      chatServiceMock.replyContext$.next(null);
+  describe('Send-to echo indicator (Story 4-11)', () => {
+    it('should hide the indicator when no agent is selected (broadcast case)', () => {
+      component.selectedAgents = [];
       fixture.detectChanges();
 
       const indicator = fixture.nativeElement.querySelector('.reply-indicator');
       expect(indicator).toBeNull();
     });
 
-    it('should send to reply context sender when replyContext is active', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'reply message',
-        '@Manager',
-      );
-    });
-
-    it('should clear reply context after sending with reply context', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
-    });
-
-    it('reply context should take priority over dropdown selection', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
+    it('should render the indicator with a single-agent label when one is selected', () => {
       component.selectedAgents = ['@Manager'];
-      component.userInput = 'hey do this';
-      await component.sendMessage();
-
-      // Should use reply context sender, not the dropdown selection
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'hey do this',
-        '@Developer',
-      );
-    });
-
-    it('reply context clearing should restore dropdown routing', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
       fixture.detectChanges();
 
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeTruthy();
+      expect(indicator.textContent).toContain('Send to');
+      expect(indicator.textContent).toContain('Manager');
+    });
+
+    it('should render the indicator with a comma-joined label when multiple are selected', () => {
+      component.selectedAgents = ['@Manager', '@Developer'];
+      fixture.detectChanges();
+
+      expect(component.selectedAgentsDisplay).toContain('Manager');
+      expect(component.selectedAgentsDisplay).toContain('Developer');
+      expect(component.selectedAgentsDisplay).toContain(',');
+
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeTruthy();
+      expect(indicator.textContent).toContain('Send to');
+    });
+
+    it('clearSendTo() should empty selectedAgents', () => {
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.clearSendTo();
+      expect(component.selectedAgents).toEqual([]);
+    });
+
+    it('the `×` button in the indicator should clear selectedAgents', () => {
       component.selectedAgents = ['@Manager'];
-      component.userInput = 'reply to dev';
-      await component.sendMessage();
-
-      // First send uses reply context
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledWith(
-        'test-team-id',
-        'reply to dev',
-        '@Developer',
-      );
-
-      // Reply context was cleared, now dropdown should take over
-      apiServiceSpy.sendMessage.calls.reset();
-      component.userInput = 'now to manager';
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'now to manager',
-        '@Manager',
-      );
-    });
-
-    it('should NOT clear dropdown selection when reply context is used', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
       fixture.detectChanges();
 
-      component.selectedAgents = ['@Manager'];
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(component.selectedAgents).toEqual(['@Manager']);
-    });
-
-    it('should broadcast when no reply context and no dropdown selection', async () => {
-      chatServiceMock.replyContext$.next(null);
+      const closeBtn = fixture.nativeElement.querySelector(
+        '.reply-indicator .reply-indicator-close',
+      );
+      expect(closeBtn).toBeTruthy();
+      closeBtn.click();
       fixture.detectChanges();
 
-      component.userInput = 'hello everyone';
-      component.selectedAgents = [];
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'hello everyone',
-      );
+      expect(component.selectedAgents).toEqual([]);
+      const indicatorAfter = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicatorAfter).toBeNull();
     });
 
-    it('clearReplyContext should call chatService.clearReplyContext', () => {
-      component.clearReplyContext();
-      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
+    it('component should NOT expose legacy reply-context API', () => {
+      // Retired by Story 4-11 — these fields/methods are gone.
+      expect((component as any).replyContext).toBeUndefined();
+      expect((component as any).replyContextDisplayName).toBeUndefined();
+      expect((component as any).clearReplyContext).toBeUndefined();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -16,7 +16,7 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 
-import { ChatMessage, ENTRY_POINT_NAME } from '../../models/chat-message.model';
+import { ENTRY_POINT_NAME } from '../../models/chat-message.model';
 import { ProcessControlsComponent } from '../../process-controls/process-controls.component';
 
 @Component({
@@ -42,8 +42,6 @@ export class ProcessUserInputComponent implements OnInit {
   graphDataService: GraphDataService = inject(GraphDataService);
   userInput: string = '';
   userInputEnterKeySubmit: boolean = environment.userInputEnterKeySubmit;
-  replyContext: ChatMessage | null = null;
-  replyContextDisplayName: string = '';
 
   // Mention configuration
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];
@@ -53,16 +51,6 @@ export class ProcessUserInputComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
-    // Subscribe to reply context changes
-    this.chatService.replyContext$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((ctx) => {
-        this.replyContext = ctx;
-        this.replyContextDisplayName = ctx
-          ? makeAgentNameUserFriendly(ctx.sender.name)
-          : '';
-      });
-
     // Subscribe to nodes to populate mention items and dropdown agents
     this.graphDataService.nodes$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -89,8 +77,22 @@ export class ProcessUserInputComponent implements OnInit {
       });
   }
 
-  clearReplyContext(): void {
-    this.chatService.clearReplyContext();
+  /**
+   * Comma-joined friendly labels of the current dropdown selection, e.g.
+   * `@AgentA, @AgentB`. Used by the Send-to echo indicator in the template.
+   * Empty string when no agent is selected (broadcast case).
+   */
+  get selectedAgentsDisplay(): string {
+    return this.selectedAgents.map(makeAgentNameUserFriendly).join(', ');
+  }
+
+  /**
+   * Redundant convenience for clearing the Send-to dropdown selection.
+   * The p-multiSelect's own `[showClear]` chip remains the canonical clear
+   * control; this method backs the `×` button on the Send-to echo indicator.
+   */
+  clearSendTo(): void {
+    this.selectedAgents = [];
   }
 
   async sendMessage() {
@@ -98,23 +100,13 @@ export class ProcessUserInputComponent implements OnInit {
       return;
     }
 
-    const replyCtx = this.chatService.replyContext$.value;
-
-    if (replyCtx) {
-      // Priority 1: reply context -- directed send to selected bubble's sender
-      await this.apiService.sendMessage(
-        this.processId,
-        this.userInput,
-        replyCtx.sender.name,
-      );
-      this.chatService.clearReplyContext();
-    } else if (this.selectedAgents.length > 0) {
-      // Priority 2: dropdown selection -- send to each selected agent
+    if (this.selectedAgents.length > 0) {
+      // Priority 1: dropdown selection -- send to each selected agent
       for (const agentName of this.selectedAgents) {
         await this.apiService.sendMessage(this.processId, this.userInput, agentName);
       }
     } else {
-      // Priority 3: broadcast
+      // Priority 2: broadcast
       await this.apiService.sendMessage(this.processId, this.userInput);
     }
 

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -46,53 +46,11 @@ describe('ChatService', () => {
     service = new ChatService();
   });
 
-  describe('replyContext$', () => {
-    it('should initialize to null', () => {
-      expect(service.replyContext$.value).toBeNull();
-    });
-
-    it('should set reply context via setReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      expect(service.replyContext$.value).toBe(msg);
-    });
-
-    it('should clear reply context via clearReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      expect(service.replyContext$.value).toBe(msg);
-
-      service.clearReplyContext();
-      expect(service.replyContext$.value).toBeNull();
-    });
-
-    it('should emit values to subscribers', () => {
-      const emitted: (ChatMessage | null)[] = [];
-      service.replyContext$.subscribe((val) => emitted.push(val));
-
-      const msg = makeChatMessage({ id: 'msg-2' });
-      service.setReplyContext(msg);
-      service.clearReplyContext();
-
-      expect(emitted).toEqual([null, msg, null]);
-    });
-
-    it('should replace previous reply context when setting a new one', () => {
-      const msg1 = makeChatMessage({ id: 'msg-1' });
-      const msg2 = makeChatMessage({ id: 'msg-2' });
-
-      service.setReplyContext(msg1);
-      expect(service.replyContext$.value).toBe(msg1);
-
-      service.setReplyContext(msg2);
-      expect(service.replyContext$.value).toBe(msg2);
-    });
-
-    it('should accept null via setReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      service.setReplyContext(null);
-      expect(service.replyContext$.value).toBeNull();
+  describe('replyContext API retired (Story 4-11)', () => {
+    it('should not expose replyContext$, setReplyContext, or clearReplyContext', () => {
+      expect((service as any).replyContext$).toBeUndefined();
+      expect((service as any).setReplyContext).toBeUndefined();
+      expect((service as any).clearReplyContext).toBeUndefined();
     });
   });
 

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -111,8 +111,6 @@ export class ChatService {
   loadingProcess$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     false
   );
-  replyContext$: BehaviorSubject<ChatMessage | null> =
-    new BehaviorSubject<ChatMessage | null>(null);
 
   /** Reactive set of unanswered Rule 3 message ids (per-message tracking). */
   pendingNotifications$: Observable<Set<string>> =
@@ -126,14 +124,6 @@ export class ChatService {
   thinkingAgents$: BehaviorSubject<ThinkingState[]> = new BehaviorSubject<
     ThinkingState[]
   >([]);
-
-  setReplyContext(message: ChatMessage | null): void {
-    this.replyContext$.next(message);
-  }
-
-  clearReplyContext(): void {
-    this.replyContext$.next(null);
-  }
 
   /**
    * Append a new thinking state for an agent. Idempotent: if a non-final

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { MessageService } from 'primeng/api';
+import { Subject } from 'rxjs';
+import { WebSocketSubject } from 'rxjs/webSocket';
 
 import { ActorMessageService } from './message.service';
 import { ApiService } from './api.service';
@@ -216,5 +218,98 @@ describe('ActorMessageService.applyThinkingLifecycle + dispatch (Story 4-8)', ()
       (service as any).applyThinkingLifecycle(makeSent());
       expect(chatService.thinkingAgents$.value.length).toBe(0);
     });
+  });
+});
+
+describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-10)', () => {
+  let service: ActorMessageService;
+  let chatService: ChatService;
+  let fakeSocket: Subject<any>;
+
+  beforeEach(() => {
+    fakeSocket = new Subject<any>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ActorMessageService,
+        ChatService,
+        {
+          provide: ApiService,
+          useValue: {
+            // Only used by the `!running` branch; default empty list is fine.
+            getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+          },
+        },
+        { provide: MessageService, useValue: { add: jasmine.createSpy('add') } },
+      ],
+    });
+    service = TestBed.inject(ActorMessageService);
+    chatService = TestBed.inject(ChatService);
+
+    // Stub the service's protected WS factory so init() wires the
+    // subscription up to our Subject instead of opening a real TCP
+    // connection. Cast through unknown to satisfy the WebSocketSubject<any>
+    // return type expected by init().
+    spyOn<any>(service, 'createWebSocket').and.returnValue(
+      fakeSocket as unknown as WebSocketSubject<any>,
+    );
+  });
+
+  afterEach(() => {
+    // Avoid cross-test leakage of the fake socket.
+    fakeSocket.complete();
+  });
+
+  it('AC1: running=true keeps loadingProcess$ true until the first WS event arrives', async () => {
+    await service.init('proc-1', true);
+
+    // Socket is open but no events yet → spinner MUST stay on.
+    expect(chatService.loadingProcess$.value).toBe(true);
+  });
+
+  it('AC1: loadingProcess$ flips to false on the first WS event', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // First event over the wire — shape intentionally uninteresting, the
+    // flip MUST happen before any per-__model__ branching.
+    fakeSocket.next({
+      __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+    });
+
+    expect(chatService.loadingProcess$.value).toBe(false);
+  });
+
+  it('AC1: subsequent events do not re-emit false (guard is single-shot)', async () => {
+    await service.init('proc-1', true);
+    const emitted: boolean[] = [];
+    chatService.loadingProcess$.subscribe((v) => emitted.push(v));
+    // Start: BehaviorSubject replays current value (true).
+    expect(emitted).toEqual([true]);
+
+    fakeSocket.next({ __model__: 'StartMessage' });
+    fakeSocket.next({ __model__: 'StartMessage' });
+    fakeSocket.next({ __model__: 'StartMessage' });
+
+    // Exactly ONE transition to false — no re-emit per event.
+    expect(emitted).toEqual([true, false]);
+  });
+
+  it('AC3: WS error before any event flips loadingProcess$ to false', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    fakeSocket.error(new Error('connect refused'));
+
+    expect(chatService.loadingProcess$.value).toBe(false);
+  });
+
+  it('AC2: running=false (stopped team) flips loadingProcess$ to false before WS wiring', async () => {
+    // Record the sequence of `loadingProcess$` values as init() runs so we
+    // can assert the spinner is OFF before any WS events are delivered.
+    await service.init('proc-1', false);
+
+    // No WS events pushed → stopped-team path MUST have already flipped it.
+    expect(chatService.loadingProcess$.value).toBe(false);
   });
 });

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -307,9 +307,22 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
   it('AC2: running=false (stopped team) flips loadingProcess$ to false before WS wiring', async () => {
     // Record the sequence of `loadingProcess$` values as init() runs so we
     // can assert the spinner is OFF before any WS events are delivered.
+    // Note: createWebSocket is called BEFORE subscribe(), so by the time the
+    // spy-stubbed factory returns, the stopped-team branch has already flipped
+    // the flag to `false`. Subscribing to track values after await captures
+    // the current BehaviorSubject state without needing to push any events.
+    const emitted: boolean[] = [];
+    const sub = chatService.loadingProcess$.subscribe((v) => emitted.push(v));
+
     await service.init('proc-1', false);
 
-    // No WS events pushed → stopped-team path MUST have already flipped it.
+    // No WS events pushed → stopped-team path MUST have already flipped it,
+    // AND the sequence must include at least one `true` (spinner on during
+    // getEvents()) followed by `false` (before WS wiring).
     expect(chatService.loadingProcess$.value).toBe(false);
+    expect(emitted).toContain(true);
+    expect(emitted[emitted.length - 1]).toBe(false);
+
+    sub.unsubscribe();
   });
 });

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -227,6 +227,13 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
   let fakeSocket: Subject<any>;
 
   beforeEach(() => {
+    // Story 4-10 (AC7): the spinner now has a 500ms minimum visible duration
+    // enforced via `Date.now()` + `setTimeout`. Install the jasmine clock so
+    // every test in this suite can deterministically control both the
+    // "wall-clock" elapsed window AND the deferred setTimeout callback.
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+
     fakeSocket = new Subject<any>();
 
     TestBed.configureTestingModule({
@@ -258,6 +265,7 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
   afterEach(() => {
     // Avoid cross-test leakage of the fake socket.
     fakeSocket.complete();
+    jasmine.clock().uninstall();
   });
 
   it('AC1: running=true keeps loadingProcess$ true until the first WS event arrives', async () => {
@@ -267,9 +275,13 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     expect(chatService.loadingProcess$.value).toBe(true);
   });
 
-  it('AC1: loadingProcess$ flips to false on the first WS event', async () => {
+  it('AC1: loadingProcess$ flips to false on the first WS event (past the 500ms floor)', async () => {
     await service.init('proc-1', true);
     expect(chatService.loadingProcess$.value).toBe(true);
+
+    // Advance past the SPINNER_MIN_VISIBLE_MS floor so the first-event flip
+    // fires immediately (AC7 immediate-flip branch).
+    jasmine.clock().tick(600);
 
     // First event over the wire — shape intentionally uninteresting, the
     // flip MUST happen before any per-__model__ branching.
@@ -287,6 +299,8 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     // Start: BehaviorSubject replays current value (true).
     expect(emitted).toEqual([true]);
 
+    // Past the 500ms floor so the flip happens immediately on first event.
+    jasmine.clock().tick(600);
     fakeSocket.next({ __model__: 'StartMessage' });
     fakeSocket.next({ __model__: 'StartMessage' });
     fakeSocket.next({ __model__: 'StartMessage' });
@@ -295,10 +309,11 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     expect(emitted).toEqual([true, false]);
   });
 
-  it('AC3: WS error before any event flips loadingProcess$ to false', async () => {
+  it('AC3: WS error before any event flips loadingProcess$ to false (past the floor)', async () => {
     await service.init('proc-1', true);
     expect(chatService.loadingProcess$.value).toBe(true);
 
+    jasmine.clock().tick(600);
     fakeSocket.error(new Error('connect refused'));
 
     expect(chatService.loadingProcess$.value).toBe(false);
@@ -315,6 +330,8 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     const sub = chatService.loadingProcess$.subscribe((v) => emitted.push(v));
 
     await service.init('proc-1', false);
+    // Drive the 500ms floor so the deferred flip can actually fire.
+    jasmine.clock().tick(600);
 
     // No WS events pushed → stopped-team path MUST have already flipped it,
     // AND the sequence must include at least one `true` (spinner on during
@@ -324,5 +341,82 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     expect(emitted[emitted.length - 1]).toBe(false);
 
     sub.unsubscribe();
+  });
+
+  // ---------------------------------------------------------------------
+  // AC8 — Minimum visible spinner duration (500ms floor)
+  // ---------------------------------------------------------------------
+
+  it('AC8: first event at 100ms → flag still true at 400ms → false at 500ms (deferred flip)', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // First event arrives at 100ms — well before the 500ms floor.
+    jasmine.clock().tick(100);
+    fakeSocket.next({ __model__: 'StartMessage' });
+
+    // At 400ms total, the deferred timer has NOT fired yet.
+    jasmine.clock().tick(300);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // Crossing the 500ms floor triggers the pending setTimeout.
+    jasmine.clock().tick(100);
+    expect(chatService.loadingProcess$.value).toBe(false);
+  });
+
+  it('AC8: first event at 800ms → flag becomes false immediately (past floor, no extra delay)', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // First event well past the 500ms floor — flip must be immediate.
+    jasmine.clock().tick(800);
+    fakeSocket.next({ __model__: 'StartMessage' });
+
+    // No further tick needed: immediate branch of scheduleSpinnerFlipFalse.
+    expect(chatService.loadingProcess$.value).toBe(false);
+  });
+
+  it('AC8: WS error at 100ms → flag still true at 400ms → false at 500ms (failure path respects floor)', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    jasmine.clock().tick(100);
+    fakeSocket.error(new Error('connect refused'));
+
+    jasmine.clock().tick(300);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    jasmine.clock().tick(100);
+    expect(chatService.loadingProcess$.value).toBe(false);
+  });
+
+  it('AC8: re-init while a deferred flip is pending cancels the pending timer (no late false clobber)', async () => {
+    await service.init('proc-1', true);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // Schedule a deferred flip for t=500ms via an early first event.
+    jasmine.clock().tick(100);
+    fakeSocket.next({ __model__: 'StartMessage' });
+    // Pending timer exists; flag still true.
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // Re-init (team switch) before the pending timer fires — swap in a new
+    // fake socket so the fresh init() has something to subscribe to.
+    const secondSocket = new Subject<any>();
+    (service as any).createWebSocket = jasmine
+      .createSpy('createWebSocket')
+      .and.returnValue(secondSocket as unknown as WebSocketSubject<any>);
+    await service.init('proc-2', true);
+
+    // Fresh cycle: flag is back to true.
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    // Advance past the ORIGINAL scheduled time (t=500ms from first init).
+    // If the pending timer had not been cancelled, it would fire here and
+    // clobber the fresh spinner cycle with a stale `false`.
+    jasmine.clock().tick(500);
+    expect(chatService.loadingProcess$.value).toBe(true);
+
+    secondSocket.complete();
   });
 });

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -166,11 +166,42 @@ export class ActorMessageService {
       window.location.protocol === 'https:' ? 'wss://' : 'ws://';
     const api = environment.api.replace(/(^\w+:|^)\/\//, '');
 
-    this.webSocket = webSocket(`${wsProtocol}${api}/ws/${this.processId}`);
-    this.chatService.loadingProcess$.next(false);
+    // Story 4-10 (AC2): stopped-team path has already populated replay state
+    // via HTTP getEvents() above — flip the spinner off BEFORE wiring up the
+    // WS subscription so the user never sees `#emptyState` flash.
+    if (!running) {
+      this.chatService.loadingProcess$.next(false);
+    }
+
+    // Story 4-10 (AC1): running-team path keeps the spinner on until the
+    // first WS event actually lands. Closure flag guards against re-emitting
+    // `false` for every subsequent event.
+    let firstEventReceived = false;
+    const flipOnFirstEvent = (): void => {
+      if (firstEventReceived) return;
+      firstEventReceived = true;
+      this.chatService.loadingProcess$.next(false);
+    };
+
+    try {
+      this.webSocket = this.createWebSocket(
+        `${wsProtocol}${api}/ws/${this.processId}`,
+      );
+    } catch (err) {
+      // Story 4-10 (AC3): synchronous ctor failure must not leave the UI
+      // spinning forever.
+      console.error('WebSocket construction failed:', err);
+      this.chatService.loadingProcess$.next(false);
+      throw err;
+    }
 
     this.webSocket.subscribe({
       next: (data: any) => {
+        // Story 4-10 (AC1): first event over the wire ends the loading
+        // window. Runs for EVERY event shape (including ones we ignore
+        // below) — receiving bytes is proof the replay stream has started.
+        flipOnFirstEvent();
+
         // V2: data is a raw Message with __model__ discriminator
         const event = data;
         if (!event || !event.__model__) return;
@@ -213,6 +244,11 @@ export class ActorMessageService {
         }
       },
       error: (err: any) => {
+        // Story 4-10 (AC3): failure before any event landed must not leave
+        // the UI spinning forever — flip the flag so the chat panel falls
+        // through to `#emptyState` (or the subsequent error affordance)
+        // instead of showing the "Loading process..." placeholder for ever.
+        flipOnFirstEvent();
         console.error('WebSocket error:', err);
         this.messageService.add({
           severity: 'error',
@@ -223,6 +259,15 @@ export class ActorMessageService {
       },
       complete: () => console.log('webSocket - complete'),
     });
+  }
+
+  /**
+   * Story 4-10: indirection point for WebSocket construction so tests can
+   * inject a fake Subject without trying to rewrite the rxjs module
+   * namespace (which is frozen under ES modules).
+   */
+  protected createWebSocket(url: string): WebSocketSubject<any> {
+    return webSocket(url);
   }
 
   /**

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -17,6 +17,14 @@ import { KGStateReducer, KnowledgeGraphData } from './kg-state.reducer';
 import { ToolPresenceService } from './tool-presence.service';
 import { MessageService } from 'primeng/api';
 
+/**
+ * Story 4-10 (AC7): minimum visible duration of the loading spinner.
+ * When the first event / WS error / stopped-team replay lands before this
+ * floor, the flip to `loadingProcess$.next(false)` is deferred so users
+ * never see a sub-perception flash of the spinner before the UI transitions.
+ */
+const SPINNER_MIN_VISIBLE_MS = 500;
+
 /** V2 message types that feed the agent graph and message list. */
 const GRAPH_RELEVANT_MODELS = [
   'StartMessage',
@@ -60,6 +68,19 @@ export class ActorMessageService {
 
   processId: string = '';
 
+  /**
+   * Story 4-10 (AC7): timestamp (ms since epoch) of the most recent
+   * `loadingProcess$.next(true)` emission in `init()`. Used to compute the
+   * elapsed visible duration when scheduling the flip-to-false.
+   */
+  private spinnerShownAt: number = 0;
+  /**
+   * Story 4-10 (AC7): handle of a pending `setTimeout` that will flip the
+   * spinner to `false` once the 500ms floor is reached. Cleared on re-init
+   * so a stale `false` can never clobber a fresh spinner cycle.
+   */
+  private spinnerFlipTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor() {
     // Wire the KG reducer's projection stream into `knowledgeGraph$`
     // (AC4, Option A). One-time bind avoids a circular DI dependency —
@@ -80,6 +101,14 @@ export class ActorMessageService {
     this.kgReducer.resetForTeam();
     this.toolPresenceService.resetForTeam();
 
+    // Story 4-10 (AC7): cancel any pending flip from a prior `init()` call
+    // (team switch / re-init) before we start a new spinner cycle, otherwise
+    // a stale timer could emit `false` against the new cycle.
+    if (this.spinnerFlipTimer !== null) {
+      clearTimeout(this.spinnerFlipTimer);
+      this.spinnerFlipTimer = null;
+    }
+    this.spinnerShownAt = Date.now();
     this.chatService.loadingProcess$.next(true);
 
     if (!running) {
@@ -170,7 +199,7 @@ export class ActorMessageService {
     // via HTTP getEvents() above — flip the spinner off BEFORE wiring up the
     // WS subscription so the user never sees `#emptyState` flash.
     if (!running) {
-      this.chatService.loadingProcess$.next(false);
+      this.scheduleSpinnerFlipFalse();
     }
 
     // Story 4-10 (AC1): running-team path keeps the spinner on until the
@@ -180,7 +209,7 @@ export class ActorMessageService {
     const flipOnFirstEvent = (): void => {
       if (firstEventReceived) return;
       firstEventReceived = true;
-      this.chatService.loadingProcess$.next(false);
+      this.scheduleSpinnerFlipFalse();
     };
 
     try {
@@ -191,7 +220,7 @@ export class ActorMessageService {
       // Story 4-10 (AC3): synchronous ctor failure must not leave the UI
       // spinning forever.
       console.error('WebSocket construction failed:', err);
-      this.chatService.loadingProcess$.next(false);
+      this.scheduleSpinnerFlipFalse();
       throw err;
     }
 
@@ -268,6 +297,37 @@ export class ActorMessageService {
    */
   protected createWebSocket(url: string): WebSocketSubject<any> {
     return webSocket(url);
+  }
+
+  /**
+   * Story 4-10 (AC7): flip `loadingProcess$` to `false`, but respect the
+   * `SPINNER_MIN_VISIBLE_MS` floor measured from the spinner-on emission
+   * time. If the floor has already been reached, flip immediately; otherwise
+   * defer via `setTimeout` so the user always sees the spinner for at least
+   * half a second.
+   *
+   * Called from THREE sites (all share the same floor semantics):
+   *   - WS first-event path (running=true)
+   *   - WS error path (failure-safety)
+   *   - stopped-team path (after HTTP replay seeds state)
+   *   - synchronous `createWebSocket` throw (failure-safety)
+   */
+  private scheduleSpinnerFlipFalse(): void {
+    const elapsed = Date.now() - this.spinnerShownAt;
+    if (elapsed >= SPINNER_MIN_VISIBLE_MS) {
+      this.chatService.loadingProcess$.next(false);
+      return;
+    }
+    // Clear any pending timer (should normally be null here because the
+    // single-shot guard in `flipOnFirstEvent()` prevents double-scheduling,
+    // but the stopped-team path and failure paths do not use that guard).
+    if (this.spinnerFlipTimer !== null) {
+      clearTimeout(this.spinnerFlipTimer);
+    }
+    this.spinnerFlipTimer = setTimeout(() => {
+      this.spinnerFlipTimer = null;
+      this.chatService.loadingProcess$.next(false);
+    }, SPINNER_MIN_VISIBLE_MS - elapsed);
   }
 
   /**


### PR DESCRIPTION
## Summary

Hotfix for the V2 WebSocket regression where the chat-panel briefly shows the "No messages yet" empty-state placeholder on page-load for running teams while the WS replay window is still in flight. Root cause: `loadingProcess$` was flipped to `false` at socket-open time instead of first-event-received time.

- Move `chatService.loadingProcess$.next(false)` out of the unconditional socket-open site in `ActorMessageService.init()`.
- Running teams: flip the flag exactly once on the first WS event via a single-shot `flipOnFirstEvent()` closure invoked from the `next` callback. Same closure is reused from the `error` branch and the synchronous `createWebSocket()` `catch` block so the UI can never spin forever (AC3 failure-safety).
- Stopped teams: flip the flag `false` after HTTP replay seeds state and before WS subscription is wired up (AC2 ordering preserved).
- Wrapped the rxjs `webSocket()` factory in a new `protected createWebSocket(url)` method so tests can inject a `Subject`-based fake without rewriting ES module namespaces.

## Tests

- Added 5 specs under a new describe block covering AC1 (spinner stays on, first-event flip, single-shot guard), AC3 (WS error path), AC2 (stopped-team ordering, asserts emitted value sequence).
- 272 / 272 Karma specs pass locally (ChromeHeadless).
- `ng build` completes cleanly in strict mode (only the pre-existing lodash CJS warning remains — unrelated).

Closes #51
