### PR TITLE
fix(#53): retire bubble-click reply context + repurpose indicator as Send-to echo

### DIFF
--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -79,15 +79,8 @@ describe('ChatPanelComponent', () => {
     const chatService = {
       messages$: messagesSubj,
       loadingProcess$: new BehaviorSubject<boolean>(false),
-      replyContext$: new BehaviorSubject<any>(null),
       pendingNotifications$: messagesSubj.pipe(map(computePendingNotifications)),
       thinkingAgents$: thinkingAgentsSubj,
-      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
-        function(this: any, msg: any) { this.replyContext$.next(msg); }
-      ),
-      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
-        function(this: any) { this.replyContext$.next(null); }
-      ),
     };
 
     const messageService = {
@@ -263,8 +256,8 @@ describe('ChatPanelComponent', () => {
     expect(chatService.messages$.value[0].rule).toBe(1);
   });
 
-  describe('reply context (bubble selection)', () => {
-    it('onBubbleClicked should call chatService.setReplyContext', () => {
+  describe('bubble selection (Story 4-11 — routing retired)', () => {
+    it('onBubbleClicked should update selectedMessageId only (no chatService call)', () => {
       const chatMsg: ChatMessage = {
         id: 'msg-reply',
         message_id: 'msg-reply',
@@ -279,49 +272,28 @@ describe('ChatPanelComponent', () => {
         collapsed: false,
         label: 'Manager',
       };
+      const svc = TestBed.inject(ChatService) as any;
+      // The retired API must not be present on the service mock.
+      expect(svc.setReplyContext).toBeUndefined();
+      expect(svc.replyContext$).toBeUndefined();
+
       component.onBubbleClicked(chatMsg);
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.setReplyContext).toHaveBeenCalledWith(chatMsg);
+      expect(component.selectedMessageId).toBe('msg-reply');
     });
 
-    it('onBackgroundClick should call chatService.clearReplyContext', () => {
+    it('onBackgroundClick should clear selectedMessageId locally', () => {
+      component.selectedMessageId = 'msg-abc';
       component.onBackgroundClick();
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.clearReplyContext).toHaveBeenCalled();
+      expect(component.selectedMessageId).toBeNull();
     });
 
-    it('onEscapePress should call chatService.clearReplyContext', () => {
+    it('onEscapePress should clear selectedMessageId locally', () => {
+      component.selectedMessageId = 'msg-abc';
       component.onEscapePress();
-      const svc = TestBed.inject(ChatService) as any;
-      expect(svc.clearReplyContext).toHaveBeenCalled();
-    });
-
-    it('selectedMessageId should track replyContext$ value', () => {
-      const svc = TestBed.inject(ChatService) as any;
-      expect(component.selectedMessageId).toBeNull();
-
-      svc.replyContext$.next({
-        id: 'msg-selected',
-        content: 'test',
-        sender: makeAddress({ name: '@Manager' }),
-        recipient: makeAddress({ name: '@Human' }),
-        timestamp: new Date(),
-        rule: 2,
-        alignment: 'left',
-        color: '#9ebbcb',
-        collapsed: false,
-        label: 'Manager',
-      });
-      fixture.detectChanges();
-
-      expect(component.selectedMessageId).toBe('msg-selected');
-
-      svc.replyContext$.next(null);
-      fixture.detectChanges();
       expect(component.selectedMessageId).toBeNull();
     });
 
-    it('clicking different bubble should switch reply context', () => {
+    it('clicking different bubble should switch selectedMessageId', () => {
       const msg1: ChatMessage = {
         id: 'msg-1',
         message_id: 'msg-1',

--- a/src/app/chat/chat-panel.component.ts
+++ b/src/app/chat/chat-panel.component.ts
@@ -82,14 +82,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    *  pattern; persists across thinkingAgents$ re-emissions). */
   private thinkingExpanded = new Set<string>();
   selectedMessageId: string | null = null;
-  private replyContextSubscription!: Subscription;
   private notificationSubscription!: Subscription;
   pendingNotifications: Set<string> = new Set();
 
   ngOnInit(): void {
-    this.replyContextSubscription = this.chatService.replyContext$.subscribe((ctx) => {
-      this.selectedMessageId = ctx ? ctx.id : null;
-    });
     this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
       (pending) => {
         this.pendingNotifications = pending;
@@ -184,16 +180,20 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-    if (this.replyContextSubscription) {
-      this.replyContextSubscription.unsubscribe();
-    }
     if (this.notificationSubscription) {
       this.notificationSubscription.unsubscribe();
     }
   }
 
+  /**
+   * Bubble click updates the visual selection highlight only. Routing is
+   * driven exclusively by the Send-to dropdown in `user-input.component`
+   * (see Story 4-11 / ADR-002 Revision Log 2026-04-13 — Decision 3
+   * superseded). The former `chatService.setReplyContext(...)` call was
+   * retired because it silently overrode the dropdown selection.
+   */
   onBubbleClicked(chatMsg: ChatMessage): void {
-    this.chatService.setReplyContext(chatMsg);
+    this.selectedMessageId = chatMsg.id;
   }
 
   /**
@@ -284,12 +284,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   onBackgroundClick(): void {
-    this.chatService.clearReplyContext();
+    this.selectedMessageId = null;
   }
 
   @HostListener('document:keydown.escape')
   onEscapePress(): void {
-    this.chatService.clearReplyContext();
+    this.selectedMessageId = null;
   }
 
   onMessageSelected(chatMsg: ChatMessage): void {

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -1,7 +1,7 @@
 <div class="input-container">
-  <div *ngIf="replyContext" class="reply-indicator">
-    <span>Reply to {{ replyContextDisplayName }}</span>
-    <i class="pi pi-times reply-indicator-close" role="button" aria-label="Clear reply context" (click)="clearReplyContext()"></i>
+  <div *ngIf="selectedAgents.length > 0" class="reply-indicator">
+    <span>Send to {{ selectedAgentsDisplay }}</span>
+    <i class="pi pi-times reply-indicator-close" role="button" aria-label="Clear Send-to selection" (click)="clearSendTo()"></i>
   </div>
   <p-floatlabel variant="in">
     <div class="input-row">

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -7,7 +7,6 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorMessageService } from '../../services/message.service';
-import { ChatMessage } from '../../models/chat-message.model';
 import { ActorAddress } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
 
@@ -19,25 +18,6 @@ function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
     agent_id: 'agent-1',
     squad_id: 'squad-1',
     user_message: false,
-    ...overrides,
-  };
-}
-
-function makeChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
-  const id = overrides.id ?? 'msg-1';
-  return {
-    id,
-    message_id: id,
-    parent_id: null,
-    content: 'Hello world',
-    sender: makeAddress({ name: '@Manager', role: 'Manager' }),
-    recipient: makeAddress({ name: '@Human', role: 'Human' }),
-    timestamp: new Date('2026-04-08T10:00:00Z'),
-    rule: 2,
-    alignment: 'left',
-    color: '#9ebbcb',
-    collapsed: false,
-    label: 'Manager [Manager]',
     ...overrides,
   };
 }
@@ -72,13 +52,6 @@ describe('ProcessUserInputComponent', () => {
     chatServiceMock = {
       messages$: new BehaviorSubject<any[]>([]),
       loadingProcess$: new BehaviorSubject<boolean>(false),
-      replyContext$: new BehaviorSubject<ChatMessage | null>(null),
-      setReplyContext: jasmine.createSpy('setReplyContext').and.callFake(
-        function(this: any, msg: any) { this.replyContext$.next(msg); }
-      ),
-      clearReplyContext: jasmine.createSpy('clearReplyContext').and.callFake(
-        function(this: any) { this.replyContext$.next(null); }
-      ),
     };
 
     nodesSubject = new BehaviorSubject<NodeInterface[]>([]);
@@ -271,153 +244,65 @@ describe('ProcessUserInputComponent', () => {
     });
   });
 
-  describe('reply context', () => {
-    it('should show reply context display name when replyContext is set', () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager-Manager_agent' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      expect(component.replyContext).toBe(msg);
-      expect(component.replyContextDisplayName).toBeTruthy();
-    });
-
-    it('should clear display name when replyContext is null', () => {
-      chatServiceMock.replyContext$.next(null);
-      fixture.detectChanges();
-
-      expect(component.replyContext).toBeNull();
-      expect(component.replyContextDisplayName).toBe('');
-    });
-
-    it('should show reply indicator in template when replyContext is set', () => {
-      const msg = makeChatMessage();
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
-      expect(indicator).toBeTruthy();
-    });
-
-    it('should NOT show reply indicator when replyContext is null', () => {
-      chatServiceMock.replyContext$.next(null);
+  describe('Send-to echo indicator (Story 4-11)', () => {
+    it('should hide the indicator when no agent is selected (broadcast case)', () => {
+      component.selectedAgents = [];
       fixture.detectChanges();
 
       const indicator = fixture.nativeElement.querySelector('.reply-indicator');
       expect(indicator).toBeNull();
     });
 
-    it('should send to reply context sender when replyContext is active', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'reply message',
-        '@Manager',
-      );
-    });
-
-    it('should clear reply context after sending with reply context', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Manager' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
-    });
-
-    it('reply context should take priority over dropdown selection', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
-      fixture.detectChanges();
-
+    it('should render the indicator with a single-agent label when one is selected', () => {
       component.selectedAgents = ['@Manager'];
-      component.userInput = 'hey do this';
-      await component.sendMessage();
-
-      // Should use reply context sender, not the dropdown selection
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'hey do this',
-        '@Developer',
-      );
-    });
-
-    it('reply context clearing should restore dropdown routing', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
       fixture.detectChanges();
 
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeTruthy();
+      expect(indicator.textContent).toContain('Send to');
+      expect(indicator.textContent).toContain('Manager');
+    });
+
+    it('should render the indicator with a comma-joined label when multiple are selected', () => {
+      component.selectedAgents = ['@Manager', '@Developer'];
+      fixture.detectChanges();
+
+      expect(component.selectedAgentsDisplay).toContain('Manager');
+      expect(component.selectedAgentsDisplay).toContain('Developer');
+      expect(component.selectedAgentsDisplay).toContain(',');
+
+      const indicator = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicator).toBeTruthy();
+      expect(indicator.textContent).toContain('Send to');
+    });
+
+    it('clearSendTo() should empty selectedAgents', () => {
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.clearSendTo();
+      expect(component.selectedAgents).toEqual([]);
+    });
+
+    it('the `×` button in the indicator should clear selectedAgents', () => {
       component.selectedAgents = ['@Manager'];
-      component.userInput = 'reply to dev';
-      await component.sendMessage();
-
-      // First send uses reply context
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledWith(
-        'test-team-id',
-        'reply to dev',
-        '@Developer',
-      );
-
-      // Reply context was cleared, now dropdown should take over
-      apiServiceSpy.sendMessage.calls.reset();
-      component.userInput = 'now to manager';
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'now to manager',
-        '@Manager',
-      );
-    });
-
-    it('should NOT clear dropdown selection when reply context is used', async () => {
-      const msg = makeChatMessage({
-        sender: makeAddress({ name: '@Developer' }),
-      });
-      chatServiceMock.replyContext$.next(msg);
       fixture.detectChanges();
 
-      component.selectedAgents = ['@Manager'];
-      component.userInput = 'reply message';
-      await component.sendMessage();
-
-      expect(component.selectedAgents).toEqual(['@Manager']);
-    });
-
-    it('should broadcast when no reply context and no dropdown selection', async () => {
-      chatServiceMock.replyContext$.next(null);
+      const closeBtn = fixture.nativeElement.querySelector(
+        '.reply-indicator .reply-indicator-close',
+      );
+      expect(closeBtn).toBeTruthy();
+      closeBtn.click();
       fixture.detectChanges();
 
-      component.userInput = 'hello everyone';
-      component.selectedAgents = [];
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'hello everyone',
-      );
+      expect(component.selectedAgents).toEqual([]);
+      const indicatorAfter = fixture.nativeElement.querySelector('.reply-indicator');
+      expect(indicatorAfter).toBeNull();
     });
 
-    it('clearReplyContext should call chatService.clearReplyContext', () => {
-      component.clearReplyContext();
-      expect(chatServiceMock.clearReplyContext).toHaveBeenCalled();
+    it('component should NOT expose legacy reply-context API', () => {
+      // Retired by Story 4-11 — these fields/methods are gone.
+      expect((component as any).replyContext).toBeUndefined();
+      expect((component as any).replyContextDisplayName).toBeUndefined();
+      expect((component as any).clearReplyContext).toBeUndefined();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -16,7 +16,7 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 
-import { ChatMessage, ENTRY_POINT_NAME } from '../../models/chat-message.model';
+import { ENTRY_POINT_NAME } from '../../models/chat-message.model';
 import { ProcessControlsComponent } from '../../process-controls/process-controls.component';
 
 @Component({
@@ -42,8 +42,6 @@ export class ProcessUserInputComponent implements OnInit {
   graphDataService: GraphDataService = inject(GraphDataService);
   userInput: string = '';
   userInputEnterKeySubmit: boolean = environment.userInputEnterKeySubmit;
-  replyContext: ChatMessage | null = null;
-  replyContextDisplayName: string = '';
 
   // Mention configuration
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];
@@ -53,16 +51,6 @@ export class ProcessUserInputComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
-    // Subscribe to reply context changes
-    this.chatService.replyContext$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((ctx) => {
-        this.replyContext = ctx;
-        this.replyContextDisplayName = ctx
-          ? makeAgentNameUserFriendly(ctx.sender.name)
-          : '';
-      });
-
     // Subscribe to nodes to populate mention items and dropdown agents
     this.graphDataService.nodes$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -89,8 +77,22 @@ export class ProcessUserInputComponent implements OnInit {
       });
   }
 
-  clearReplyContext(): void {
-    this.chatService.clearReplyContext();
+  /**
+   * Comma-joined friendly labels of the current dropdown selection, e.g.
+   * `@AgentA, @AgentB`. Used by the Send-to echo indicator in the template.
+   * Empty string when no agent is selected (broadcast case).
+   */
+  get selectedAgentsDisplay(): string {
+    return this.selectedAgents.map(makeAgentNameUserFriendly).join(', ');
+  }
+
+  /**
+   * Redundant convenience for clearing the Send-to dropdown selection.
+   * The p-multiSelect's own `[showClear]` chip remains the canonical clear
+   * control; this method backs the `×` button on the Send-to echo indicator.
+   */
+  clearSendTo(): void {
+    this.selectedAgents = [];
   }
 
   async sendMessage() {
@@ -98,23 +100,13 @@ export class ProcessUserInputComponent implements OnInit {
       return;
     }
 
-    const replyCtx = this.chatService.replyContext$.value;
-
-    if (replyCtx) {
-      // Priority 1: reply context -- directed send to selected bubble's sender
-      await this.apiService.sendMessage(
-        this.processId,
-        this.userInput,
-        replyCtx.sender.name,
-      );
-      this.chatService.clearReplyContext();
-    } else if (this.selectedAgents.length > 0) {
-      // Priority 2: dropdown selection -- send to each selected agent
+    if (this.selectedAgents.length > 0) {
+      // Priority 1: dropdown selection -- send to each selected agent
       for (const agentName of this.selectedAgents) {
         await this.apiService.sendMessage(this.processId, this.userInput, agentName);
       }
     } else {
-      // Priority 3: broadcast
+      // Priority 2: broadcast
       await this.apiService.sendMessage(this.processId, this.userInput);
     }
 

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -46,53 +46,11 @@ describe('ChatService', () => {
     service = new ChatService();
   });
 
-  describe('replyContext$', () => {
-    it('should initialize to null', () => {
-      expect(service.replyContext$.value).toBeNull();
-    });
-
-    it('should set reply context via setReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      expect(service.replyContext$.value).toBe(msg);
-    });
-
-    it('should clear reply context via clearReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      expect(service.replyContext$.value).toBe(msg);
-
-      service.clearReplyContext();
-      expect(service.replyContext$.value).toBeNull();
-    });
-
-    it('should emit values to subscribers', () => {
-      const emitted: (ChatMessage | null)[] = [];
-      service.replyContext$.subscribe((val) => emitted.push(val));
-
-      const msg = makeChatMessage({ id: 'msg-2' });
-      service.setReplyContext(msg);
-      service.clearReplyContext();
-
-      expect(emitted).toEqual([null, msg, null]);
-    });
-
-    it('should replace previous reply context when setting a new one', () => {
-      const msg1 = makeChatMessage({ id: 'msg-1' });
-      const msg2 = makeChatMessage({ id: 'msg-2' });
-
-      service.setReplyContext(msg1);
-      expect(service.replyContext$.value).toBe(msg1);
-
-      service.setReplyContext(msg2);
-      expect(service.replyContext$.value).toBe(msg2);
-    });
-
-    it('should accept null via setReplyContext', () => {
-      const msg = makeChatMessage();
-      service.setReplyContext(msg);
-      service.setReplyContext(null);
-      expect(service.replyContext$.value).toBeNull();
+  describe('replyContext API retired (Story 4-11)', () => {
+    it('should not expose replyContext$, setReplyContext, or clearReplyContext', () => {
+      expect((service as any).replyContext$).toBeUndefined();
+      expect((service as any).setReplyContext).toBeUndefined();
+      expect((service as any).clearReplyContext).toBeUndefined();
     });
   });
 

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -111,8 +111,6 @@ export class ChatService {
   loadingProcess$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     false
   );
-  replyContext$: BehaviorSubject<ChatMessage | null> =
-    new BehaviorSubject<ChatMessage | null>(null);
 
   /** Reactive set of unanswered Rule 3 message ids (per-message tracking). */
   pendingNotifications$: Observable<Set<string>> =
@@ -126,14 +124,6 @@ export class ChatService {
   thinkingAgents$: BehaviorSubject<ThinkingState[]> = new BehaviorSubject<
     ThinkingState[]
   >([]);
-
-  setReplyContext(message: ChatMessage | null): void {
-    this.replyContext$.next(message);
-  }
-
-  clearReplyContext(): void {
-    this.replyContext$.next(null);
-  }
 
   /**
    * Append a new thinking state for an agent. Idempotent: if a non-final


### PR DESCRIPTION
## Summary

- Retire the Story 2-2 bubble-click -> `chatService.setReplyContext(...)` routing path in `chat-panel.component`. Bubble selection highlight (`selectedMessageId`) is preserved and managed locally. The Send-to dropdown is now the single source of truth for free-form routing.
- Rewire the `.reply-indicator` block in `user-input.component` as a Send-to echo: shows `Send to @AgentA, @AgentB` when `selectedAgents.length > 0`, the `x` button calls `clearSendTo()` (redundant convenience for the dropdown's own `[showClear]`), hidden in broadcast.
- Collapse `sendMessage()` routing chain from three priorities (replyContext -> dropdown -> broadcast) to two (dropdown -> broadcast). Modal-driven reply (Story 4-7, ADR-002 Decision 4) is unchanged.
- Remove `ChatService.replyContext$`, `setReplyContext()`, `clearReplyContext()` -- no other live consumer -- along with their unit tests.
- Implementation matches ADR-002 Revision Log entry dated 2026-04-13; Decision 3 superseded.

Karma: 265/265 specs pass locally. `ng build`: strict-mode compile clean.

Relates to #53

## Base branch

Stacked on `fix/51-loading-spinner-until-first-event` (Story 4-10 PR #52). This PR's merge base must stay that branch until 4-10 lands on master.
