### PR TITLE
fix: render thinking-bubble tool list live during ephemeral phase

### DIFF
--- a/src/app/chat/chat-thinking.component.html
+++ b/src/app/chat/chat-thinking.component.html
@@ -12,7 +12,7 @@
     <span class="spacer"></span>
     <span class="timestamp">{{ state().start_time | date: 'HH:mm' }}</span>
   </div>
-  <div class="tool-list" *ngIf="(expanded() || state().final) && state().tools.length > 0">
+  <div class="tool-list" *ngIf="state().tools.length > 0">
     <div
       class="tool-entry"
       *ngFor="let t of state().tools; trackBy: trackByToolId"

--- a/src/app/chat/chat-thinking.component.spec.ts
+++ b/src/app/chat/chat-thinking.component.spec.ts
@@ -69,6 +69,21 @@ describe('ChatThinkingComponent (Story 4-8)', () => {
     expect(entries.length).toBe(2);
   });
 
+  it('collapsed non-final state with tools renders tool list (live streaming)', () => {
+    const tools = [
+      {
+        tool_call_id: 'call-1',
+        tool_name: 'search_web',
+        arguments_preview: 'q=x',
+        done: false,
+      },
+    ];
+    setInputs(makeState({ final: false, tools }), false);
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.tool-list')).not.toBeNull();
+    expect(el.querySelectorAll('.tool-entry').length).toBe(1);
+  });
+
   it('expanded non-final state with tools renders tool list', () => {
     const tools = [
       {


### PR DESCRIPTION
## Summary

Hotfix for Story 4-8: the `.tool-list` `*ngIf` in `chat-thinking.component.html` was gating visibility on `(expanded() || state().final) && state().tools.length > 0`, which hid the live tool-call stream until the ReAct turn finalised. `ChatService` (chatFold reducer) already accumulated tools correctly — the bug was purely the template visibility gate.

## Changes

- `src/app/chat/chat-thinking.component.html`: simplified the `.tool-list` `*ngIf` to `state().tools.length > 0`. Visibility now gates purely on tool presence; `[class.final]` / `[class.expanded]` bindings on the outer `.thinking-bubble` div remain untouched so SCSS-driven styling (collapsed height, caret, cursor) is unaffected.
- `src/app/chat/chat-thinking.component.spec.ts`: added a "collapsed non-final state with tools renders tool list (live streaming)" spec that seeds `final: false, expanded: false, tools: [<1 entry>]` and asserts `.tool-list` is in the DOM with one `.tool-entry`.

## Acceptance Criteria

- AC1 — Live tool list while bubble is ephemeral: covered by new spec.
- AC2 — Empty-tools state still hides the list: unchanged existing spec still passes.
- AC3 — Final / expanded behaviour unchanged: existing specs for `final=true` and `final=false, expanded=true` still pass; `[class.final]` / `[class.expanded]` bindings intact.
- AC4 — Full Karma suite green (266/266) and `ng build` strict-mode compile clean.

## Scope

- Two files only: the template and its spec. `chat.service.ts` chatFold reducer and `.scss` untouched. No cross-submodule changes.

Closes #63
