### PR TITLE
Fix thinking bubble stuck on empty ProcessedMessage

### DIFF
--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -329,6 +329,28 @@ describe('chatFold / chatStep (pure)', () => {
     expect(state.thinkingAgents.length).toBe(0);
   });
 
+  it('ProcessedMessage for different agent does NOT clear another agent thinking', () => {
+    const rcv = makeReceived(); // agent-1
+    const proc = makeProcessed({
+      sender: makeAddress({ name: '@Writer', agent_id: 'agent-2' }),
+    });
+    const state = chatFold([rcv, proc]);
+    expect(state.thinkingAgents.length).toBe(1);
+    expect(state.thinkingAgents[0].agent_id).toBe('agent-1');
+    expect(state.thinkingAgents[0].final).toBe(false);
+  });
+
+  it('ProcessedMessage after SentMessage already finalised → idempotent no-op', () => {
+    const rcv = makeReceived();
+    const sent = makeSent({
+      sender: makeAddress({ name: '@Researcher', agent_id: 'agent-1', role: 'Worker' }),
+    });
+    const proc = makeProcessed();
+    const state = chatFold([rcv, sent, proc]);
+    // SentMessage already removed the entry (no tools), ProcessedMessage is a no-op
+    expect(state.thinkingAgents.length).toBe(0);
+  });
+
   it('(AC6 / FR11) UnknownFutureMessage interleaved is a pure no-op', () => {
     const rcv = makeReceived();
     const unk = makeUnknown();

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -7,6 +7,7 @@ import {
   AkgenticMessage,
   BaseMessage,
   EventMessage,
+  ProcessedMessage,
   ReceivedMessage,
   SentMessage,
   StartMessage,
@@ -110,6 +111,21 @@ function makeStateChanged(): StateChangedMessage {
     content: null,
     __model__: 'akgentic.core.messages.orchestrator.StateChangedMessage',
     state: { phase: 'x' },
+  };
+}
+
+function makeProcessed(overrides: Partial<ProcessedMessage> = {}): ProcessedMessage {
+  return {
+    id: 'proc-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-04-12T10:00:00Z',
+    sender: makeAddress({ name: '@Researcher', agent_id: 'agent-1' }),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.ProcessedMessage',
+    message_id: 'inner-rcv-1',
+    ...overrides,
   };
 }
 
@@ -284,6 +300,33 @@ describe('chatFold / chatStep (pure)', () => {
     });
     const state = chatFold([rcv, sentSys]);
     expect(state.thinkingAgents.length).toBe(1);
+  });
+
+  it('ProcessedMessage with no tools in active thinking → ephemeral exit (entry removed)', () => {
+    const rcv = makeReceived();
+    const proc = makeProcessed();
+    const state = chatFold([rcv, proc]);
+    expect(state.thinkingAgents.length).toBe(0);
+  });
+
+  it('ProcessedMessage with tools in active thinking → persistent (final=true, entry kept)', () => {
+    const rcv = makeReceived();
+    const call = makeEvent({
+      __model__: 'akgentic.llm.event.ToolCallEvent',
+      tool_call_id: 'call-1',
+      tool_name: 'search_web',
+      arguments: '{}',
+    });
+    const proc = makeProcessed();
+    const state = chatFold([rcv, call, proc]);
+    expect(state.thinkingAgents.length).toBe(1);
+    expect(state.thinkingAgents[0].final).toBe(true);
+  });
+
+  it('ProcessedMessage with no prior thinking state → no-op', () => {
+    const proc = makeProcessed();
+    const state = chatFold([proc]);
+    expect(state.thinkingAgents.length).toBe(0);
   });
 
   it('(AC6 / FR11) UnknownFutureMessage interleaved is a pure no-op', () => {

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -17,8 +17,10 @@ import {
   AkgenticMessage,
   EventMessage,
   isEventMessage,
+  isProcessedMessage,
   isReceivedMessage,
   isSentMessage,
+  ProcessedMessage,
   ReceivedMessage,
   SentMessage,
 } from '../models/message.types';
@@ -61,6 +63,7 @@ export interface ThinkingToolEntry {
  *   EventMessage+ToolCallEvent  → pushes an entry into tools
  *   EventMessage+ToolReturnEvent → flips entry.done to true
  *   SentMessage                 → if tools empty: removed; else final = true
+ *   ProcessedMessage            → if tools empty: removed; else final = true
  */
 export interface ThinkingState {
   /** Stable UUID of the receiving agent actor (from ReceivedMessage.sender). */
@@ -221,8 +224,23 @@ function applyToolReturnToThinking(
 
 function applySentToThinking(state: ChatState, msg: SentMessage): ChatState {
   if (msg.sender.role === ACTOR_SYSTEM_ROLE) return state;
+  return finaliseThinking(state, msg.sender.agent_id);
+}
+
+function applyProcessedToThinking(
+  state: ChatState,
+  msg: ProcessedMessage,
+): ChatState {
+  return finaliseThinking(state, msg.sender.agent_id);
+}
+
+/**
+ * Shared finalisation logic for thinking bubbles.
+ * If the bubble has no tools: remove it. Otherwise: set `final: true`.
+ */
+function finaliseThinking(state: ChatState, agentId: string): ChatState {
   const idx = state.thinkingAgents.findIndex(
-    (s) => s.agent_id === msg.sender.agent_id && !s.final,
+    (s) => s.agent_id === agentId && !s.final,
   );
   if (idx === -1) return state;
   const existing = state.thinkingAgents[idx];
@@ -252,6 +270,9 @@ export function chatStep(state: ChatState, msg: AkgenticMessage): ChatState {
   if (isSentMessage(msg)) {
     const afterMsg = applyMessageFromSent(state, msg);
     return applySentToThinking(afterMsg, msg);
+  }
+  if (isProcessedMessage(msg)) {
+    return applyProcessedToThinking(state, msg);
   }
   if (isReceivedMessage(msg)) {
     return applyReceivedToThinking(state, msg);


### PR DESCRIPTION
## Summary

- Handle `ProcessedMessage` in `chatStep()` to clear thinking bubbles when the LLM returns an empty structured output (`{"messages": []}`)
- Extract shared `finaliseThinking()` helper used by both `SentMessage` and `ProcessedMessage` handlers (DRY)
- Add 5 new tests covering ProcessedMessage lifecycle: ephemeral exit, persistent finalisation, no-op, agent-id mismatch, and double-finalise idempotency

## Code Review Findings

| Severity | Issue | Fix |
|----------|-------|-----|
| MEDIUM | Missing edge-case test: ProcessedMessage for different agent should not clear unrelated thinking bubble | Added test |
| LOW | Missing edge-case test: ProcessedMessage after SentMessage already finalised (double-finalise idempotency) | Added test |

All 324 tests pass (322 original + 2 review additions).

Closes #65
