### PR TITLE
feat: activate workspace panel (Story 6-2)

### DIFF
--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -233,15 +233,48 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
     expect(component.currentVisualizationMode).toBe('team');
   });
 
-  it('scenario 5 — no regression: Team / Member / Messages entries remain present under both presence states (order preserved)', async () => {
+  it('scenario 5 — no regression: Team / Member / Messages entries remain present under both KG presence states (order preserved)', async () => {
+    // `hasWorkspace` defaults to `true` in production (Story 6-2 AC1), so
+    // Workspace is always present; the legacy KG-presence regression check
+    // now runs against `[team, member, workspace, messages]` without KG and
+    // `[team, member, knowledge-graph, workspace, messages]` with KG.
     let options = await firstValue(component.visualizationOptions$);
     let labels = options.map((o) => o.value);
-    expect(labels).toEqual(['team', 'member', 'messages']);
+    expect(labels).toEqual(['team', 'member', 'workspace', 'messages']);
 
     log.append(makeKgStart('kg-start-1'));
     options = await firstValue(component.visualizationOptions$);
     labels = options.map((o) => o.value);
-    expect(labels).toEqual(['team', 'member', 'knowledge-graph', 'messages']);
+    expect(labels).toEqual([
+      'team',
+      'member',
+      'knowledge-graph',
+      'workspace',
+      'messages',
+    ]);
+  });
+
+  it('scenario 6 — hasWorkspace=true: Workspace appears between KG and Messages (Story 6-2 AC1, AC2)', async () => {
+    // Default is `hasWorkspace = true` (Story 6-2 AC1). Without KG, the
+    // tab order degrades gracefully to [team, member, workspace, messages].
+    let options = await firstValue(component.visualizationOptions$);
+    expect(options.map((o) => o.value)).toEqual([
+      'team',
+      'member',
+      'workspace',
+      'messages',
+    ]);
+
+    // With KG present, Workspace sits between KG and Messages (AC2 order).
+    log.append(makeKgStart('kg-start-1'));
+    options = await firstValue(component.visualizationOptions$);
+    expect(options.map((o) => o.value)).toEqual([
+      'team',
+      'member',
+      'knowledge-graph',
+      'workspace',
+      'messages',
+    ]);
   });
 });
 

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -77,11 +77,10 @@ export class ProcessComponent implements OnDestroy {
 
   processId: string = '';
   processType: string = '';
-  // `hasWorkspace` remains hardcoded: reactivating the workspace panel is a
-  // separate, future story (Epic 5 covers KG only). Keeping the flag in the
-  // filter predicate below so a future story can swap `of(false)` for a real
-  // observable in one line. (ADR-004 §Decision 4)
-  hasWorkspace: boolean = false;
+  // Workspace presence is static: every team has a workspace directory by
+  // default (backend creates one on team boot). Reactive presence detection
+  // for workspace is an explicit future enhancement — out of scope today.
+  hasWorkspace: boolean = true;
 
   /**
    * Reactive presence observable for the `#KnowledgeGraphTool` actor.
@@ -96,12 +95,12 @@ export class ProcessComponent implements OnDestroy {
   private readonly allVisualizationOptions: VisualizationOption[] = [
     { label: 'Team', value: 'team', icon: 'pi pi-users' },
     { label: 'Member', value: 'member', icon: 'pi pi-user' },
-    { label: 'Workspace', value: 'workspace', icon: 'pi pi-folder-open' },
     {
       label: 'Knowledge graph',
       value: 'knowledge-graph',
       icon: 'pi pi-sitemap',
     },
+    { label: 'Workspace', value: 'workspace', icon: 'pi pi-folder-open' },
     { label: 'Messages', value: 'messages', icon: 'pi pi-envelope' },
   ];
 

--- a/src/app/process/workspace-explorer/workspace-explorer.component.html
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.html
@@ -67,6 +67,7 @@
             [value]="treeNodes"
             selectionMode="single"
             (onNodeSelect)="onNodeSelect($event)"
+            (onNodeExpand)="onNodeExpand($event)"
             [style]="{ width: '100%', border: 'none' }"
           />
         </div>

--- a/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
@@ -1,0 +1,389 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TreeNode } from 'primeng/api';
+import { BehaviorSubject } from 'rxjs';
+
+import { ContextService } from '../../services/context.service';
+import { FileNode, WorkspaceService } from '../../services/workspace.service';
+import { UploadModalComponent } from './upload-modal/upload-modal.component';
+import { WorkspaceExplorerComponent } from './workspace-explorer.component';
+
+// --------------------------------------------------------------------
+// Fixture helpers
+// --------------------------------------------------------------------
+
+function makeTeam(): any {
+  return {
+    team_id: 'proc',
+    name: 'Demo Team',
+    status: 'running',
+    created_at: '2026-04-08T10:00:00Z',
+    updated_at: '2026-04-08T10:00:00Z',
+    config_name: 'demo',
+    description: null,
+  };
+}
+
+function fileNode(overrides: Partial<FileNode>): FileNode {
+  return {
+    name: overrides.name || 'x',
+    path: overrides.path || 'x',
+    type: overrides.type || 'file',
+    size: overrides.size ?? 1,
+    extension: overrides.extension,
+    ...overrides,
+  };
+}
+
+describe('WorkspaceExplorerComponent', () => {
+  let component: WorkspaceExplorerComponent;
+  let fixture: ComponentFixture<WorkspaceExplorerComponent>;
+  let workspaceServiceSpy: jasmine.SpyObj<WorkspaceService>;
+  let contextServiceStub: {
+    currentProcessId$: BehaviorSubject<string>;
+    getCurrentTeam: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    workspaceServiceSpy = jasmine.createSpyObj('WorkspaceService', [
+      'getWorkspaceTree',
+      'getFileContent',
+      'getDownloadUrl',
+      'uploadFiles',
+    ]);
+    contextServiceStub = {
+      currentProcessId$: new BehaviorSubject<string>('proc'),
+      getCurrentTeam: jasmine
+        .createSpy('getCurrentTeam')
+        .and.callFake(async () => makeTeam()),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [WorkspaceExplorerComponent, NoopAnimationsModule],
+      providers: [
+        { provide: WorkspaceService, useValue: workspaceServiceSpy },
+        { provide: ContextService, useValue: contextServiceStub },
+      ],
+    })
+      .overrideComponent(WorkspaceExplorerComponent, {
+        set: {
+          imports: [CommonModule],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+  });
+
+  // --- loadWorkspace -------------------------------------------------
+
+  describe('loadWorkspace', () => {
+    it('scenario 1 — root listing wraps backend entries under synthetic Root Folder', async () => {
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([
+        fileNode({
+          name: 'a.md',
+          path: 'a.md',
+          type: 'file',
+          size: 10,
+          extension: '.md',
+        }),
+        fileNode({ name: 'sub', path: 'sub', type: 'directory', size: 0 }),
+      ]);
+
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      // Don't detectChanges yet — call loadWorkspace explicitly and await it
+      await component.ngOnInit();
+
+      expect(component.treeNodes.length).toBe(1);
+      const root = component.treeNodes[0];
+      expect(root.label).toBe('Root Folder');
+      expect(root.children?.length).toBe(2);
+
+      // The directory child should be lazy (children === undefined, leaf false)
+      const subChild = root.children![1];
+      expect(subChild.label).toBe('sub');
+      expect(subChild.leaf).toBe(false);
+      expect(subChild.children).toBeUndefined();
+
+      // The file child should be a leaf
+      const fileChild = root.children![0];
+      expect(fileChild.label).toBe('a.md');
+      expect(fileChild.leaf).toBe(true);
+    });
+
+    it('scenario 2 — empty backend renders synthetic root with empty children', async () => {
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      await component.ngOnInit();
+
+      // Synthetic root always exists; its children are []
+      expect(component.treeNodes.length).toBe(1);
+      expect(component.treeNodes[0].label).toBe('Root Folder');
+      expect(component.treeNodes[0].children).toEqual([]);
+      expect(component.errorMessage).toBeNull();
+    });
+
+    it('scenario 3 — HTTP error sets errorMessage and clears loading', async () => {
+      workspaceServiceSpy.getWorkspaceTree.and.rejectWith(new Error('500'));
+
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      await component.ngOnInit();
+
+      expect(component.errorMessage).toBe('500');
+      expect(component.loading).toBe(false);
+    });
+  });
+
+  // --- onNodeExpand --------------------------------------------------
+
+  describe('onNodeExpand', () => {
+    beforeEach(() => {
+      // Neutral initial state; tests manually fabricate TreeNodes.
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      component.processId = 'proc';
+    });
+
+    it('scenario 4 — first-click on unloaded directory fetches and populates children', async () => {
+      const subDir: TreeNode = {
+        label: 'sub',
+        data: fileNode({ name: 'sub', path: 'sub', type: 'directory' }),
+        leaf: false,
+        children: undefined,
+      };
+      component.treeNodes = [subDir];
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([
+        fileNode({
+          name: 'inner.ts',
+          path: 'sub/inner.ts',
+          type: 'file',
+          size: 1,
+          extension: '.ts',
+        }),
+      ]);
+
+      await component.onNodeExpand({ node: subDir });
+
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledOnceWith(
+        'proc',
+        'sub'
+      );
+      expect(subDir.children?.length).toBe(1);
+      expect(subDir.children![0].leaf).toBe(true);
+      expect(subDir.children![0].label).toBe('inner.ts');
+    });
+
+    it('scenario 5 — second-click on already-loaded directory is a no-op', async () => {
+      const subDir: TreeNode = {
+        label: 'sub',
+        data: fileNode({ name: 'sub', path: 'sub', type: 'directory' }),
+        leaf: false,
+        children: undefined,
+      };
+      component.treeNodes = [subDir];
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([
+        fileNode({ name: 'x', path: 'sub/x', type: 'file' }),
+      ]);
+
+      await component.onNodeExpand({ node: subDir });
+      await component.onNodeExpand({ node: subDir });
+
+      expect(workspaceServiceSpy.getWorkspaceTree.calls.count()).toBe(1);
+    });
+
+    it('scenario 6 — expand on file node is a no-op', async () => {
+      const fileNd: TreeNode = {
+        label: 'a.md',
+        data: fileNode({ name: 'a.md', path: 'a.md', type: 'file' }),
+        leaf: true,
+        children: undefined,
+      };
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      await component.onNodeExpand({ node: fileNd });
+
+      expect(workspaceServiceSpy.getWorkspaceTree).not.toHaveBeenCalled();
+    });
+
+    it('scenario 7 — empty-directory response caches (second click is a no-op)', async () => {
+      const subDir: TreeNode = {
+        label: 'empty',
+        data: fileNode({ name: 'empty', path: 'empty', type: 'directory' }),
+        leaf: false,
+        children: undefined,
+      };
+      component.treeNodes = [subDir];
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+
+      await component.onNodeExpand({ node: subDir });
+      expect(subDir.children).toEqual([]);
+
+      await component.onNodeExpand({ node: subDir });
+      expect(workspaceServiceSpy.getWorkspaceTree.calls.count()).toBe(1);
+    });
+
+    it('scenario 8 — HTTP error sets errorMessage and leaves children undefined (retryable)', async () => {
+      const subDir: TreeNode = {
+        label: 'bad',
+        data: fileNode({ name: 'bad', path: 'bad', type: 'directory' }),
+        leaf: false,
+        children: undefined,
+      };
+      component.treeNodes = [subDir];
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.rejectWith(new Error('boom'));
+
+      await component.onNodeExpand({ node: subDir });
+
+      expect(component.errorMessage).toBe('boom');
+      expect(subDir.children).toBeUndefined();
+    });
+  });
+
+  // --- handleUploadComplete -----------------------------------------
+
+  describe('handleUploadComplete', () => {
+    beforeEach(() => {
+      // Keep ngOnInit's loadWorkspace call happy with an empty listing
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+      workspaceServiceSpy.uploadFiles.and.resolveTo();
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      component.processId = 'proc';
+    });
+
+    it('scenario 9 — refreshes only the target subdirectory', async () => {
+      // Set up a tree with root + expanded `docs` subdir containing a.md
+      const aMd: TreeNode = {
+        label: 'a.md',
+        data: fileNode({
+          name: 'a.md',
+          path: 'docs/a.md',
+          type: 'file',
+          extension: '.md',
+        }),
+        leaf: true,
+      };
+      const docs: TreeNode = {
+        label: 'docs',
+        data: fileNode({ name: 'docs', path: 'docs', type: 'directory' }),
+        leaf: false,
+        children: [aMd],
+      };
+      const root: TreeNode = {
+        label: 'Root Folder',
+        data: fileNode({
+          name: 'Root Folder',
+          path: '',
+          type: 'directory',
+        }),
+        children: [docs],
+        expanded: true,
+      };
+      component.treeNodes = [root];
+      component.uploadTargetPath = 'docs';
+
+      // Stub the upload modal ViewChild
+      component.uploadModal = {
+        getSelectedFiles: () => [new File(['x'], 'b.md')],
+      } as unknown as UploadModalComponent;
+
+      // Fresh listing for docs after upload
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([
+        fileNode({
+          name: 'a.md',
+          path: 'docs/a.md',
+          type: 'file',
+          extension: '.md',
+        }),
+        fileNode({
+          name: 'b.md',
+          path: 'docs/b.md',
+          type: 'file',
+          extension: '.md',
+        }),
+      ]);
+
+      const loadWorkspaceSpy = spyOn(component, 'loadWorkspace').and.callThrough();
+
+      await component.handleUploadComplete();
+
+      expect(workspaceServiceSpy.uploadFiles).toHaveBeenCalledTimes(1);
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledOnceWith(
+        'proc',
+        'docs'
+      );
+
+      const refreshedDocs = component.treeNodes[0].children![0];
+      expect(refreshedDocs.children?.length).toBe(2);
+
+      // Critically: no full-tree refresh was issued
+      expect(loadWorkspaceSpy).not.toHaveBeenCalled();
+    });
+
+    it('scenario 10 — root target refreshes the synthetic Root Folder wrapper children', async () => {
+      const root: TreeNode = {
+        label: 'Root Folder',
+        data: fileNode({
+          name: 'Root Folder',
+          path: '',
+          type: 'directory',
+        }),
+        children: [],
+        expanded: true,
+      };
+      component.treeNodes = [root];
+      component.uploadTargetPath = '';
+      component.uploadModal = {
+        getSelectedFiles: () => [new File(['x'], 'c.md')],
+      } as unknown as UploadModalComponent;
+
+      workspaceServiceSpy.getWorkspaceTree.calls.reset();
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([
+        fileNode({
+          name: 'c.md',
+          path: 'c.md',
+          type: 'file',
+          extension: '.md',
+        }),
+      ]);
+
+      await component.handleUploadComplete();
+
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledOnceWith(
+        'proc',
+        ''
+      );
+      // Root wrapper itself stays; its children are replaced with fresh listing
+      expect(component.treeNodes.length).toBe(1);
+      expect(component.treeNodes[0].label).toBe('Root Folder');
+      expect(component.treeNodes[0].children?.length).toBe(1);
+      expect(component.treeNodes[0].children![0].label).toBe('c.md');
+    });
+
+    it('scenario 11 — no files selected: no-op (uploadFiles NOT called)', async () => {
+      component.uploadModal = {
+        getSelectedFiles: () => [],
+      } as unknown as UploadModalComponent;
+      workspaceServiceSpy.uploadFiles.calls.reset();
+
+      await component.handleUploadComplete();
+
+      expect(workspaceServiceSpy.uploadFiles).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/process/workspace-explorer/workspace-explorer.component.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.ts
@@ -149,6 +149,43 @@ export class WorkspaceExplorerComponent implements OnInit {
     return iconMap[ext] || 'pi pi-file';
   }
 
+  /**
+   * PrimeNG lazy-expand handler: when a user clicks the expand arrow on a
+   * directory TreeNode whose children have never been fetched (`children ===
+   * undefined`), fetch that directory's entries from `WorkspaceService` and
+   * splice them into the node. Loaded-empty (`children === []`) and loaded-
+   * populated directories short-circuit via the `!== undefined` guard — the
+   * second expand on any directory never issues a second HTTP call.
+   */
+  async onNodeExpand(event: {
+    node: TreeNode;
+    originalEvent?: Event;
+  }): Promise<void> {
+    const node = event.node;
+    const fileNode = node.data as FileNode | undefined;
+
+    // Only directories are lazy-loaded
+    if (!fileNode || fileNode.type !== 'directory') return;
+    // Cache hit: already loaded (empty or populated)
+    if (node.children !== undefined) return;
+
+    try {
+      const children = await this.workspaceService.getWorkspaceTree(
+        this.processId,
+        fileNode.path
+      );
+      node.children = this.convertToTreeNodes(children);
+      // Re-assign the top-level array reference so Angular's default CD
+      // picks up the mutation on a nested TreeNode's `children` property.
+      this.treeNodes = [...this.treeNodes];
+    } catch (error: any) {
+      console.error('Error loading subdirectory', error);
+      this.errorMessage = error?.message || 'Failed to load subdirectory';
+      // Leave node.children as undefined so a subsequent user-initiated
+      // expand can retry the fetch.
+    }
+  }
+
   async onNodeSelect(event: any) {
     const node: FileNode = event.node.data;
 
@@ -279,11 +316,63 @@ export class WorkspaceExplorerComponent implements OnInit {
         this.uploadTargetPath
       );
 
-      // Refresh the workspace tree
-      await this.loadWorkspace();
+      // Refresh ONLY the directory the user uploaded to — preserves the
+      // rest of the user's expansion state. Root ('') targets the synthetic
+      // Root Folder wrapper; subdirs are located via `findTreeNodeByPath`.
+      await this.refreshDirectory(this.uploadTargetPath);
     } catch (error: any) {
       console.error('Upload failed', error);
       throw error;
     }
+  }
+
+  /**
+   * Re-fetch a single directory listing and splice the fresh children into
+   * the tree at that path. For the root ('') this replaces the synthetic
+   * Root Folder wrapper's children (the wrapper itself stays). For subdirs
+   * we walk the tree to locate the matching TreeNode; if not found (e.g.
+   * user uploaded to a dir that hasn't been expanded yet), silently return —
+   * the next manual expand will lazy-fetch the fresh listing anyway.
+   */
+  private async refreshDirectory(path: string): Promise<void> {
+    const fresh = await this.workspaceService.getWorkspaceTree(
+      this.processId,
+      path
+    );
+    const freshNodes = this.convertToTreeNodes(fresh);
+
+    if (path === '') {
+      if (this.treeNodes.length > 0) {
+        this.treeNodes[0].children = freshNodes;
+        this.treeNodes = [...this.treeNodes];
+      }
+      return;
+    }
+
+    const target = this.findTreeNodeByPath(this.treeNodes, path);
+    if (target) {
+      target.children = freshNodes;
+      this.treeNodes = [...this.treeNodes];
+    }
+  }
+
+  /**
+   * Recursive depth-first walk locating the TreeNode whose `data.path`
+   * matches `path`. Returns `null` if no match exists in the currently
+   * materialized tree (lazy: unloaded subtrees are invisible to this walk).
+   */
+  private findTreeNodeByPath(
+    nodes: TreeNode[],
+    path: string
+  ): TreeNode | null {
+    for (const n of nodes) {
+      const fn = n.data as FileNode | undefined;
+      if (fn?.path === path) return n;
+      if (n.children) {
+        const found = this.findTreeNodeByPath(n.children, path);
+        if (found) return found;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Reactivates the Workspace panel in the right-column visualization selector on top of Story 6-1's `WorkspaceService` V2 adapter. Closes out Epic 6.

- Flip `hasWorkspace` to `true` in `ProcessComponent` (static presence — reactive workspace presence is an explicit future enhancement).
- Reorder `allVisualizationOptions` to `[Team, Member, Knowledge graph, Workspace, Messages]`.
- Adapt `WorkspaceExplorerComponent` for PrimeNG lazy subdirectory loading: new `onNodeExpand()` with `children !== undefined` cache guard (handles loaded-empty `[]` correctly), file-node no-op, retryable-on-error shape.
- Target upload refresh at the uploaded directory only via new `refreshDirectory(path)` + recursive `findTreeNodeByPath()` — preserves the user's expansion state instead of resetting the full tree.

## Tests

- `process.component.spec.ts`: scenario 5 assertions updated for `hasWorkspace = true`; new scenario 6 explicitly covers the workspace tab order with KG on/off.
- New `workspace-explorer.component.spec.ts`: 11 scenarios (loadWorkspace root/empty/error; onNodeExpand first-click/second-click/file-node/empty-cache/error; handleUploadComplete target-subdir/root/no-files).
- Local gate: lint (not configured), `npm test` → **352 SUCCESS** (340 baseline + 12 new), `npm run build` → bundle complete, 0 TS errors.

## Stacked PR

Base branch: `feat/67-workspace-service-v2-adapter` (Story 6-1, PR #69, not yet merged). Will rebase to master once #69 lands.

Closes #71
Relates to epic-6
