### PR TITLE
Send as routing and dynamic state (Story 7-2)

### DIFF
--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -31,17 +31,21 @@
   </p-floatlabel>
 
   <div class="button-group">
-    @if (humanAgents.length >= 2) {
-      <label class="send-as-label">Send as</label>
-      <p-dropdown
-        [options]="humanAgentOptions"
-        [(ngModel)]="selectedSender"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="Send as"
-        [showClear]="true"
-        size="small"
-      ></p-dropdown>
+    @if (humanAgents.length > 1) {
+      <div class="send-as-group">
+        <label class="send-as-label">Send as</label>
+        <p-dropdown
+          [options]="humanAgentOptions"
+          [(ngModel)]="selectedSender"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Send as"
+          [showClear]="true"
+          size="small"
+          appendTo="body"
+          [panelStyleClass]="'send-as-panel-up'"
+        ></p-dropdown>
+      </div>
     }
     <label class="send-to-label">Send to</label>
     <p-multiSelect

--- a/src/app/process/user-input/user-input.component.scss
+++ b/src/app/process/user-input/user-input.component.scss
@@ -7,7 +7,6 @@
     font-size: 0.8rem;
     color: #64748b;
     white-space: nowrap;
-    margin-left: auto;
   }
 
   .send-as-label {
@@ -16,8 +15,16 @@
     white-space: nowrap;
   }
 
-  p-dropdown {
-    margin-right: 0.5rem;
+  // Story 7-3: wrap the "Send as" label + dropdown so the pair right-aligns
+  // inside `.button-group`. `margin-left: auto` pushes the Send-as group
+  // (and, by proximity, the Send-to cluster that follows it) to the right
+  // edge of the row.
+  .send-as-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-left: auto;
   }
 
   p-multiSelect {
@@ -25,6 +32,10 @@
     min-width: 150px;
   }
 }
+
+// Story 7-3 note: the `.send-as-panel-up` overlay rule lives in
+// `src/styles.scss` because `appendTo="body"` renders the PrimeNG panel
+// outside the component's scoped styles. See that file for the rule.
 
 .reply-indicator {
   display: flex;

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -8,6 +8,7 @@ import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorAddress } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
+import { makeAgentNameUserFriendly } from '../../lib/util';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
   return {
@@ -299,7 +300,7 @@ describe('ProcessUserInputComponent', () => {
       expect(component.selectedSender).toBeNull();
     });
 
-    it('populates humanAgents with role === Human and actorName !== @Human', () => {
+    it('populates humanAgents with role === Human (Story 7-3)', () => {
       nodesSubject.next([
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
         makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
@@ -307,29 +308,39 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
       ]);
 
-      expect(component.humanAgents.length).toBe(2);
+      // Story 7-3: @Human is now INCLUDED alongside other human-role nodes.
+      expect(component.humanAgents.length).toBe(3);
       expect(component.humanAgents.map((n) => n.actorName)).toEqual([
         '@Support',
         '@Operator',
+        '@Human',
       ]);
       expect(component.humanAgentOptions.map((o) => o.value)).toEqual([
         '@Support',
         '@Operator',
+        '@Human',
       ]);
       // Labels come from makeAgentNameUserFriendly (passes @Support through
       // as-is since there is no '-' role segment).
       expect(component.humanAgentOptions[0].label).toBe('@Support');
     });
 
-    it('excludes the entry-point @Human even when role === Human', () => {
+    it('includes the entry-point @Human when role === Human (Story 7-3)', () => {
       nodesSubject.next([
         makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
       ]);
 
-      expect(component.humanAgents.length).toBe(1);
-      expect(component.humanAgents[0].actorName).toBe('@Support');
-      expect(component.humanAgentOptions.map((o) => o.value)).not.toContain('@Human');
+      // Story 7-3 (AC #1, AC #2): the @Human entry point is a first-class
+      // selectable sender. The filter uses role === HUMAN_ROLE only.
+      expect(component.humanAgents.length).toBe(2);
+      expect(component.humanAgents.map((n) => n.actorName)).toContain('@Human');
+      expect(component.humanAgents.map((n) => n.actorName)).toContain('@Support');
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Human');
+      // AC #2: label for @Human uses the friendly helper, not a hard-coded string.
+      const humanOpt = component.humanAgentOptions.find((o) => o.value === '@Human');
+      expect(humanOpt).toBeTruthy();
+      expect(humanOpt!.label).toBe(makeAgentNameUserFriendly('@Human'));
     });
 
     it('excludes nodes whose role !== Human', () => {
@@ -354,9 +365,10 @@ describe('ProcessUserInputComponent', () => {
       expect(dropdown).toBeNull();
     });
 
-    it('is hidden when humanAgents.length === 1', () => {
+    it('is hidden when humanAgents.length === 1 (solo @Human) (Story 7-3)', () => {
+      // Story 7-3: humans include @Human; solo-@Human still hides dropdown.
       nodesSubject.next([
-        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
       ]);
       fixture.detectChanges();
 
@@ -364,16 +376,19 @@ describe('ProcessUserInputComponent', () => {
       expect(dropdown).toBeNull();
     });
 
-    it('is visible when humanAgents.length === 2 and carries humanAgentOptions', () => {
+    it('is visible when humanAgents.length === 2 (@Human + @Support) (Story 7-3)', () => {
+      // Story 7-3: threshold fires at 2 humans INCLUDING @Human.
       nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
-        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
       ]);
       fixture.detectChanges();
 
       const dropdown = fixture.nativeElement.querySelector('p-dropdown');
       expect(dropdown).not.toBeNull();
       expect(component.humanAgentOptions.length).toBe(2);
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Human');
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Support');
     });
 
     it('picking an option sets selectedSender to the option value', () => {
@@ -511,6 +526,36 @@ describe('ProcessUserInputComponent', () => {
       expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
       expect(component.userInput).toBe('   ');
     });
+
+    it('Priority 1: @Human as sender routes via sendMessageFromTo (Story 7-3)', async () => {
+      component.selectedSender = '@Human';
+      component.selectedAgents = ['@Manager'];
+      component.userInput = 'hello from human';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id', '@Human', '@Manager', 'hello from human',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('Priority 2: @Human as sender with no recipient auto-targets first dropdown agent (Story 7-3)', async () => {
+      component.selectedSender = '@Human';
+      component.selectedAgents = [];
+      component.userInput = 'auto-target from @Human';
+
+      await component.sendMessage();
+
+      const firstDropdownAgent = component.dropdownAgents[0]?.value;
+      expect(firstDropdownAgent).toBeTruthy();
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id', '@Human', firstDropdownAgent!, 'auto-target from @Human',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
   });
 
   describe('"Send as" dynamic state (Story 7-2)', () => {
@@ -584,6 +629,69 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
       ]);
       expect(component.selectedSender).toBeNull();
+    });
+
+    it('clears selectedSender === "@Human" when @Human disappears from the roster (Story 7-3)', () => {
+      // Initial: @Human + @Support both present, selectedSender = @Human
+      nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Human';
+
+      // Defensive case: @Human somehow removed (leaving only non-entry humans).
+      // The clear-on-fire predicate fires because @Human is no longer in humanAgents.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+
+      expect(component.selectedSender).toBeNull();
+      expect(component.humanAgents.length).toBe(2);
+    });
+  });
+
+  describe('"Send as" layout and panel positioning (Story 7-3)', () => {
+    beforeEach(() => {
+      nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+      fixture.detectChanges();
+    });
+
+    it('renders p-dropdown with appendTo="body" (AC #14)', () => {
+      const dropdown = fixture.nativeElement.querySelector('p-dropdown');
+      expect(dropdown).not.toBeNull();
+      // In Angular dev-mode runtime, string inputs appear as DOM attributes.
+      // `appendTo` is bound as a literal string on the template, so it
+      // surfaces as an attribute on the <p-dropdown> element.
+      expect(dropdown.getAttribute('appendTo')).toBe('body');
+    });
+
+    it('renders p-dropdown with the upward panel style class configured (AC #14)', () => {
+      const dropdown = fixture.nativeElement.querySelector('p-dropdown');
+      expect(dropdown).not.toBeNull();
+      // [panelStyleClass] is an input binding — Angular reflects its current
+      // value via `ng-reflect-panel-style-class` in dev mode. Accept any
+      // deterministic channel that carries the class name.
+      const panelClass =
+        dropdown.getAttribute('ng-reflect-panel-style-class') ||
+        dropdown.getAttribute('panelStyleClass');
+      expect(panelClass).toContain('send-as-panel-up');
+    });
+
+    it('right-aligns the Send-as group inside .button-group (AC #15)', () => {
+      const group = fixture.nativeElement.querySelector('.send-as-group');
+      expect(group).not.toBeNull();
+      // The implementation uses both `justify-content: flex-end` (intra-group
+      // alignment) and `margin-left: auto` (pushes the group to the right
+      // inside `.button-group`). Either is acceptable evidence that the
+      // Send-as block is right-aligned.
+      const style = window.getComputedStyle(group);
+      expect(
+        style.justifyContent === 'flex-end' || style.marginLeft === 'auto',
+      ).toBeTrue();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -43,10 +43,9 @@ describe('ProcessUserInputComponent', () => {
   let nodesSubject: BehaviorSubject<NodeInterface[]>;
 
   beforeEach(async () => {
-    apiServiceSpy = jasmine.createSpyObj('ApiService', [
-      'sendMessage',
-    ]);
+    apiServiceSpy = jasmine.createSpyObj('ApiService', ['sendMessage', 'sendMessageFromTo']);
     apiServiceSpy.sendMessage.and.returnValue(Promise.resolve());
+    apiServiceSpy.sendMessageFromTo.and.returnValue(Promise.resolve());
 
     chatServiceMock = {
       messages$: new BehaviorSubject<any[]>([]),
@@ -390,40 +389,201 @@ describe('ProcessUserInputComponent', () => {
       expect(component.selectedSender).toBe('@Support');
     });
 
-    it('a non-null selectedSender does NOT alter sendMessage() routing (AC #6 guard)', async () => {
+  });
+
+  describe('"Send as" routing (Story 7-2)', () => {
+    beforeEach(() => {
+      // 2 non-entry-point humans so the dropdown would be visible
       nodesSubject.next([
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
         makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
       ]);
-      component.selectedSender = '@Support';
-      component.selectedAgents = ['@Manager'];
-      component.userInput = 'hello';
-
-      // Guard: sendMessageFromTo is NOT on ApiService spy — if production code
-      // called it, the test would throw. Additionally verify the per-agent
-      // Priority 1 path from Story 3-1 remains byte-for-byte intact.
-      await component.sendMessage();
-
-      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'hello',
-        '@Manager',
-      );
-      expect((apiServiceSpy as any).sendMessageFromTo).toBeUndefined();
     });
 
-    it('a non-null selectedSender with empty selectedAgents still broadcasts (AC #6 guard)', async () => {
+    it('Priority 1: sender + recipients -> sendMessageFromTo per recipient (AC #1)', async () => {
       component.selectedSender = '@Support';
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.userInput = 'hello';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledTimes(2);
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledWith(
+        'test-team-id', '@Support', '@Manager', 'hello',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledWith(
+        'test-team-id', '@Support', '@Developer', 'hello',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('Priority 2: sender, no recipient, non-empty dropdownAgents -> first dropdown agent (AC #2)', async () => {
+      // Override the beforeEach roster with workers only so dropdownAgents[0]
+      // is @Manager (the "typical supervisor" case from AC #2). The current
+      // dropdown filter (Story 3-1) excludes only the entry-point @Human; any
+      // other @-prefixed node — including humans like @Support — would
+      // otherwise land in dropdownAgents and shadow the worker at index 0.
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
+      ]);
+      // selectedSender is set AFTER the emission, so the clear-on-count-drop
+      // logic (which runs inside the nodes$ subscription) doesn't see it.
+      component.selectedSender = '@Support';
+      component.selectedAgents = [];
+      component.userInput = 'first-agent auto-target';
+
+      // sanity-check the expected first entry.
+      expect(component.dropdownAgents[0].value).toBe('@Manager');
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id', '@Support', '@Manager', 'first-agent auto-target',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('Priority 2 edge case: sender, no recipient, empty dropdownAgents -> no send, input preserved (AC #3)', async () => {
+      // Emit a roster with 2 humans but NO worker agents in the Send-to dropdown.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+      ]);
+      // Force the edge case by emptying dropdownAgents directly:
+      component.dropdownAgents = [];
+      component.selectedSender = '@Support';
+      component.selectedAgents = [];
+      component.userInput = 'orphan sender';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('orphan sender');
+    });
+
+    it('Priority 3: no sender + recipients -> sendMessage per recipient (AC #4, Story 3-1 preserved)', async () => {
+      component.selectedSender = null;
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.userInput = 'hello team';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledTimes(2);
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledWith(
+        'test-team-id', 'hello team', '@Manager',
+      );
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledWith(
+        'test-team-id', 'hello team', '@Developer',
+      );
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('Priority 4: no sender + no recipient -> broadcast (AC #5, Story 3-1 preserved)', async () => {
+      component.selectedSender = null;
       component.selectedAgents = [];
       component.userInput = 'broadcast hello';
 
       await component.sendMessage();
 
       expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
-        'test-team-id',
-        'broadcast hello',
+        'test-team-id', 'broadcast hello',
       );
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('empty input guard runs first across all priorities (AC #6)', async () => {
+      component.selectedSender = '@Support';
+      component.selectedAgents = ['@Manager'];
+      component.userInput = '   '; // whitespace only
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('   ');
+    });
+  });
+
+  describe('"Send as" dynamic state (Story 7-2)', () => {
+    it('clears selectedSender when the selected sender is fired (AC #7)', () => {
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+        makeNode({ name: 'thi-1', actorName: '@Third', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Support';
+
+      // Fire @Support by emitting a roster without it (count stays >= 2).
+      nodesSubject.next([
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+        makeNode({ name: 'thi-1', actorName: '@Third', role: 'Human' }),
+      ]);
+
+      expect(component.selectedSender).toBeNull();
+      expect(component.humanAgents.length).toBe(2);
+    });
+
+    it('clears selectedSender when human count drops below 2 (AC #8)', () => {
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Support';
+
+      // Drop to 1 non-entry-point human.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+
+      expect(component.selectedSender).toBeNull();
+      expect(component.humanAgents.length).toBe(1);
+    });
+
+    it('preserves selectedSender when the selection still exists and count >= 2', () => {
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+        makeNode({ name: 'thi-1', actorName: '@Third', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Support';
+
+      // Fire an unrelated human -> @Support stays selected.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+
+      expect(component.selectedSender).toBe('@Support');
+    });
+
+    it('does not resurrect a cleared selectedSender when count recovers', () => {
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Support';
+
+      // Drop below 2 -> selection cleared.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+      expect(component.selectedSender).toBeNull();
+
+      // Recover to 2 humans -> selection STAYS null (user must repick).
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+      expect(component.selectedSender).toBeNull();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -80,12 +80,13 @@ export class ProcessUserInputComponent implements OnInit {
           agents.some((n) => n.actorName === a),
         );
 
-        // "Send as" human selector (Story 7-1): populate humanAgents /
-        // humanAgentOptions from the same emission. Visibility is template-driven
-        // by humanAgents.length >= 2. Routing wiring is Story 7-2.
-        this.humanAgents = nodes.filter(
-          (n) => n.role === HUMAN_ROLE && n.actorName !== ENTRY_POINT_NAME,
-        );
+        // "Send as" human selector (Story 7-1, revised Story 7-3): populate
+        // humanAgents / humanAgentOptions from the same emission. Visibility is
+        // template-driven by humanAgents.length > 1. Routing wiring is
+        // Story 7-2. Story 7-3 drops the actorName !== ENTRY_POINT_NAME clause
+        // so @Human is a first-class selectable sender (ADR-007 Revision
+        // 2026-04-15, FR2 amendment).
+        this.humanAgents = nodes.filter((n) => n.role === HUMAN_ROLE);
         this.humanAgentOptions = this.humanAgents.map((n) => ({
           label: makeAgentNameUserFriendly(n.actorName),
           value: n.actorName,

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -90,6 +90,18 @@ export class ProcessUserInputComponent implements OnInit {
           label: makeAgentNameUserFriendly(n.actorName),
           value: n.actorName,
         }));
+
+        // NFR1 / Story 7-2: keep selectedSender coherent with the live roster.
+        // Clear the selection when the chosen sender is fired, OR when the
+        // non-entry-point human count drops below 2 (dropdown hidden — selection
+        // would be invisible and stale).
+        if (
+          this.selectedSender !== null &&
+          (this.humanAgents.length < 2 ||
+            !this.humanAgents.some((n) => n.actorName === this.selectedSender))
+        ) {
+          this.selectedSender = null;
+        }
       });
   }
 
@@ -116,13 +128,33 @@ export class ProcessUserInputComponent implements OnInit {
       return;
     }
 
-    if (this.selectedAgents.length > 0) {
-      // Priority 1: dropdown selection -- send to each selected agent
+    const hasSender = this.selectedSender !== null && this.selectedSender !== '';
+    const hasRecipients = this.selectedAgents.length > 0;
+
+    if (hasSender && hasRecipients) {
+      // Priority 1: explicit sender + explicit recipients
+      for (const recipient of this.selectedAgents) {
+        await this.apiService.sendMessageFromTo(
+          this.processId, this.selectedSender!, recipient, this.userInput,
+        );
+      }
+    } else if (hasSender && !hasRecipients) {
+      // Priority 2: explicit sender, no recipient -> first dropdown agent
+      const defaultRecipient = this.dropdownAgents[0]?.value;
+      if (!defaultRecipient) {
+        // AC #3: no candidate recipient exists -> do not send, preserve input
+        return;
+      }
+      await this.apiService.sendMessageFromTo(
+        this.processId, this.selectedSender!, defaultRecipient, this.userInput,
+      );
+    } else if (hasRecipients) {
+      // Priority 3: default sender + explicit recipients (Story 3-1 preserved)
       for (const agentName of this.selectedAgents) {
         await this.apiService.sendMessage(this.processId, this.userInput, agentName);
       }
     } else {
-      // Priority 2: broadcast
+      // Priority 4: broadcast (Story 3-1 preserved)
       await this.apiService.sendMessage(this.processId, this.userInput);
     }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -127,6 +127,16 @@ chat-wrapper {
   margin-top: 0.5rem;
 }
 
+// Story 7-3: PrimeNG `p-dropdown` overlay rendered with `appendTo="body"`.
+// The Send-as dropdown lives at the bottom of the chat panel, so opening
+// the panel downward would clip it below the viewport edge. This class,
+// passed via `[panelStyleClass]="'send-as-panel-up'"` on the trigger,
+// lifts the overlay above the trigger. `-100%` backs off its own height;
+// the extra `2.5rem` clears the trigger height (matching `size="small"`).
+.send-as-panel-up {
+  transform: translateY(calc(-100% - 2.5rem));
+}
+
 // markdown styles
 markdown {
 


### PR DESCRIPTION
## Summary

Wires the "Send as" dropdown (Story 7-1) into `sendMessage()` with a four-priority routing table, and adds dynamic-state reactivity to keep `selectedSender` coherent with the live human-agent roster.

- **Four-priority routing** in `sendMessage()`:
  1. sender + recipients → `sendMessageFromTo` per recipient
  2. sender + no recipient → `sendMessageFromTo` with `dropdownAgents[0]` as auto-target; early return preserving input when no candidate exists
  3. no sender + recipients → `sendMessage(teamId, content, recipient)` per recipient (Story 3-1 preserved byte-for-byte)
  4. no sender + no recipient → `sendMessage(teamId, content)` broadcast (Story 3-1 preserved)
- **Clear-on-fire / clear-on-count-drop** inside the existing `nodes$` subscription: resets `selectedSender` to `null` whenever the selection's invariant ("selected sender exists as non-entry-point Human AND humanAgents.length >= 2") is violated.
- Empty-input guard remains the first statement of `sendMessage()` (applies uniformly to all four priorities).
- No template / SCSS / service changes. No reintroduction of the retired bubble-click reply-context path.

## Changes

- `src/app/process/user-input/user-input.component.ts` — routing table + clear-on-fire/count logic.
- `src/app/process/user-input/user-input.component.spec.ts` — `ApiService` spy extended with `sendMessageFromTo`; two obsolete Story 7-1 "AC #6 guard" tests removed; new `describe('"Send as" routing (Story 7-2)', ...)` block (6 tests, one per priority branch + empty-input guard); new `describe('"Send as" dynamic state (Story 7-2)', ...)` block (4 tests for clear-on-fire, clear-on-count-drop, preservation, non-resurrection).

## Scope

All changes confined to `packages/akgentic-frontend/`. Two files touched, both inside `src/app/process/user-input/`. No backend / API / other-component / cross-submodule edits.

## Verification

- `ng test --watch=false`: **342 / 342 passing**.
- `ng build`: clean (only the pre-existing lodash CommonJS warning, unrelated to this story).
- Adversarial code review: no HIGH or MEDIUM findings; all 12 ACs verified against implementation and tests.

Closes #72

Relates to #72

Stacked on top of PR #70 (Story 7-1); base branch: `feat/68-send-as-dropdown-visibility`.
