### PR TITLE
fix: clear PrimeNG fileUpload widget after upload modal reset (Story 6-3)

### DIFF
--- a/src/app/process/workspace-explorer/upload-modal/upload-modal.component.spec.ts
+++ b/src/app/process/workspace-explorer/upload-modal/upload-modal.component.spec.ts
@@ -1,0 +1,103 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FileUpload } from 'primeng/fileupload';
+
+import { UploadModalComponent } from './upload-modal.component';
+
+// --------------------------------------------------------------------
+// Test helpers
+// --------------------------------------------------------------------
+
+function makeFile(name: string, content = 'x'): File {
+  return new File([content], name);
+}
+
+function installFileUploadSpy(component: UploadModalComponent): jasmine.Spy {
+  const clearSpy = jasmine.createSpy('clear');
+  component.fileUpload = { clear: clearSpy } as unknown as FileUpload;
+  return clearSpy;
+}
+
+// --------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------
+
+describe('UploadModalComponent', () => {
+  let component: UploadModalComponent;
+  let fixture: ComponentFixture<UploadModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UploadModalComponent, NoopAnimationsModule],
+    })
+      .overrideComponent(UploadModalComponent, {
+        set: {
+          // Strip PrimeNG template rendering; we stub the ViewChild manually
+          // so tests never require the dialog content to be in the DOM.
+          imports: [],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          template: '',
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(UploadModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('scenario 1 — clears FileUpload widget after successful upload', fakeAsync(() => {
+    const clearSpy = installFileUploadSpy(component);
+    component.selectedFiles = [makeFile('a.md'), makeFile('b.md')];
+
+    component.uploadFiles();
+    // uploadFiles is async; let the microtask queue drain before advancing
+    // the clock past the success-path 1500ms auto-close setTimeout.
+    tick(0);
+    tick(1500);
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(component.selectedFiles).toEqual([]);
+    expect(component.visible).toBe(false);
+  }));
+
+  it('scenario 2 — retains FileUpload widget on upload error', fakeAsync(() => {
+    const clearSpy = installFileUploadSpy(component);
+    component.selectedFiles = [makeFile('a.md')];
+
+    // Force the success path inside the try-block to throw so that the
+    // catch-branch at upload-modal.component.ts:78-80 executes. The auto-close
+    // setTimeout is only scheduled on success, so resetModal() must NOT run.
+    spyOn(component.uploadComplete, 'emit').and.throwError('network down');
+
+    component.uploadFiles();
+    tick(0);
+    tick(2000); // well past the 1500ms success timeout that never schedules
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect(component.selectedFiles.length).toBe(1);
+    expect(component.errorMessage).toBe('network down');
+  }));
+
+  it('scenario 3 — clears FileUpload widget on manual cancel (onHide)', () => {
+    const clearSpy = installFileUploadSpy(component);
+    component.selectedFiles = [makeFile('a.md')];
+    component.visible = true;
+
+    component.onHide();
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(component.selectedFiles).toEqual([]);
+    expect(component.visible).toBe(false);
+  });
+
+  it('scenario 4 — resetModal is safe when FileUpload ViewChild is undefined', () => {
+    // Simulate the dialog-never-opened case: ViewChild has not resolved yet.
+    component.fileUpload = undefined as unknown as FileUpload;
+    component.selectedFiles = [makeFile('a.md')];
+
+    expect(() => component.onHide()).not.toThrow();
+    expect(component.selectedFiles).toEqual([]);
+  });
+});

--- a/src/app/process/workspace-explorer/upload-modal/upload-modal.component.ts
+++ b/src/app/process/workspace-explorer/upload-modal/upload-modal.component.ts
@@ -1,8 +1,8 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
-import { FileUploadModule } from 'primeng/fileupload';
+import { FileUpload, FileUploadModule } from 'primeng/fileupload';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { MessageModule } from 'primeng/message';
 
@@ -25,6 +25,8 @@ export class UploadModalComponent {
   @Input() targetPath: string = '';
   @Output() visibleChange = new EventEmitter<boolean>();
   @Output() uploadComplete = new EventEmitter<void>();
+
+  @ViewChild(FileUpload) fileUpload!: FileUpload;
 
   selectedFiles: File[] = [];
   uploading = false;
@@ -84,6 +86,10 @@ export class UploadModalComponent {
   }
 
   private resetModal() {
+    // Clear the PrimeNG widget's internal files array first. The optional
+    // chain guards against the ViewChild being undefined when the dialog
+    // content has not yet been rendered (see issue #75 / Story 6-3 AC5).
+    this.fileUpload?.clear();
     this.selectedFiles = [];
     this.uploading = false;
     this.uploadProgress = 0;


### PR DESCRIPTION
## Summary

Fixes Story 6-3: the PrimeNG `p-fileUpload` widget's internal files array was not cleared after a successful upload (or manual cancel), so reopening the Upload Files modal for a new session still rendered the prior selection.

- Inject the PrimeNG `FileUpload` widget into `UploadModalComponent` via `@ViewChild(FileUpload)` and call `this.fileUpload?.clear()` as the first statement of `resetModal()`. Optional chain guards against an undefined ViewChild before the dialog has rendered.
- Widget is RETAINED on upload failure: the `catch` branch of `uploadFiles()` never invokes `resetModal()`, and the 1500 ms auto-close `setTimeout` is scoped to the `try` path.
- New `upload-modal.component.spec.ts` covers four scenarios: success clears, error retains, manual cancel clears, undefined ViewChild is safe.

Local gate: `ng test` 356/356 SUCCESS, `ng build` OK (pre-existing lodash CJS warning unrelated).

Closes #75
