### PR TITLE
Send as: include @Human, upward panel, right-aligned layout (Story 7-3)

### DIFF
--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -31,17 +31,21 @@
   </p-floatlabel>
 
   <div class="button-group">
-    @if (humanAgents.length >= 2) {
-      <label class="send-as-label">Send as</label>
-      <p-dropdown
-        [options]="humanAgentOptions"
-        [(ngModel)]="selectedSender"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="Send as"
-        [showClear]="true"
-        size="small"
-      ></p-dropdown>
+    @if (humanAgents.length > 1) {
+      <div class="send-as-group">
+        <label class="send-as-label">Send as</label>
+        <p-dropdown
+          [options]="humanAgentOptions"
+          [(ngModel)]="selectedSender"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Send as"
+          [showClear]="true"
+          size="small"
+          appendTo="body"
+          [panelStyleClass]="'send-as-panel-up'"
+        ></p-dropdown>
+      </div>
     }
     <label class="send-to-label">Send to</label>
     <p-multiSelect

--- a/src/app/process/user-input/user-input.component.scss
+++ b/src/app/process/user-input/user-input.component.scss
@@ -7,7 +7,6 @@
     font-size: 0.8rem;
     color: #64748b;
     white-space: nowrap;
-    margin-left: auto;
   }
 
   .send-as-label {
@@ -16,8 +15,16 @@
     white-space: nowrap;
   }
 
-  p-dropdown {
-    margin-right: 0.5rem;
+  // Story 7-3: wrap the "Send as" label + dropdown so the pair right-aligns
+  // inside `.button-group`. `margin-left: auto` pushes the Send-as group
+  // (and, by proximity, the Send-to cluster that follows it) to the right
+  // edge of the row.
+  .send-as-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-left: auto;
   }
 
   p-multiSelect {
@@ -25,6 +32,10 @@
     min-width: 150px;
   }
 }
+
+// Story 7-3 note: the `.send-as-panel-up` overlay rule lives in
+// `src/styles.scss` because `appendTo="body"` renders the PrimeNG panel
+// outside the component's scoped styles. See that file for the rule.
 
 .reply-indicator {
   display: flex;

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -8,6 +8,7 @@ import { ChatService } from '../../services/chat.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorAddress } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
+import { makeAgentNameUserFriendly } from '../../lib/util';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
   return {
@@ -299,7 +300,7 @@ describe('ProcessUserInputComponent', () => {
       expect(component.selectedSender).toBeNull();
     });
 
-    it('populates humanAgents with role === Human and actorName !== @Human', () => {
+    it('populates humanAgents with role === Human (Story 7-3)', () => {
       nodesSubject.next([
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
         makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
@@ -307,29 +308,39 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
       ]);
 
-      expect(component.humanAgents.length).toBe(2);
+      // Story 7-3: @Human is now INCLUDED alongside other human-role nodes.
+      expect(component.humanAgents.length).toBe(3);
       expect(component.humanAgents.map((n) => n.actorName)).toEqual([
         '@Support',
         '@Operator',
+        '@Human',
       ]);
       expect(component.humanAgentOptions.map((o) => o.value)).toEqual([
         '@Support',
         '@Operator',
+        '@Human',
       ]);
       // Labels come from makeAgentNameUserFriendly (passes @Support through
       // as-is since there is no '-' role segment).
       expect(component.humanAgentOptions[0].label).toBe('@Support');
     });
 
-    it('excludes the entry-point @Human even when role === Human', () => {
+    it('includes the entry-point @Human when role === Human (Story 7-3)', () => {
       nodesSubject.next([
         makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
       ]);
 
-      expect(component.humanAgents.length).toBe(1);
-      expect(component.humanAgents[0].actorName).toBe('@Support');
-      expect(component.humanAgentOptions.map((o) => o.value)).not.toContain('@Human');
+      // Story 7-3 (AC #1, AC #2): the @Human entry point is a first-class
+      // selectable sender. The filter uses role === HUMAN_ROLE only.
+      expect(component.humanAgents.length).toBe(2);
+      expect(component.humanAgents.map((n) => n.actorName)).toContain('@Human');
+      expect(component.humanAgents.map((n) => n.actorName)).toContain('@Support');
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Human');
+      // AC #2: label for @Human uses the friendly helper, not a hard-coded string.
+      const humanOpt = component.humanAgentOptions.find((o) => o.value === '@Human');
+      expect(humanOpt).toBeTruthy();
+      expect(humanOpt!.label).toBe(makeAgentNameUserFriendly('@Human'));
     });
 
     it('excludes nodes whose role !== Human', () => {
@@ -354,9 +365,10 @@ describe('ProcessUserInputComponent', () => {
       expect(dropdown).toBeNull();
     });
 
-    it('is hidden when humanAgents.length === 1', () => {
+    it('is hidden when humanAgents.length === 1 (solo @Human) (Story 7-3)', () => {
+      // Story 7-3: humans include @Human; solo-@Human still hides dropdown.
       nodesSubject.next([
-        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
       ]);
       fixture.detectChanges();
 
@@ -364,16 +376,19 @@ describe('ProcessUserInputComponent', () => {
       expect(dropdown).toBeNull();
     });
 
-    it('is visible when humanAgents.length === 2 and carries humanAgentOptions', () => {
+    it('is visible when humanAgents.length === 2 (@Human + @Support) (Story 7-3)', () => {
+      // Story 7-3: threshold fires at 2 humans INCLUDING @Human.
       nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
         makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
-        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
       ]);
       fixture.detectChanges();
 
       const dropdown = fixture.nativeElement.querySelector('p-dropdown');
       expect(dropdown).not.toBeNull();
       expect(component.humanAgentOptions.length).toBe(2);
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Human');
+      expect(component.humanAgentOptions.map((o) => o.value)).toContain('@Support');
     });
 
     it('picking an option sets selectedSender to the option value', () => {
@@ -511,6 +526,36 @@ describe('ProcessUserInputComponent', () => {
       expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
       expect(component.userInput).toBe('   ');
     });
+
+    it('Priority 1: @Human as sender routes via sendMessageFromTo (Story 7-3)', async () => {
+      component.selectedSender = '@Human';
+      component.selectedAgents = ['@Manager'];
+      component.userInput = 'hello from human';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id', '@Human', '@Manager', 'hello from human',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
+
+    it('Priority 2: @Human as sender with no recipient auto-targets first dropdown agent (Story 7-3)', async () => {
+      component.selectedSender = '@Human';
+      component.selectedAgents = [];
+      component.userInput = 'auto-target from @Human';
+
+      await component.sendMessage();
+
+      const firstDropdownAgent = component.dropdownAgents[0]?.value;
+      expect(firstDropdownAgent).toBeTruthy();
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledOnceWith(
+        'test-team-id', '@Human', firstDropdownAgent!, 'auto-target from @Human',
+      );
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('');
+    });
   });
 
   describe('"Send as" dynamic state (Story 7-2)', () => {
@@ -584,6 +629,69 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
       ]);
       expect(component.selectedSender).toBeNull();
+    });
+
+    it('clears selectedSender === "@Human" when @Human disappears from the roster (Story 7-3)', () => {
+      // Initial: @Human + @Support both present, selectedSender = @Human
+      nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+      component.selectedSender = '@Human';
+
+      // Defensive case: @Human somehow removed (leaving only non-entry humans).
+      // The clear-on-fire predicate fires because @Human is no longer in humanAgents.
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+      ]);
+
+      expect(component.selectedSender).toBeNull();
+      expect(component.humanAgents.length).toBe(2);
+    });
+  });
+
+  describe('"Send as" layout and panel positioning (Story 7-3)', () => {
+    beforeEach(() => {
+      nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+      ]);
+      fixture.detectChanges();
+    });
+
+    it('renders p-dropdown with appendTo="body" (AC #14)', () => {
+      const dropdown = fixture.nativeElement.querySelector('p-dropdown');
+      expect(dropdown).not.toBeNull();
+      // In Angular dev-mode runtime, string inputs appear as DOM attributes.
+      // `appendTo` is bound as a literal string on the template, so it
+      // surfaces as an attribute on the <p-dropdown> element.
+      expect(dropdown.getAttribute('appendTo')).toBe('body');
+    });
+
+    it('renders p-dropdown with the upward panel style class configured (AC #14)', () => {
+      const dropdown = fixture.nativeElement.querySelector('p-dropdown');
+      expect(dropdown).not.toBeNull();
+      // [panelStyleClass] is an input binding — Angular reflects its current
+      // value via `ng-reflect-panel-style-class` in dev mode. Accept any
+      // deterministic channel that carries the class name.
+      const panelClass =
+        dropdown.getAttribute('ng-reflect-panel-style-class') ||
+        dropdown.getAttribute('panelStyleClass');
+      expect(panelClass).toContain('send-as-panel-up');
+    });
+
+    it('right-aligns the Send-as group inside .button-group (AC #15)', () => {
+      const group = fixture.nativeElement.querySelector('.send-as-group');
+      expect(group).not.toBeNull();
+      // The implementation uses both `justify-content: flex-end` (intra-group
+      // alignment) and `margin-left: auto` (pushes the group to the right
+      // inside `.button-group`). Either is acceptable evidence that the
+      // Send-as block is right-aligned.
+      const style = window.getComputedStyle(group);
+      expect(
+        style.justifyContent === 'flex-end' || style.marginLeft === 'auto',
+      ).toBeTrue();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -80,12 +80,13 @@ export class ProcessUserInputComponent implements OnInit {
           agents.some((n) => n.actorName === a),
         );
 
-        // "Send as" human selector (Story 7-1): populate humanAgents /
-        // humanAgentOptions from the same emission. Visibility is template-driven
-        // by humanAgents.length >= 2. Routing wiring is Story 7-2.
-        this.humanAgents = nodes.filter(
-          (n) => n.role === HUMAN_ROLE && n.actorName !== ENTRY_POINT_NAME,
-        );
+        // "Send as" human selector (Story 7-1, revised Story 7-3): populate
+        // humanAgents / humanAgentOptions from the same emission. Visibility is
+        // template-driven by humanAgents.length > 1. Routing wiring is
+        // Story 7-2. Story 7-3 drops the actorName !== ENTRY_POINT_NAME clause
+        // so @Human is a first-class selectable sender (ADR-007 Revision
+        // 2026-04-15, FR2 amendment).
+        this.humanAgents = nodes.filter((n) => n.role === HUMAN_ROLE);
         this.humanAgentOptions = this.humanAgents.map((n) => ({
           label: makeAgentNameUserFriendly(n.actorName),
           value: n.actorName,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -127,6 +127,16 @@ chat-wrapper {
   margin-top: 0.5rem;
 }
 
+// Story 7-3: PrimeNG `p-dropdown` overlay rendered with `appendTo="body"`.
+// The Send-as dropdown lives at the bottom of the chat panel, so opening
+// the panel downward would clip it below the viewport edge. This class,
+// passed via `[panelStyleClass]="'send-as-panel-up'"` on the trigger,
+// lifts the overlay above the trigger. `-100%` backs off its own height;
+// the extra `2.5rem` clears the trigger height (matching `size="small"`).
+.send-as-panel-up {
+  transform: translateY(calc(-100% - 2.5rem));
+}
+
 // markdown styles
 markdown {
 


### PR DESCRIPTION
## Summary

Story 7-3 — UX revision of the "Send as" human selector built in stories 7-1 (PR #70) and 7-2 (PR #74). Four narrow changes inside `src/app/process/user-input/`:

- **FR2 amendment — inclusive sender set:** drop `actorName !== ENTRY_POINT_NAME` from the `humanAgents` filter. `@Human` is now a first-class selectable sender alongside any other human-role node. Filter is `role === HUMAN_ROLE` only.
- **FR3 restated — visibility threshold:** template guard uses `@if (humanAgents.length > 1)` (canonical form, numerically equivalent to `>= 2`). The two humans counted now include `@Human`, so solo-`@Human` teams still hide the dropdown; the moment a second human joins, it appears with both options.
- **R3 — upward panel:** `<p-dropdown>` gets `appendTo="body"` + `[panelStyleClass]="'send-as-panel-up'"`. The overlay escapes the `.button-group` flex context so the panel is not clipped by the bottom-anchored input row. The `.send-as-panel-up` rule lives in `src/styles.scss` (global, because the panel renders outside scoped styles).
- **R4 — right-aligned group:** wrap the `@if` block in `<div class="send-as-group">` with `display: flex; justify-content: flex-end; margin-left: auto`. Removed the obsolete `.send-to-label { margin-left: auto }` and `p-dropdown { margin-right: 0.5rem }` rules that no longer make sense under the new grouping.

Routing is **unchanged** — the existing 4-priority table from ADR-007 Decision 2 (shipped by Story 7-2) handles `@Human` as a sender identically to any other human. No special-case. No backend changes.

ADR-007 is amended with a `## Revision 2026-04-15` section documenting FR2/FR3 amendments, the upward-panel decision, the right-align decision, the routing clarification (no special-case), and the dynamic-state note. Planning-doc amendment only; no executable code depends on the ADR.

## Test Evidence

- `ng test --watch=false`: **348/348 pass** (headless Chrome)
- `ng build`: success
- Spec updates:
  - Story 7-1 population tests flipped to assert `@Human` IS included when `role === Human`
  - Story 7-1 visibility fixtures updated: `length === 1` emits solo `@Human`; `length === 2` emits `@Human + @Support`
  - Two new Story 7-3 routing tests appended to the Story 7-2 `describe` block (`@Human`-as-sender, Priority 1 and Priority 2)
  - One new Story 7-3 dynamic-state test: `clears selectedSender === "@Human" when @Human disappears from the roster`
  - New Story 7-3 `describe('"Send as" layout and panel positioning')` block asserting `appendTo="body"`, `panelStyleClass` contains `send-as-panel-up`, and `.send-as-group` is right-aligned

## Review

Adversarial code review completed by Rex (BMM dev-reviewer):
- All 18 ACs validated against the implementation — every one IMPLEMENTED
- All 10 tasks marked [x] audited against the code/tests — all confirmed done
- Scope discipline (Golden Rule 4): all code changes within `packages/akgentic-frontend/`; ADR-007 amendment lives under `_bmad-output/akgentic-frontend/decisions/` as allowed
- ADR Reference Discipline (Golden Rule 8): no `assert "ADR-NNN" in ...` patterns; ADR references only in comments/docstrings/planning doc
- No HIGH or MEDIUM findings. A few LOW observations (SCSS transform tied to PrimeNG v19 DOM, obsolete `ENTRY_POINT_NAME` import kept for mention-items filter) were judged documentation-adequate per the story's explicit scope

Closes #76

Relates to #68, #72
Stacks on #74 (base branch: `feat/72-send-as-routing-and-dynamic-state`)
