### PR TITLE
fix: send-as dropdown panel positioning + placeholder duplicate

### DIFF
--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -39,11 +39,9 @@
           [(ngModel)]="selectedSender"
           optionLabel="label"
           optionValue="value"
-          placeholder="Send as"
+          placeholder="@Human"
           [showClear]="true"
           size="small"
-          appendTo="body"
-          [panelStyleClass]="'send-as-panel-up'"
         ></p-dropdown>
       </div>
     }

--- a/src/app/process/user-input/user-input.component.scss
+++ b/src/app/process/user-input/user-input.component.scss
@@ -25,6 +25,19 @@
     gap: 0.5rem;
     justify-content: flex-end;
     margin-left: auto;
+    // Positioning context for the upward-opening dropdown overlay below.
+    position: relative;
+  }
+
+  // Pin the Send-as dropdown panel above its trigger. The dropdown is
+  // rendered inline (no `appendTo="body"`), so the overlay is a child of
+  // `.send-as-group` and `bottom: 100%` resolves against the trigger's
+  // own height. ::ng-deep is required because PrimeNG renders the panel
+  // outside the component's scoped style boundary.
+  :host ::ng-deep .send-as-group .p-dropdown-panel {
+    top: auto !important;
+    bottom: 100%;
+    margin-bottom: 0.25rem;
   }
 
   p-multiSelect {
@@ -32,10 +45,6 @@
     min-width: 150px;
   }
 }
-
-// Story 7-3 note: the `.send-as-panel-up` overlay rule lives in
-// `src/styles.scss` because `appendTo="body"` renders the PrimeNG panel
-// outside the component's scoped styles. See that file for the rule.
 
 .reply-indicator {
   display: flex;

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -660,25 +660,20 @@ describe('ProcessUserInputComponent', () => {
       fixture.detectChanges();
     });
 
-    it('renders p-dropdown with appendTo="body" (AC #14)', () => {
+    it('renders p-dropdown inline (no appendTo="body") so the panel can pin to its trigger (AC #14)', () => {
       const dropdown = fixture.nativeElement.querySelector('p-dropdown');
       expect(dropdown).not.toBeNull();
-      // In Angular dev-mode runtime, string inputs appear as DOM attributes.
-      // `appendTo` is bound as a literal string on the template, so it
-      // surfaces as an attribute on the <p-dropdown> element.
-      expect(dropdown.getAttribute('appendTo')).toBe('body');
+      // Hotfix for Story 7-3: panel must be a child of `.send-as-group`
+      // so `bottom: 100%` resolves against the trigger. `appendTo="body"`
+      // moves the panel out of that positioning context and breaks layout.
+      expect(dropdown.getAttribute('appendTo')).toBeNull();
     });
 
-    it('renders p-dropdown with the upward panel style class configured (AC #14)', () => {
-      const dropdown = fixture.nativeElement.querySelector('p-dropdown');
+    it('renders the dropdown inside the .send-as-group positioning context (AC #14)', () => {
+      const group = fixture.nativeElement.querySelector('.send-as-group');
+      expect(group).not.toBeNull();
+      const dropdown = group.querySelector('p-dropdown');
       expect(dropdown).not.toBeNull();
-      // [panelStyleClass] is an input binding — Angular reflects its current
-      // value via `ng-reflect-panel-style-class` in dev mode. Accept any
-      // deterministic channel that carries the class name.
-      const panelClass =
-        dropdown.getAttribute('ng-reflect-panel-style-class') ||
-        dropdown.getAttribute('panelStyleClass');
-      expect(panelClass).toContain('send-as-panel-up');
     });
 
     it('right-aligns the Send-as group inside .button-group (AC #15)', () => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -127,16 +127,6 @@ chat-wrapper {
   margin-top: 0.5rem;
 }
 
-// Story 7-3: PrimeNG `p-dropdown` overlay rendered with `appendTo="body"`.
-// The Send-as dropdown lives at the bottom of the chat panel, so opening
-// the panel downward would clip it below the viewport edge. This class,
-// passed via `[panelStyleClass]="'send-as-panel-up'"` on the trigger,
-// lifts the overlay above the trigger. `-100%` backs off its own height;
-// the extra `2.5rem` clears the trigger height (matching `size="small"`).
-.send-as-panel-up {
-  transform: translateY(calc(-100% - 2.5rem));
-}
-
 // markdown styles
 markdown {
 


### PR DESCRIPTION
## Summary

Hotfix on top of #76 (Story 7-3). Fixes the broken Send-As dropdown panel position and a placeholder that duplicated its label.

- Drop `appendTo="body"` + the global `.send-as-panel-up` transform rule (overlay was floating far above the trigger because the transform over-corrected by the panel's own height while PrimeNG anchored to absolute coords).
- Position the panel inline: `.send-as-group { position: relative }` + `:host ::ng-deep .p-dropdown-panel { top: auto !important; bottom: 100%; margin-bottom: 0.25rem }`.
- Change placeholder `Send as` → `@Human` so the trigger signals the implicit default sender instead of echoing the adjacent label.
- Update the two stale spec assertions that pinned `appendTo="body"` and the panel style class.

348/348 unit tests pass; `ng build` clean.

Stacks on `feat/76-send-as-include-human-and-upward-panel` (PR #78).

Relates to #79
