### PR TITLE
feat: runtime config injection and enterprise auth for K8s deployment

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -2,13 +2,13 @@ FROM node:lts AS build
 
 WORKDIR /frontend
 
-COPY frontend/package*.json ./
+COPY package*.json ./
 RUN npm install
 
-COPY frontend/public ./public
-COPY frontend/src ./src
-COPY frontend/angular.json .
-COPY frontend/tsconfig*.json .
+COPY public ./public
+COPY src ./src
+COPY angular.json .
+COPY tsconfig*.json .
 
 ARG BUILD_MODE
 
@@ -21,7 +21,7 @@ FROM nginx:alpine
 COPY --from=build /frontend/dist/akgent-app/browser /usr/share/nginx/html
 
 # Copy nginx configuration for SPA routing
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Replace with caddy !
 # https://medium.com/@remast/simplest-webserver-for-angular-in-6-lines-e8dc12eddd42

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,12 +7,12 @@ import { MenubarModule } from 'primeng/menubar';
 import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
-import { environment } from '../environments/environment';
 import { isRunning } from './models/team.interface';
 import { emptyableCombineLatest } from './lib/util';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
+import { ConfigService } from './services/config.service';
 import { ContextService } from './services/context.service';
 import { FaviconService } from './services/favicon.service';
 import { ViewService } from './view.service';
@@ -33,8 +33,9 @@ import { ViewService } from './view.service';
 export class AppComponent {
   title = 'akgent-app';
   items: MenuItem[] | undefined;
-  logo: string = environment.logo;
-  hideLogin: boolean = environment.hideLogin;
+  private configService = inject(ConfigService);
+  logo: string = '';
+  hideLogin: boolean = true;
   processType: string = '';
   processConfigName: string = '';
   processRunning: boolean = false;
@@ -49,7 +50,12 @@ export class AppComponent {
   router = inject(Router);
 
   ngOnInit() {
-    this.faviconService.setFavicon(environment.favicon);
+    this.logo = this.configService.logo;
+    this.hideLogin = this.configService.hideLogin;
+    this.faviconService.setFavicon(this.configService.favicon);
+
+    // Fetch the authenticated user from the backend session
+    this.authService.checkAuth().subscribe();
     const destroyed = new Subject();
 
     this.destroyRef.onDestroy(() => {
@@ -128,7 +134,7 @@ export class AppComponent {
               ]
             : []),
         ].filter((item) =>
-          environment.hideHome ? item.label != 'Home' : true,
+          this.configService.hideHome ? item.label != 'Home' : true,
         );
       });
   }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { APP_INITIALIZER, ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -13,10 +13,10 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
-import { environment } from '../environments/environment';
 import customPreset from './app.theme';
 import { CredentialsInterceptor } from './credentials.interceptor';
 import { markedOptionsFactory } from './lib/util';
+import { ConfigService } from './services/config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -39,14 +39,18 @@ export const appConfig: ApplicationConfig = {
       },
     }),
     provideHttpClient(withInterceptorsFromDi()),
-    ...(environment.hideLogin
-      ? []
-      : [
-          {
-            provide: HTTP_INTERCEPTORS,
-            useClass: CredentialsInterceptor,
-            multi: true,
-          },
-        ]),
+    // Always register — the interceptor checks hideLogin at runtime
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: CredentialsInterceptor,
+      multi: true,
+    },
+    // Load runtime config before app renders
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (config: ConfigService) => () => config.load(),
+      deps: [ConfigService],
+      multi: true,
+    },
   ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,4 @@
 import { Routes } from '@angular/router';
-import { environment } from '../environments/environment';
 import { AuthGuard } from './auth.guard';
 import { HomeComponent } from './home/home.component';
 import { LoginComponent } from './login/login.component';
@@ -10,13 +9,13 @@ export const routes: Routes = [
     path: '',
     component: HomeComponent,
     title: 'Home page',
-    canActivate: environment.hideLogin ? [] : [AuthGuard],
+    canActivate: [AuthGuard],
   },
   {
     path: 'process/:id',
     component: ProcessComponent,
     title: 'Process page',
-    canActivate: environment.hideLogin ? [] : [AuthGuard],
+    canActivate: [AuthGuard],
   },
   { path: 'login', component: LoginComponent, title: 'Login page' },
 ];

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -3,26 +3,30 @@ import { CanActivate, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AuthService } from './services/auth.service';
+import { ConfigService } from './services/config.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
   authService: AuthService = inject(AuthService);
   router: Router = inject(Router);
+  config: ConfigService = inject(ConfigService);
 
   canActivate(): Observable<boolean> {
+    // Community tier: skip auth entirely
+    if (this.config.hideLogin) {
+      return of(true);
+    }
+
     return this.authService.checkAuth().pipe(
       map((user) => {
         if (user) {
-          // If the user data is returned, allow access
           return true;
         } else {
-          // Otherwise, redirect to the login page
           this.router.navigate(['/login']);
           return false;
         }
       }),
       catchError((err) => {
-        // If there is an error (e.g. 401), redirect to the login page
         this.router.navigate(['/login']);
         return of(false);
       })

--- a/src/app/credentials.interceptor.ts
+++ b/src/app/credentials.interceptor.ts
@@ -4,16 +4,22 @@ import {
   HttpInterceptor,
   HttpRequest,
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { ConfigService } from './services/config.service';
 
 @Injectable()
 export class CredentialsInterceptor implements HttpInterceptor {
+  private config = inject(ConfigService);
+
   intercept(
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    // Clone la requête et active withCredentials
+    // Community tier (hideLogin=true): pass through without credentials
+    if (this.config.hideLogin) {
+      return next.handle(req);
+    }
     const clonedReq = req.clone({ withCredentials: true });
     return next.handle(clonedReq);
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -14,8 +14,8 @@ import { TagModule } from 'primeng/tag';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 
-import { environment } from '../../environments/environment';
 import { AuthService } from '../services/auth.service';
+import { ConfigService } from '../services/config.service';
 import { ContextService } from '../services/context.service';
 
 @Component({
@@ -38,6 +38,7 @@ export class HomeComponent {
   contextService: ContextService = inject(ContextService);
   router: Router = inject(Router);
   authService: AuthService = inject(AuthService);
+  private config = inject(ConfigService);
 
   // Catalog entries for the team creation dropdown
   catalogEntries$ = new BehaviorSubject<any[]>([]);
@@ -74,7 +75,7 @@ export class HomeComponent {
     // Load the current context.
     this.context = await this.contextService.getTeams();
 
-    if (environment.hideHome) {
+    if (this.config.hideHome) {
       // If no team exists, create one using the first catalog entry.
       if (!this.context || this.context.length === 0) {
         const entry = this.selectedCatalogEntry$.value;

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -24,19 +24,17 @@
     <!-- Provider content area -->
     <div class="provider-content" *ngIf="loginProviders.length > 0">
 
-      <!-- Azure AD Provider -->
-      <div *ngIf="isProviderActive('azure') && isProviderEnabled('azure')" class="provider-panel">
-        <button (click)="loginAzure()" class="login-button azure-button">
-          <img src="microsoft_auth_button.svg" alt="Azure AD" class="icon" />
-        </button>
-      </div>
-
-      <!-- Google Provider -->
-      <div *ngIf="isProviderActive('google') && isProviderEnabled('google')" class="provider-panel">
-        <button (click)="loginGoogle()" class="login-button google-button">
-          <img src="google_auth_button.svg" alt="Google" class="icon" />
-        </button>
-      </div>
+      <!-- OAuth/OIDC Providers (azure, google, default, or any custom) -->
+      <ng-container *ngFor="let provider of loginProviders">
+        <div *ngIf="isOAuthProvider(provider) && isProviderActive(provider)" class="provider-panel">
+          <button (click)="loginOAuth(provider)" class="login-button oauth-button">
+            <img *ngIf="provider === 'azure'" src="microsoft_auth_button.svg" alt="Azure AD" class="icon" />
+            <img *ngIf="provider === 'google'" src="google_auth_button.svg" alt="Google" class="icon" />
+            <span *ngIf="provider !== 'azure' && provider !== 'google'" class="pi pi-sign-in"></span>
+            <span *ngIf="provider !== 'azure' && provider !== 'google'">{{ getProviderLabel(provider) }}</span>
+          </button>
+        </div>
+      </ng-container>
 
       <!-- API Key Provider -->
       <div *ngIf="isProviderActive('apikey') && isProviderEnabled('apikey')" class="provider-panel">

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,8 +2,8 @@ import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { environment } from '../../environments/environment';
 import { AuthService } from '../services/auth.service';
+import { ConfigService } from '../services/config.service';
 import { AuthProvider } from '../models/auth.types';
 
 @Component({
@@ -14,13 +14,15 @@ import { AuthProvider } from '../models/auth.types';
   standalone: true,
 })
 export class LoginComponent {
+  private config = inject(ConfigService);
+
   // Configuration
-  logo: string = environment.logo;
-  welcomeMessage: string = environment.welcomeMessage;
-  apiBaseUrl: string = environment.api;
+  logo: string = this.config.logo;
+  welcomeMessage: string = this.config.welcomeMessage;
+  apiBaseUrl: string = this.config.api;
 
   // Multi-provider configuration
-  loginProviders: AuthProvider[] = environment.loginProviders;
+  loginProviders: AuthProvider[] = this.config.loginProviders;
 
   // UI State
   activeProvider: AuthProvider | '';
@@ -61,28 +63,23 @@ export class LoginComponent {
   }
 
   getProviderLabel(provider: AuthProvider): string {
-    const labels: Record<AuthProvider, string> = {
+    const labels: Record<string, string> = {
       azure: 'Azure AD',
       google: 'Google',
-      apikey: 'API Key'
+      apikey: 'API Key',
+      default: 'Sign In',
     };
     return labels[provider] || provider.charAt(0).toUpperCase() + provider.slice(1);
   }
 
-  /**
-   * Redirects the user to the backend endpoint that initiates
-   * the Azure AD OAuth 2.0 authorization flow.
-   */
-  loginAzure(): void {
-    window.location.href = `${this.apiBaseUrl}/auth/login/azure`;
+  /** Returns true if the provider is an OAuth/OIDC provider (not API key). */
+  isOAuthProvider(provider: AuthProvider): boolean {
+    return provider !== 'apikey';
   }
 
-  /**
-   * Redirects the user to the backend endpoint that initiates
-   * the Google OAuth 2.0 authorization flow.
-   */
-  loginGoogle(): void {
-    window.location.href = `${this.apiBaseUrl}/auth/login/google`;
+  /** Redirects to the backend OAuth login endpoint for any provider. */
+  loginOAuth(provider: AuthProvider): void {
+    window.location.href = `${this.apiBaseUrl}/auth/login/${provider}`;
   }
 
   /**

--- a/src/app/models/auth.types.ts
+++ b/src/app/models/auth.types.ts
@@ -1,4 +1,4 @@
-export type AuthProvider = 'azure' | 'google' | 'apikey';
+export type AuthProvider = 'azure' | 'google' | 'apikey' | 'default' | (string & {});
 
 export interface Environment {
   production: boolean;

--- a/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
+++ b/src/app/process/agent-tabs/akgent-state/akgent-state.component.ts
@@ -15,8 +15,8 @@ import { ButtonModule } from 'primeng/button';
 import { TextareaModule } from 'primeng/textarea';
 import { MessageService } from 'primeng/api';
 
-import { environment } from '../../../../environments/environment';
 import { AkgentService } from '../../../services/akgent.service';
+import { ConfigService } from '../../../services/config.service';
 import { ActorMessageService } from '../../../services/message.service';
 
 @Component({
@@ -31,6 +31,7 @@ export class AkgentStateComponent {
 
   akgentService: AkgentService = inject(AkgentService);
   actorMessageService: ActorMessageService = inject(ActorMessageService);
+  private config = inject(ConfigService);
   toastService: MessageService = inject(MessageService);
   formBuider: FormBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
@@ -95,7 +96,7 @@ export class AkgentStateComponent {
   }
 
   mapKeysToUserFriendlyNames(key: string): string {
-    if (environment.production) {
+    if (this.config.production) {
       if (key === 'Backstory') {
         return 'Objectives';
       } else if (key === 'Support Ticket') {

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -10,8 +10,8 @@ import { MultiSelectModule } from 'primeng/multiselect';
 import { TextareaModule } from 'primeng/textarea';
 import { MentionModule } from 'angular-mentions';
 
-import { environment } from '../../../environments/environment';
 import { makeAgentNameUserFriendly } from '../../lib/util';
+import { ConfigService } from '../../services/config.service';
 
 import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
@@ -41,8 +41,9 @@ export class ProcessUserInputComponent implements OnInit {
   apiService: ApiService = inject(ApiService);
   chatService: ChatService = inject(ChatService);
   graphDataService: GraphDataService = inject(GraphDataService);
+  private config = inject(ConfigService);
   userInput: string = '';
-  userInputEnterKeySubmit: boolean = environment.userInputEnterKeySubmit;
+  userInputEnterKeySubmit: boolean = this.config.userInputEnterKeySubmit;
 
   // Mention configuration
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
+import { ConfigService } from './config.service';
 import { FetchService } from './fetch.service';
 import {
   TeamContext,
@@ -19,8 +19,9 @@ export class ApiService {
   fetchService: FetchService = inject(FetchService);
   authService: AuthService = inject(AuthService);
   router: Router = inject(Router);
+  private config = inject(ConfigService);
 
-  private apiUrl = environment.api;
+  private get apiUrl(): string { return this.config.api; }
 
   // --- Team CRUD (AC1) ---
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,52 +1,86 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { inject, Injectable } from '@angular/core';
+import { BehaviorSubject, from, Observable, of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { ConfigService } from './config.service';
+
+const ANONYMOUS_USER = { user_id: 'anonymous', email: '', name: 'Anonymous' };
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  private currentUserSubject = new BehaviorSubject<any>({
-    user_id: 'anonymous',
-    email: '',
-    name: 'Anonymous',
-  });
+  private config = inject(ConfigService);
+  private currentUserSubject = new BehaviorSubject<any>(ANONYMOUS_USER);
   currentUser$ = this.currentUserSubject.asObservable();
 
-  /** Returns anonymous user immediately -- no server call (community tier). */
+  /**
+   * Check auth status against the backend.
+   * - Community tier (hideLogin=true): returns anonymous immediately.
+   * - Enterprise tier: calls GET /auth/me with session cookie.
+   */
   checkAuth(): Observable<any> {
-    return of({ user_id: 'anonymous', email: '', name: 'Anonymous' });
+    if (this.config.hideLogin) {
+      return of(ANONYMOUS_USER);
+    }
+
+    const options: RequestInit = { credentials: 'include' };
+    return from(
+      fetch(`${this.config.api}/auth/me`, options).then(async (r) => {
+        if (!r.ok) return null;
+        return r.json();
+      })
+    ).pipe(
+      tap((user) => {
+        if (user) {
+          // Ensure name is never empty — fall back to email or user_id
+          if (!user.name) {
+            user.name = user.email || user.user_id || 'User';
+          }
+          this.currentUserSubject.next(user);
+        } else {
+          this.currentUserSubject.next(ANONYMOUS_USER);
+        }
+      }),
+      catchError(() => {
+        this.currentUserSubject.next(ANONYMOUS_USER);
+        return of(null);
+      })
+    );
   }
 
-  /** Returns the current user value (anonymous for community tier). */
   get currentUserValue(): any {
     return this.currentUserSubject.value;
   }
 
-  // --- Backward-compatible stubs (Story 1.2 will remove these) ---
-
-  /** @deprecated No-op in community tier. */
+  /** @deprecated Use OAuth flow instead. */
   loginWithApiKey(_apiKey: string): Observable<any> {
     return of({ success: true, user: this.currentUserValue });
   }
 
-  /** @deprecated No-op in community tier. */
+  /** @deprecated */
   setApiKey(_apiKey: string): void {}
 
-  /** @deprecated No-op in community tier. */
+  /** @deprecated */
   clearApiKey(): void {}
 
-  /** @deprecated No-op in community tier. */
+  /** @deprecated */
   getApiKey(): string | null {
     return null;
   }
 
-  /** @deprecated No-op in community tier. */
+  /** @deprecated */
   getAuthHeaders(): any {
     return {};
   }
 
-  /** @deprecated No-op in community tier -- navigates to home. */
+  /** Logout: redirect to backend logout which clears session and redirects to IdP logout. */
   logout(): void {
-    console.warn('logout is a no-op in community tier');
+    if (this.config.hideLogin) {
+      return;
+    }
+    // Full browser redirect — the backend clears the session and redirects
+    // to the IdP's end_session_endpoint, which clears the SSO session and
+    // redirects back to /login.
+    window.location.href = `${this.config.api}/auth/logout`;
   }
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { Environment, AuthProvider } from '../models/auth.types';
+import { environment } from '../../environments/environment';
+
+/**
+ * Runtime configuration service.
+ *
+ * Fetches `/config.json` at app startup (via APP_INITIALIZER) and merges it
+ * over the build-time `environment.ts` defaults. In local dev (no config.json
+ * served), the build-time defaults are used as-is.
+ *
+ * All components and services should inject this service instead of importing
+ * `environment` directly.
+ */
+@Injectable({ providedIn: 'root' })
+export class ConfigService {
+  private config: Environment = { ...environment };
+
+  /** Called once by APP_INITIALIZER before the app renders. */
+  async load(): Promise<void> {
+    try {
+      const response = await fetch('/config.json');
+      if (response.ok) {
+        const runtime = await response.json();
+        this.config = { ...this.config, ...runtime };
+      }
+    } catch {
+      // config.json not available (local dev) — use build-time defaults
+    }
+  }
+
+  get api(): string {
+    return this.config.api;
+  }
+
+  get logo(): string {
+    return this.config.logo;
+  }
+
+  get welcomeMessage(): string {
+    return this.config.welcomeMessage;
+  }
+
+  get loginProviders(): AuthProvider[] {
+    return this.config.loginProviders;
+  }
+
+  get autoRedirectContext(): string {
+    return this.config.autoRedirectContext;
+  }
+
+  get hideHome(): boolean {
+    return this.config.hideHome;
+  }
+
+  get hideLogin(): boolean {
+    return this.config.hideLogin;
+  }
+
+  get initRightPanelCollapsed(): boolean {
+    return this.config.initRightPanelCollapsed;
+  }
+
+  get userInputEnterKeySubmit(): boolean {
+    return this.config.userInputEnterKeySubmit;
+  }
+
+  get favicon(): string {
+    return this.config.favicon;
+  }
+
+  get production(): boolean {
+    return this.config.production;
+  }
+}

--- a/src/app/services/feedback.service.ts
+++ b/src/app/services/feedback.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { environment } from '../../environments/environment';
+import { ConfigService } from './config.service';
 import { ChatMessage } from '../models/chat-message.model';
 import { chatFold } from './chat.service';
 import { FetchService } from './fetch.service';
@@ -22,6 +22,7 @@ export interface FeedbackBackend {
 export class FeedbackService {
   fetchService: FetchService = inject(FetchService);
   private readonly log: MessageLogService = inject(MessageLogService);
+  private config = inject(ConfigService);
 
   /** Snapshot of the current derived chat message list via `chatFold` over
    *  the unified message log. Replaces the pre-refactor
@@ -35,14 +36,14 @@ export class FeedbackService {
 
   async getFeedback(run_id: string): Promise<any> {
     const response = await this.fetchService.fetch({
-      url: `${environment.api}/get-feedback?run_id=${run_id}`,
+      url: `${this.config.api}/get-feedback?run_id=${run_id}`,
     });
     return response;
   }
 
   async setFeedback(run_id: string, feedback: Feedback) {
     const feedback_id = await this.fetchService.fetch({
-      url: `${environment.api}/set-feedback`,
+      url: `${this.config.api}/set-feedback`,
       options: {
         method: 'POST',
         body: JSON.stringify({

--- a/src/app/services/fetch.service.ts
+++ b/src/app/services/fetch.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, inject } from '@angular/core';
 import { MessageService } from 'primeng/api';
-import { environment } from '../../environments/environment';
+import { ConfigService } from './config.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FetchService {
   messageService: MessageService = inject(MessageService);
+  private config = inject(ConfigService);
 
   async fetch({
     url,
@@ -19,7 +20,7 @@ export class FetchService {
     successMessage?: string;
     errorMessage?: string;
   }): Promise<any> {
-    options = environment.hideLogin
+    options = this.config.hideLogin
       ? options
       : { ...options, credentials: 'include' };
     const response = await fetch(url, options);

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -3,7 +3,7 @@ import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 import { bufferTime, filter, take } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
-import { environment } from '../../environments/environment';
+import { ConfigService } from './config.service';
 import { AkgenticMessage } from '../models/message.types';
 import { EventResponse } from '../models/team.interface';
 
@@ -39,6 +39,7 @@ export class ActorMessageService {
   apiService: ApiService = inject(ApiService);
   chatService: ChatService = inject(ChatService);
   messageService: MessageService = inject(MessageService);
+  private config: ConfigService = inject(ConfigService);
   /**
    * Story 6.1 (ADR-005 §Decision 1): component-scoped append-only log of
    * every WS + REST-replay message. Story 6.2 migrated KG presence + KG
@@ -184,7 +185,7 @@ export class ActorMessageService {
     // V2: connect directly -- no ticket needed (community tier, AC8)
     const wsProtocol =
       window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-    const api = environment.api.replace(/(^\w+:|^)\/\//, '');
+    const api = this.config.api.replace(/(^\w+:|^)\/\//, '');
 
     // Story 4-10 (AC2): stopped-team path has already populated replay state
     // via HTTP getEvents() above — flip the spinner off BEFORE wiring up the

--- a/src/app/services/workspace.service.spec.ts
+++ b/src/app/services/workspace.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { environment } from '../../environments/environment';
+import { ConfigService } from './config.service';
 import { FetchService } from './fetch.service';
 import {
   MAX_UPLOAD_SIZE_BYTES,
@@ -46,6 +47,7 @@ describe('WorkspaceService', () => {
       providers: [
         WorkspaceService,
         { provide: FetchService, useValue: fetchServiceSpy },
+        { provide: ConfigService, useValue: { api: environment.api, hideLogin: environment.hideLogin } },
       ],
     });
 

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { environment } from '../../environments/environment';
+import { ConfigService } from './config.service';
 import { FetchService } from './fetch.service';
 
 export interface FileNode {
@@ -44,7 +44,9 @@ export const MAX_UPLOAD_SIZE_BYTES = 10_485_760;
 })
 export class WorkspaceService {
   fetchService: FetchService = inject(FetchService);
-  private apiUrl = environment.api;
+  private config = inject(ConfigService);
+
+  private get apiUrl(): string { return this.config.api; }
 
   async getWorkspaceTree(
     processId: string,
@@ -85,7 +87,7 @@ export class WorkspaceService {
     // Inline the credentials logic from fetch.service.ts so auth cookies
     // still propagate. See ADR-006 §Decision 2.2.
     const url = `${this.apiUrl}/workspace/${processId}/file?path=${encodeURIComponent(filePath)}`;
-    const options: RequestInit = environment.hideLogin
+    const options: RequestInit = this.config.hideLogin
       ? {}
       : { credentials: 'include' };
     const response = await fetch(url, options);

--- a/src/app/view.service.ts
+++ b/src/app/view.service.ts
@@ -1,13 +1,17 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { environment } from '../environments/environment';
+import { ConfigService } from './services/config.service';
 
-const INITIAL_COLLAPSED = environment.initRightPanelCollapsed;
 @Injectable({
   providedIn: 'root',
 })
 export class ViewService {
-  isRightColumnCollapsed$ = new BehaviorSubject<boolean>(INITIAL_COLLAPSED);
+  private config = inject(ConfigService);
+  isRightColumnCollapsed$ = new BehaviorSubject<boolean>(false);
+
+  constructor() {
+    this.isRightColumnCollapsed$.next(this.config.initRightPanelCollapsed);
+  }
 
   toggleRightColumn(): void {
     this.isRightColumnCollapsed$.next(!this.isRightColumnCollapsed$.value);


### PR DESCRIPTION
## Summary

- Replace build-time `environment.ts` imports with a runtime `ConfigService` that fetches `/config.json` at startup via `APP_INITIALIZER`, falling back to `environment.ts` defaults when absent (community edition).
- Wire `AuthService` to call `GET /auth/me` for session-based enterprise auth, with generic OAuth provider support in the login component (no hardcoded Azure/Google) and full logout via backend redirect to the IdP `end_session_endpoint`.
- Fix `frontend.Dockerfile` COPY paths to work from inside the frontend directory (one image for all environments, config via Helm ConfigMap).

Relates to #81