### PR TITLE
fix: remove trailing slash on catalog teams endpoint

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -155,7 +155,7 @@ export class ApiService {
 
   async getTeamConfigs(): Promise<any> {
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/catalog/api/teams/`,
+      url: `${this.apiUrl}/catalog/api/teams`,
     });
   }
 


### PR DESCRIPTION
## Summary
- Remove trailing slash on `/catalog/api/teams/` endpoint in `ApiService.getTeamConfigs()`
- Eliminates a 307 Temporary Redirect on every catalog teams fetch

Relates to #85

## Test plan
- [x] Verify no 307 redirect in server logs when loading the home page
- [x] Verify team configs still load correctly