### PR TITLE
feat: disable Submit when team is stopped

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,6 @@ import { MenubarModule } from 'primeng/menubar';
 import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
-import { isRunning } from './models/team.interface';
 import { emptyableCombineLatest } from './lib/util';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
@@ -73,10 +72,10 @@ export class AppComponent {
         if (processId) {
           try {
             const process =
-              await this.contextService.getCurrentTeam(processId);
+              await this.contextService.getCurrentTeam(processId, false);
             this.processType = process?.name || '';
             this.processConfigName = process?.config_name || '';
-            this.processRunning = process ? isRunning(process) : false;
+            this.processRunning = this.contextService.currentTeamRunning$.value;
           } catch (error) {
             console.error('Error fetching process:', error);
             this.processType = '';

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -88,7 +88,7 @@
           size="small"
           label="Submit"
           (click)="sendMessage()"
-          [disabled]="!userInput || isLoading"
+          [disabled]="!userInput || isLoading || !(contextService.currentTeamRunning$ | async)"
         >
           <ng-container *ngIf="isLoading; else refreshIcon">
             <i class="pi pi-spinner pi-spin"></i>

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -234,6 +234,7 @@ export class AkgentChatComponent {
   userInput = '';
   isLoading = false;
   async sendMessage() {
+    if (!this.contextService.currentTeamRunning$.value) return;
     this.isLoading = true;
     const processId = this.contextService.currentProcessId$.value;
     try {

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -62,7 +62,7 @@
       size="small"
       label="Submit"
       (click)="sendMessage()"
-      [disabled]="!userInput"
+      [disabled]="!userInput || !(contextService.currentTeamRunning$ | async)"
     />
   </div>
 </div>

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -15,6 +15,7 @@ import { ConfigService } from '../../services/config.service';
 
 import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
+import { ContextService } from '../../services/context.service';
 import { GraphDataService, HUMAN_ROLE } from '../../services/graph-data.service';
 
 import { ENTRY_POINT_NAME } from '../../models/chat-message.model';
@@ -40,6 +41,7 @@ export class ProcessUserInputComponent implements OnInit {
 
   apiService: ApiService = inject(ApiService);
   chatService: ChatService = inject(ChatService);
+  contextService: ContextService = inject(ContextService);
   graphDataService: GraphDataService = inject(GraphDataService);
   private config = inject(ConfigService);
   userInput: string = '';
@@ -126,7 +128,7 @@ export class ProcessUserInputComponent implements OnInit {
   }
 
   async sendMessage() {
-    if (!this.userInput || this.userInput.trim() === '') {
+    if (!this.contextService.currentTeamRunning$.value || !this.userInput || this.userInput.trim() === '') {
       return;
     }
 

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { ApiService } from './api.service';
-import { TeamContext } from '../models/team.interface';
+import { isRunning, TeamContext } from '../models/team.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -11,6 +11,9 @@ export class ContextService {
   apiService: ApiService = inject(ApiService);
   router: Router = inject(Router);
   currentProcessId$ = new BehaviorSubject<string>('');
+  /** Reactive running state of the current team. Updated by getCurrentTeam()
+   *  and reset when navigating away. Future: fed by homepage WebSocket. */
+  currentTeamRunning$ = new BehaviorSubject<boolean>(false);
 
   _context: TeamContext[] = [];
 
@@ -28,6 +31,7 @@ export class ContextService {
         (t: TeamContext) => t.team_id === teamId
       );
       if (cached) {
+        this.currentTeamRunning$.next(isRunning(cached));
         return cached;
       }
     }
@@ -38,6 +42,10 @@ export class ContextService {
       t.team_id === teamId ? team : t
     );
 
+    if (team) {
+      this.currentTeamRunning$.next(isRunning(team));
+    }
+
     return team;
   }
 
@@ -47,6 +55,7 @@ export class ContextService {
 
   async clear(teamId: string) {
     await this.deleteTeam(teamId);
+    this.currentTeamRunning$.next(false);
     await this.router.navigate(['/']);
   }
 


### PR DESCRIPTION
## Summary

- Adds a reactive `currentTeamRunning$: BehaviorSubject<boolean>` on `ContextService`, updated from both branches of `getCurrentTeam()` (cache-hit and fresh-fetch) and reset in `clear()`.
- Disables the Submit button in both `AkgentChatComponent` and `ProcessUserInputComponent` whenever the current team is not running (via `| async` in the templates) and short-circuits both `sendMessage()` methods before any routing logic kicks in.
- Switches `AppComponent` to `getCurrentTeam(processId, false)` (explicit cache-bypass) and sources `processRunning` from the reactive observable instead of calling `isRunning(process)` locally.

## Acceptance criteria

See the 12 ACs in `_bmad-output/akgentic-frontend/stories/2-5-disable-submit-when-team-stopped.md`. All 12 pass (verified by code review at `_bmad-output/akgentic-frontend/reviews/2-5-review.md`).

## Known gaps

Task 5 (unit test coverage) is deferred per the story section "Test coverage gap" and will land in a follow-up commit/PR on this branch before merge. Task 6 (CI green) is this PR's gating check.

## Test plan

- [ ] CI green on this PR
- [ ] Manual: start a team, stop it, verify both Submit buttons become disabled
- [ ] Manual: type in the input, try Enter — confirm `sendMessage()` is a no-op on a stopped team
- [ ] Manual: navigate away and back — confirm no stale `true` state leaks across navigations

Closes #88
