### PR TITLE
feat: deduplicate MessageLogService on REST+WS replay overlap

### DIFF
--- a/src/app/services/message-log.service.ts
+++ b/src/app/services/message-log.service.ts
@@ -56,17 +56,26 @@ export class MessageLogService {
 
   /** Append a single message to the log. Prefer `appendAll` when a batch is
    *  available — `appendAll` produces one `log$` emission per batch, whereas
-   *  calling `append` N times produces N emissions. */
+   *  calling `append` N times produces N emissions. Skips duplicates by `id`. */
   append(msg: AkgenticMessage): void {
+    if (msg.id && this._log$.value.some(m => m.id === msg.id)) return;
     this._log$.next([...this._log$.value, msg]);
   }
 
-  /** Append N messages in a single emission. Under ADR-005's frame-batched
-   *  ingestion (NFR7: N<1000) a plain array spread is acceptable — no need
-   *  for immutable-list data structures. */
+  /** Append N messages in a single emission, deduplicating by `id`.
+   *  Under ADR-005's frame-batched ingestion (NFR7: N<1000) a plain array
+   *  spread is acceptable — no need for immutable-list data structures.
+   *
+   *  Deduplication handles the case where a WS replay delivers events
+   *  already loaded via REST getEvents() (e.g., team restored while the
+   *  frontend is viewing the stopped team's history). */
   appendAll(msgs: AkgenticMessage[]): void {
     if (msgs.length === 0) return;
-    this._log$.next([...this._log$.value, ...msgs]);
+    const current = this._log$.value;
+    const existingIds = new Set(current.map(m => m.id).filter(Boolean));
+    const newMsgs = msgs.filter(m => !m.id || !existingIds.has(m.id));
+    if (newMsgs.length === 0) return;
+    this._log$.next([...current, ...newMsgs]);
   }
 
   /** Reset the log to empty. Called in `ActorMessageService.init()` step (b)


### PR DESCRIPTION
## Summary
- `MessageLogService.append()` and `appendAll()` now dedupe by `msg.id`.
- Id-less messages are always appended (system-synthetic events are not persisted and cannot duplicate).
- Full-duplicate `appendAll()` batches short-circuit — no emission, preserves OnPush array reference.

## Bug this closes
User on a stopped team's process page (history loaded via REST `getEvents()`) restores the team without navigating away. The fresh WS connection replays events already in the log. Pre-fix: every message / graph node / KG state renders twice. Post-fix: log is the union of REST + WS event ids, each present exactly once.

## Acceptance criteria
See the 12 ACs in `_bmad-output/akgentic-frontend/stories/5-4-message-log-dedup-on-rest-ws-replay-overlap.md`. All pass by inspection of this diff.

## Known gaps
- Task 3 (unit test coverage) is deferred per the story's §Test coverage gap and will land in a follow-up commit on this branch before merge.
- Task 4 (CI green) is this PR's gating check.

## Test plan
- [ ] CI green
- [ ] Manual: load a stopped team with recorded history in the process view. Restore the team without navigating away. Verify no duplicate messages in the chat, no duplicate nodes/edges in the graph, no KG-presence flicker during the restoration transition.
- [ ] Manual: navigate away and back to the restored team. Verify the log reloads cleanly (no stale duplicates surviving navigation).

Closes #90
