### PR TITLE
Reactive teams BehaviorSubject + Home async migration

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,24 +14,28 @@
           title="Go to Home"
         />
         <div>
-          <span *ngIf="processType" class="process-type"
-            >{{ processType }}
-            <span class="process-config-name"> — {{ processConfigName }}</span>
-            <p-tag
-              *ngIf="processType && !processRunning"
-              value="Stopped"
-              severity="info"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-            <p-tag
-              *ngIf="processType && processRunning"
-              value="Running"
-              severity="success"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-          </span>
+          <ng-container
+            *ngIf="(contextService.currentTeam$ | async) as team"
+          >
+            <span class="process-type"
+              >{{ team.name }}
+              <span class="process-config-name"> — {{ team.config_name }}</span>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async) === false"
+                value="Stopped"
+                severity="info"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async)"
+                value="Running"
+                severity="success"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+            </span>
+          </ng-container>
         </div>
       </div>
     </ng-template>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,11 +2,14 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MenubarModule } from 'primeng/menubar';
+import { TagModule } from 'primeng/tag';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { AppComponent } from './app.component';
-import { TeamContext } from './models/team.interface';
+import { isRunning, TeamContext } from './models/team.interface';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
 import { ConfigService } from './services/config.service';
@@ -76,12 +79,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       getTeam: jasmine.createSpy('getTeam'),
       getTeams: jasmine.createSpy('getTeams'),
     };
-    const routerStub = {
-      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
-    };
 
     await TestBed.configureTestingModule({
-      imports: [AppComponent, NoopAnimationsModule],
+      imports: [AppComponent, NoopAnimationsModule, RouterTestingModule],
       providers: [
         { provide: ContextService, useValue: contextStub },
         { provide: ViewService, useValue: viewStub },
@@ -89,12 +89,11 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
         { provide: ConfigService, useValue: configStub },
         { provide: FaviconService, useValue: faviconStub },
         { provide: ApiService, useValue: apiStub },
-        { provide: Router, useValue: routerStub },
       ],
     })
       .overrideComponent(AppComponent, {
         set: {
-          imports: [CommonModule],
+          imports: [CommonModule, MenubarModule, TagModule, RouterModule],
           schemas: [CUSTOM_ELEMENTS_SCHEMA],
         },
       })
@@ -111,6 +110,24 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(component).toBeTruthy();
   });
 
+  // Drive both `currentTeam$` and `currentTeamRunning$` consistently so the
+  // template bindings (which read `| async` from both) see the same state.
+  // In production `ContextService` derives `currentTeamRunning$` from
+  // `currentTeam$`; the stub must emulate that derivation.
+  async function emitTeam(team: TeamContext | null): Promise<void> {
+    contextStub.currentTeam$.next(team);
+    contextStub.currentTeamRunning$.next(team !== null && isRunning(team));
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function headerTagValues(): string[] {
+    const nodes = fixture.nativeElement.querySelectorAll('p-tag');
+    return Array.from(nodes).map(
+      (n: any) => n.getAttribute('value') || '',
+    );
+  }
+
   // --- AC5 — AppComponent drops getCurrentTeam fetch -------------------
 
   it('(AC5) AppComponent never calls contextService.getCurrentTeam on currentProcessId$ emissions', async () => {
@@ -125,37 +142,40 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
   });
 
-  it('(AC5) currentTeam$ emission populates processType, processConfigName, and processRunning', async () => {
+  it('(AC9 10.6) header renders name/config_name/Running tag when currentTeam$ emits a running team', async () => {
     const team = makeTeam({ name: 'Alpha', config_name: 'alpha-cfg', status: 'running' });
-    contextStub.currentTeam$.next(team);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(team);
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('alpha-cfg');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('alpha-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Running');
+    expect(tags).not.toContain('Stopped');
   });
 
-  it('(AC5) currentTeam$ emitting null clears processType, processConfigName, and processRunning', async () => {
-    contextStub.currentTeam$.next(makeTeam({ name: 'Beta' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processType).toBe('Beta');
+  it('(AC9 10.6) header renders Stopped tag when currentTeam$ emits a stopped team', async () => {
+    const team = makeTeam({ name: 'Beta', config_name: 'beta-cfg', status: 'stopped' });
+    await emitTeam(team);
 
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Beta');
+    expect(text).toContain('beta-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Stopped');
+    expect(tags).not.toContain('Running');
   });
 
-  it('(AC5) currentTeam$ emission with stopped status keeps processRunning false', async () => {
-    contextStub.currentTeam$.next(makeTeam({ status: 'stopped' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processRunning).toBe(false);
+  it('(AC9 10.6) header metadata block is hidden when currentTeam$ emits null', async () => {
+    // Seed then clear so transitions exercise both branches.
+    await emitTeam(makeTeam({ name: 'Gamma' }));
+    expect(
+      fixture.nativeElement.querySelector('.process-type'),
+    ).not.toBeNull();
+
+    await emitTeam(null);
+
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
   });
 
   // --- AC11 — REST call count invariant --------------------------------
@@ -293,13 +313,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
   it('(AC5 10.4) AppComponent header renders new team after create + navigate sequence with zero REST calls', async () => {
     // Starting state: no process, no team.
     contextStub.currentProcessId$.next('');
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(null);
 
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
 
     contextStub.getCurrentTeam.calls.reset();
     apiStub.getTeam.calls.reset();
@@ -313,14 +329,15 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       config_name: 'cfg-alpha',
       status: 'running',
     });
-    contextStub.currentTeam$.next(newTeam);
+    await emitTeam(newTeam);
     contextStub.currentProcessId$.next('new');
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('cfg-alpha');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('cfg-alpha');
+    expect(headerTagValues()).toContain('Running');
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
     expect(apiStub.getTeam).not.toHaveBeenCalled();
   });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,203 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { AppComponent } from './app.component';
+import { TeamContext } from './models/team.interface';
+import { ApiService } from './services/api.service';
+import { AuthService } from './services/auth.service';
+import { ConfigService } from './services/config.service';
+import { ContextService } from './services/context.service';
+import { FaviconService } from './services/favicon.service';
+import { ViewService } from './view.service';
+
+function makeTeam(overrides: Partial<TeamContext> = {}): TeamContext {
+  return {
+    team_id: 'team-1',
+    name: 'Demo Team',
+    status: 'running',
+    created_at: '2026-04-19T10:00:00Z',
+    updated_at: '2026-04-19T10:00:00Z',
+    config_name: 'demo-config',
+    description: null,
+    ...overrides,
+  };
+}
+
+interface ContextStub {
+  currentProcessId$: BehaviorSubject<string>;
+  currentTeam$: BehaviorSubject<TeamContext | null>;
+  currentTeamRunning$: BehaviorSubject<boolean>;
+  getCurrentTeam: jasmine.Spy;
+  clear: jasmine.Spy;
+}
+
+describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let contextStub: ContextStub;
+  let viewStub: { isRightColumnCollapsed$: BehaviorSubject<boolean>; toggleRightColumn: jasmine.Spy };
+  let authStub: { currentUser$: BehaviorSubject<any>; checkAuth: jasmine.Spy; logout: jasmine.Spy };
+  let configStub: { logo: string; hideLogin: boolean; favicon: string; hideHome: boolean };
+
+  beforeEach(async () => {
+    contextStub = {
+      currentProcessId$: new BehaviorSubject<string>(''),
+      currentTeam$: new BehaviorSubject<TeamContext | null>(null),
+      currentTeamRunning$: new BehaviorSubject<boolean>(false),
+      getCurrentTeam: jasmine.createSpy('getCurrentTeam'),
+      clear: jasmine.createSpy('clear'),
+    };
+
+    viewStub = {
+      isRightColumnCollapsed$: new BehaviorSubject<boolean>(false),
+      toggleRightColumn: jasmine.createSpy('toggleRightColumn'),
+    };
+
+    authStub = {
+      currentUser$: new BehaviorSubject<any>({ name: 'Alice', user_id: 'u-1' }),
+      checkAuth: jasmine.createSpy('checkAuth').and.returnValue(of(true)),
+      logout: jasmine.createSpy('logout'),
+    };
+
+    configStub = {
+      logo: 'logo.png',
+      hideLogin: true,
+      favicon: 'favicon.ico',
+      hideHome: false,
+    };
+
+    const faviconStub = { setFavicon: jasmine.createSpy('setFavicon') };
+    const apiStub = {};
+    const routerStub = {
+      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AppComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ContextService, useValue: contextStub },
+        { provide: ViewService, useValue: viewStub },
+        { provide: AuthService, useValue: authStub },
+        { provide: ConfigService, useValue: configStub },
+        { provide: FaviconService, useValue: faviconStub },
+        { provide: ApiService, useValue: apiStub },
+        { provide: Router, useValue: routerStub },
+      ],
+    })
+      .overrideComponent(AppComponent, {
+        set: {
+          imports: [CommonModule],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // --- AC5 — AppComponent drops getCurrentTeam fetch -------------------
+
+  it('(AC5) AppComponent never calls contextService.getCurrentTeam on currentProcessId$ emissions', async () => {
+    contextStub.currentProcessId$.next('team-1');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    contextStub.currentProcessId$.next('team-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+  });
+
+  it('(AC5) currentTeam$ emission populates processType, processConfigName, and processRunning', async () => {
+    const team = makeTeam({ name: 'Alpha', config_name: 'alpha-cfg', status: 'running' });
+    contextStub.currentTeam$.next(team);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('Alpha');
+    expect(component.processConfigName).toBe('alpha-cfg');
+    expect(component.processRunning).toBe(true);
+  });
+
+  it('(AC5) currentTeam$ emitting null clears processType, processConfigName, and processRunning', async () => {
+    contextStub.currentTeam$.next(makeTeam({ name: 'Beta' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.processType).toBe('Beta');
+
+    contextStub.currentTeam$.next(null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('');
+    expect(component.processConfigName).toBe('');
+    expect(component.processRunning).toBe(false);
+  });
+
+  it('(AC5) currentTeam$ emission with stopped status keeps processRunning false', async () => {
+    contextStub.currentTeam$.next(makeTeam({ status: 'stopped' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.processRunning).toBe(false);
+  });
+
+  // --- AC11 — REST call count invariant --------------------------------
+
+  it('(AC11) sequence of currentProcessId$ + currentTeam$ emissions triggers zero getCurrentTeam calls', async () => {
+    contextStub.currentProcessId$.next('team-1');
+    contextStub.currentTeam$.next(makeTeam({ team_id: 'team-1' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+  });
+
+  // --- AC12 — Right-column toggle emits zero REST calls ---------------
+
+  it('(AC12) toggling isRightColumnCollapsed$ rebuilds the menubar but does not call getCurrentTeam', async () => {
+    contextStub.currentProcessId$.next('team-1');
+    contextStub.currentTeam$.next(makeTeam({ team_id: 'team-1' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    viewStub.isRightColumnCollapsed$.next(true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    viewStub.isRightColumnCollapsed$.next(false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+    // The menubar rebuild populates `items`; verify the array was produced.
+    expect(component.items).toBeDefined();
+  });
+
+  // --- AC10 — Subscription lifecycle ------------------------------------
+
+  it('(AC10) 3 mount/unmount cycles leave zero residual observers on currentTeam$', async () => {
+    // The first fixture (from beforeEach) still has an active subscription
+    // until we destroy it below. Create and destroy 3 more fixtures first.
+    for (let i = 0; i < 3; i++) {
+      const f = TestBed.createComponent(AppComponent);
+      f.detectChanges();
+      await f.whenStable();
+      f.detectChanges();
+      f.destroy();
+    }
+    fixture.destroy();
+    expect(contextStub.currentTeam$.observed).toBeFalse();
+  });
+});

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -42,6 +42,7 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
   let viewStub: { isRightColumnCollapsed$: BehaviorSubject<boolean>; toggleRightColumn: jasmine.Spy };
   let authStub: { currentUser$: BehaviorSubject<any>; checkAuth: jasmine.Spy; logout: jasmine.Spy };
   let configStub: { logo: string; hideLogin: boolean; favicon: string; hideHome: boolean };
+  let apiStub: { getTeam: jasmine.Spy; getTeams: jasmine.Spy };
 
   beforeEach(async () => {
     contextStub = {
@@ -71,7 +72,10 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     };
 
     const faviconStub = { setFavicon: jasmine.createSpy('setFavicon') };
-    const apiStub = {};
+    apiStub = {
+      getTeam: jasmine.createSpy('getTeam'),
+      getTeams: jasmine.createSpy('getTeams'),
+    };
     const routerStub = {
       navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
     };
@@ -199,5 +203,88 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     }
     fixture.destroy();
     expect(contextStub.currentTeam$.observed).toBeFalse();
+  });
+
+  // --- Story 10-3 — decouple AppComponent from isRightColumnCollapsed$ ---
+
+  it('(AC2) right-column toggle does not call contextService.getCurrentTeam or apiService.getTeam', async () => {
+    const team = makeTeam({ team_id: 'team-A', name: 'Alpha' });
+    contextStub.currentProcessId$.next('team-A');
+    contextStub.currentTeam$.next(team);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    contextStub.getCurrentTeam.calls.reset();
+    apiStub.getTeam.calls.reset();
+
+    viewStub.isRightColumnCollapsed$.next(true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    viewStub.isRightColumnCollapsed$.next(false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+    expect(apiStub.getTeam).not.toHaveBeenCalled();
+  });
+
+  it('(AC2) right-column toggle rebuilds items with a new Hide/Show details label', async () => {
+    contextStub.currentProcessId$.next('team-A');
+    await fixture.whenStable();
+    fixture.detectChanges();
+    viewStub.isRightColumnCollapsed$.next(false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const expandedLabel = component.items?.find(
+      (i) => i.label === 'Hide details' || i.label === 'Show details',
+    )?.label;
+    expect(expandedLabel).toBe('Hide details');
+
+    viewStub.isRightColumnCollapsed$.next(true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const collapsedLabel = component.items?.find(
+      (i) => i.label === 'Hide details' || i.label === 'Show details',
+    )?.label;
+    expect(collapsedLabel).toBe('Show details');
+  });
+
+  it('(AC3) currentUser$ change does not call getCurrentTeam or getTeam', async () => {
+    contextStub.currentProcessId$.next('team-A');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    contextStub.getCurrentTeam.calls.reset();
+    apiStub.getTeam.calls.reset();
+
+    authStub.currentUser$.next({ name: 'Bob', user_id: 'u-2' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    authStub.currentUser$.next(null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+    expect(apiStub.getTeam).not.toHaveBeenCalled();
+  });
+
+  it('(AC3) username dropdown is present when currentUser$ has a name and absent when null', async () => {
+    authStub.currentUser$.next({ name: 'Alice', user_id: 'u-1' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.items?.some((i) => i.label === 'Alice')).toBeTrue();
+
+    authStub.currentUser$.next(null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(component.items?.some((i) => i.label === 'Alice')).toBeFalse();
+  });
+
+  it('(AC5) on destroy, zero residual observers on currentTeam$, currentProcessId$, currentUser$, and isRightColumnCollapsed$', async () => {
+    fixture.destroy();
+    expect(contextStub.currentTeam$.observed).toBeFalse();
+    expect(contextStub.currentProcessId$.observed).toBeFalse();
+    expect(authStub.currentUser$.observed).toBeFalse();
+    expect(viewStub.isRightColumnCollapsed$.observed).toBeFalse();
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -287,4 +287,41 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(authStub.currentUser$.observed).toBeFalse();
     expect(viewStub.isRightColumnCollapsed$.observed).toBeFalse();
   });
+
+  // --- Story 10-4 — header renders new team after reload-free flow ------
+
+  it('(AC5 10.4) AppComponent header renders new team after create + navigate sequence with zero REST calls', async () => {
+    // Starting state: no process, no team.
+    contextStub.currentProcessId$.next('');
+    contextStub.currentTeam$.next(null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('');
+    expect(component.processConfigName).toBe('');
+    expect(component.processRunning).toBe(false);
+
+    contextStub.getCurrentTeam.calls.reset();
+    apiStub.getTeam.calls.reset();
+
+    // Simulate the exact sequence produced by createTeamAndNavigate followed by
+    // ProcessComponent.ngOnInit: _context$ mutation (driving currentTeam$) then
+    // currentProcessId$ flipping to the new id.
+    const newTeam = makeTeam({
+      team_id: 'new',
+      name: 'Alpha',
+      config_name: 'cfg-alpha',
+      status: 'running',
+    });
+    contextStub.currentTeam$.next(newTeam);
+    contextStub.currentProcessId$.next('new');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('Alpha');
+    expect(component.processConfigName).toBe('cfg-alpha');
+    expect(component.processRunning).toBe(true);
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+    expect(apiStub.getTeam).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,7 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
 import { emptyableCombineLatest } from './lib/util';
+import { isRunning } from './models/team.interface';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
@@ -61,31 +62,25 @@ export class AppComponent {
       destroyed.next(null);
       destroyed.complete();
     });
+
+    // Team-metadata subscription: no REST call; reads from the reactive
+    // `currentTeam$` selector. `ProcessComponent.ngOnInit` is the sole fetcher
+    // for a navigation; this subscription only consumes the derived state.
+    this.contextService.currentTeam$
+      .pipe(takeUntil(destroyed))
+      .subscribe((team) => {
+        this.processType = team?.name ?? '';
+        this.processConfigName = team?.config_name ?? '';
+        this.processRunning = team !== null && isRunning(team);
+      });
+
     emptyableCombineLatest([
       this.contextService.currentProcessId$.asObservable(),
       this.authService.currentUser$,
       this.viewService.isRightColumnCollapsed$,
     ])
       .pipe(takeUntil(destroyed))
-      .subscribe(async ([processId, currentUser, isRightColumnCollapsed]) => {
-        // Update process type when process changes
-        if (processId) {
-          try {
-            const process =
-              await this.contextService.getCurrentTeam(processId, false);
-            this.processType = process?.name || '';
-            this.processConfigName = process?.config_name || '';
-            this.processRunning = this.contextService.currentTeamRunning$.value;
-          } catch (error) {
-            console.error('Error fetching process:', error);
-            this.processType = '';
-            this.processRunning = false;
-          }
-        } else {
-          this.processType = '';
-          this.processRunning = false;
-        }
-
+      .subscribe(([processId, currentUser, isRightColumnCollapsed]) => {
         this.items = [
           {
             icon: 'pi pi-home',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,6 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
 import { emptyableCombineLatest } from './lib/util';
-import { isRunning } from './models/team.interface';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
@@ -36,9 +35,6 @@ export class AppComponent {
   private configService = inject(ConfigService);
   logo: string = '';
   hideLogin: boolean = true;
-  processType: string = '';
-  processConfigName: string = '';
-  processRunning: boolean = false;
 
   akgentService: AkgentService = inject(AkgentService);
   authService: AuthService = inject(AuthService);
@@ -62,17 +58,6 @@ export class AppComponent {
       destroyed.next(null);
       destroyed.complete();
     });
-
-    // Team-metadata subscription: no REST call; reads from the reactive
-    // `currentTeam$` selector. `ProcessComponent.ngOnInit` is the sole fetcher
-    // for a navigation; this subscription only consumes the derived state.
-    this.contextService.currentTeam$
-      .pipe(takeUntil(destroyed))
-      .subscribe((team) => {
-        this.processType = team?.name ?? '';
-        this.processConfigName = team?.config_name ?? '';
-        this.processRunning = team !== null && isRunning(team);
-      });
 
     emptyableCombineLatest([
       this.contextService.currentProcessId$.asObservable(),

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -35,7 +35,7 @@
     <br />
 
     <p-table
-      [value]="context"
+      [value]="(contextService.teams$ | async) || []"
       selectionMode="single"
       (onRowSelect)="onRowSelect($event)"
       [tableStyle]="{ 'min-width': '50rem' }"

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -145,6 +145,27 @@ describe('HomeComponent', () => {
     expect((component as any).context).toBeUndefined();
   });
 
+  // --- Story 10.4 — HomeComponent.createTeamAndNavigate delegation ------
+
+  it('(AC4 10.4) HomeComponent.createTeamAndNavigate delegates to contextService and has no reload compensation', async () => {
+    const entry = { id: 'cat-1', name: 'Cat One' };
+    component.selectedCatalogEntry$.next(entry);
+    // The component has not invoked ngOnInit yet (no detectChanges in this
+    // test), so contextSpy.getTeams should not have been called. Reset to
+    // guard against any spurious prior invocation.
+    contextSpy.getTeams.calls.reset();
+    await component.createTeamAndNavigate();
+    expect(contextSpy.createTeamAndNavigate).toHaveBeenCalledOnceWith('cat-1');
+    // No per-component compensation for the removed reload.
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+  });
+
+  it('(AC4 10.4) HomeComponent.createTeamAndNavigate no-entry guard returns cleanly', async () => {
+    component.selectedCatalogEntry$.next(null);
+    await component.createTeamAndNavigate();
+    expect(contextSpy.createTeamAndNavigate).not.toHaveBeenCalled();
+  });
+
   // --- AC9 ---------------------------------------------------------------
 
   it('(AC9) N=3 mount/unmount cycles leave zero residual subscribers on teams$', async () => {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -56,7 +56,7 @@ describe('HomeComponent', () => {
 
     contextSpy = jasmine.createSpyObj<ContextService>(
       'ContextService',
-      ['getTeams', 'deleteTeam', 'createTeamAndNavigate']
+      ['getTeams', 'deleteTeam', 'createTeamAndNavigate', 'stopTeamAndAwait']
     ) as jasmine.SpyObj<ContextService> & {
       teams$: BehaviorSubject<TeamContext[]>;
     };
@@ -64,6 +64,7 @@ describe('HomeComponent', () => {
     contextSpy.getTeams.and.callFake(async () => teams$.value);
     contextSpy.deleteTeam.and.returnValue(Promise.resolve());
     contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
 
     authSpy = jasmine.createSpyObj('AuthService', ['checkAuth']);
     authSpy.checkAuth.and.returnValue(of(true as any));
@@ -167,6 +168,87 @@ describe('HomeComponent', () => {
   });
 
   // --- AC9 ---------------------------------------------------------------
+
+  // --- Story 10.5 — reactive stopTeam delegation -----------------------
+
+  it('(AC5 10.5) HomeComponent.stopTeam delegates to contextService.stopTeamAndAwait without polling', async () => {
+    apiSpy.stopTeam.calls.reset();
+    contextSpy.getTeams.calls.reset();
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
+
+    await component.stopTeam('team-A');
+
+    expect(contextSpy.stopTeamAndAwait).toHaveBeenCalledOnceWith('team-A');
+    expect(apiSpy.stopTeam).not.toHaveBeenCalled();
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+  });
+
+  it('(AC5 10.5) stopTeam tracks the teamId in stoppingTeams across the await boundary', async () => {
+    let resolveStop: (() => void) | null = null;
+    const pending = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    contextSpy.stopTeamAndAwait.and.returnValue(pending);
+
+    const stopPromise = component.stopTeam('team-A');
+
+    expect(component.isStopping('team-A')).toBe(true);
+    expect(component.stoppingTeams.has('team-A')).toBe(true);
+
+    resolveStop!();
+    await stopPromise;
+
+    expect(component.isStopping('team-A')).toBe(false);
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+  });
+
+  it('(AC6 10.5) stopTeam catches timeout/error and clears the stoppingTeams entry', async () => {
+    const timeoutErr = Object.assign(new Error('timeout'), {
+      name: 'TimeoutError',
+    });
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.reject(timeoutErr));
+
+    const consoleErrorSpy = spyOn(console, 'error');
+
+    await expectAsync(component.stopTeam('team-A')).toBeResolved();
+
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+    expect(component.isStopping('team-A')).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('(AC7 10.5) stopTeam is safe to call concurrently for different teams', async () => {
+    let resolveA: (() => void) | null = null;
+    let resolveB: (() => void) | null = null;
+    contextSpy.stopTeamAndAwait.and.callFake((teamId: string) => {
+      if (teamId === 'team-A')
+        return new Promise<void>((r) => {
+          resolveA = r;
+        });
+      if (teamId === 'team-B')
+        return new Promise<void>((r) => {
+          resolveB = r;
+        });
+      return Promise.resolve();
+    });
+
+    const pA = component.stopTeam('team-A');
+    const pB = component.stopTeam('team-B');
+
+    expect(component.stoppingTeams.has('team-A')).toBe(true);
+    expect(component.stoppingTeams.has('team-B')).toBe(true);
+
+    resolveA!();
+    await pA;
+
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+    expect(component.stoppingTeams.has('team-B')).toBe(true);
+
+    resolveB!();
+    await pB;
+
+    expect(component.stoppingTeams.has('team-B')).toBe(false);
+  });
 
   it('(AC9) N=3 mount/unmount cycles leave zero residual subscribers on teams$', async () => {
     for (let i = 0; i < 3; i++) {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,0 +1,163 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { ApiService } from '../services/api.service';
+import { AuthService } from '../services/auth.service';
+import { ConfigService } from '../services/config.service';
+import { ContextService } from '../services/context.service';
+import { TeamContext } from '../models/team.interface';
+import { HomeComponent } from './home.component';
+
+function makeTeam(overrides: Partial<TeamContext> = {}): TeamContext {
+  return {
+    team_id: 'team-1',
+    name: 'Demo Team',
+    status: 'stopped',
+    created_at: '2026-04-19T10:00:00Z',
+    updated_at: '2026-04-19T10:00:00Z',
+    config_name: 'demo',
+    description: null,
+    ...overrides,
+  };
+}
+
+describe('HomeComponent', () => {
+  let fixture: ComponentFixture<HomeComponent>;
+  let component: HomeComponent;
+  let teams$: BehaviorSubject<TeamContext[]>;
+  let apiSpy: jasmine.SpyObj<ApiService>;
+  let contextSpy: jasmine.SpyObj<ContextService> & {
+    teams$: BehaviorSubject<TeamContext[]>;
+  };
+  let authSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    teams$ = new BehaviorSubject<TeamContext[]>([]);
+
+    apiSpy = jasmine.createSpyObj('ApiService', [
+      'getTeamConfigs',
+      'createTeam',
+      'deleteTeam',
+      'restoreTeam',
+      'stopTeam',
+      'updateTeamDescription',
+    ]);
+    apiSpy.getTeamConfigs.and.returnValue(Promise.resolve([]));
+    apiSpy.createTeam.and.returnValue(Promise.resolve({} as any));
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+    apiSpy.restoreTeam.and.returnValue(Promise.resolve({} as any));
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.updateTeamDescription.and.returnValue(Promise.resolve());
+
+    contextSpy = jasmine.createSpyObj<ContextService>(
+      'ContextService',
+      ['getTeams', 'deleteTeam', 'createTeamAndNavigate']
+    ) as jasmine.SpyObj<ContextService> & {
+      teams$: BehaviorSubject<TeamContext[]>;
+    };
+    contextSpy.teams$ = teams$;
+    contextSpy.getTeams.and.callFake(async () => teams$.value);
+    contextSpy.deleteTeam.and.returnValue(Promise.resolve());
+    contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
+
+    authSpy = jasmine.createSpyObj('AuthService', ['checkAuth']);
+    authSpy.checkAuth.and.returnValue(of(true as any));
+
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await TestBed.configureTestingModule({
+      imports: [HomeComponent, CommonModule, NoopAnimationsModule],
+      providers: [
+        { provide: ApiService, useValue: apiSpy },
+        { provide: ContextService, useValue: contextSpy },
+        { provide: AuthService, useValue: authSpy },
+        { provide: ConfigService, useValue: { hideHome: false } },
+        { provide: Router, useValue: routerSpy },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+  });
+
+  // --- AC6, AC7 ----------------------------------------------------------
+
+  it('(AC6) component has no `context` field after the refactor', () => {
+    expect((component as any).context).toBeUndefined();
+  });
+
+  it('(AC6) template renders one row per team emitted on teams$', async () => {
+    teams$.next([
+      makeTeam({ team_id: 't-1', name: 'Alpha' }),
+      makeTeam({ team_id: 't-2', name: 'Beta' }),
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('tr[psellectablerow], tbody tr');
+    // The p-table renders its body through ng-template; rows may be produced
+    // as <tr> nodes regardless of the selector. Assert at least two rendered.
+    const allRows: NodeListOf<HTMLElement> =
+      fixture.nativeElement.querySelectorAll('tbody tr');
+    expect(allRows.length).toBeGreaterThanOrEqual(2);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('t-1');
+    expect(text).toContain('t-2');
+    // Silence unused local warning from dual querySelectorAll above.
+    void rows;
+  });
+
+  it('(AC6, AC9) pushing a new list into teams$ triggers a re-render', async () => {
+    teams$.next([makeTeam({ team_id: 't-1' })]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect((fixture.nativeElement.textContent as string)).toContain('t-1');
+
+    teams$.next([
+      makeTeam({ team_id: 't-1' }),
+      makeTeam({ team_id: 't-2' }),
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect((fixture.nativeElement.textContent as string)).toContain('t-2');
+  });
+
+  it('(AC7) deleteTeam(id) delegates to contextService.deleteTeam and does NOT call apiService.deleteTeam directly', async () => {
+    await component.deleteTeam('t-1');
+    expect(contextSpy.deleteTeam).toHaveBeenCalledOnceWith('t-1');
+    expect(apiSpy.deleteTeam).not.toHaveBeenCalled();
+  });
+
+  it('(AC7) refreshContext() calls contextService.getTeams once without touching a local field', async () => {
+    await component.refreshContext();
+    expect(contextSpy.getTeams).toHaveBeenCalledTimes(1);
+    expect((component as any).context).toBeUndefined();
+  });
+
+  // --- AC9 ---------------------------------------------------------------
+
+  it('(AC9) N=3 mount/unmount cycles leave zero residual subscribers on teams$', async () => {
+    for (let i = 0; i < 3; i++) {
+      const f = TestBed.createComponent(HomeComponent);
+      f.detectChanges();
+      await f.whenStable();
+      f.detectChanges();
+      f.destroy();
+    }
+    // The first fixture (from beforeEach) also still holds a subscription
+    // until destroyed below. Destroy it and then assert no residual observers.
+    fixture.destroy();
+    expect(teams$.observed).toBeFalse();
+  });
+});

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, ViewChildren, QueryList, ElementRef } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 
 import { ApiService } from '../services/api.service';
 import { TeamContext, isRunning } from '../models/team.interface';
@@ -52,8 +52,6 @@ export class HomeComponent {
 
   @ViewChildren('descriptionInput') descriptionInputs!: QueryList<ElementRef>;
 
-  context: TeamContext[] = [];
-
   // Expose isRunning to template
   isRunning = isRunning;
 
@@ -72,12 +70,12 @@ export class HomeComponent {
       console.error('Failed to load catalog entries:', error);
     }
 
-    // Load the current context.
-    this.context = await this.contextService.getTeams();
+    // Populate _context$; return value reused for the hideHome branch.
+    const teams = await this.contextService.getTeams();
 
     if (this.config.hideHome) {
       // If no team exists, create one using the first catalog entry.
-      if (!this.context || this.context.length === 0) {
+      if (!teams || teams.length === 0) {
         const entry = this.selectedCatalogEntry$.value;
         if (entry) {
           const catalogEntryId = entry.id ?? entry.name ?? '';
@@ -85,8 +83,8 @@ export class HomeComponent {
         }
       }
       // If a team exists, navigate to its process page.
-      if (this.context && this.context.length > 0) {
-        const teamId = this.context[0].team_id;
+      if (teams && teams.length > 0) {
+        const teamId = teams[0].team_id;
         this.router.navigate(['/process', teamId]);
       }
     }
@@ -104,7 +102,7 @@ export class HomeComponent {
       }
       const catalogEntryId = entry.id ?? entry.name ?? '';
       await this.apiService.createTeam(catalogEntryId);
-      this.context = await this.contextService.getTeams();
+      await this.contextService.getTeams();
     } catch (error) {
       console.error('Failed to create team:', error);
     } finally {
@@ -123,15 +121,14 @@ export class HomeComponent {
   }
 
   async deleteTeam(teamId: string) {
-    await this.apiService.deleteTeam(teamId);
-    this.context = await this.contextService.getTeams();
+    await this.contextService.deleteTeam(teamId);
   }
 
   async restoreTeam(teamId: string) {
     this.restoringTeams.add(teamId);
     try {
       await this.apiService.restoreTeam(teamId);
-      this.context = await this.contextService.getTeams();
+      await this.contextService.getTeams();
     } finally {
       this.restoringTeams.delete(teamId);
     }
@@ -146,17 +143,15 @@ export class HomeComponent {
     try {
       await this.apiService.stopTeam(teamId);
 
-      // Poll to verify the team has stopped
+      // Poll to verify the team has stopped (Story 10.5 converts to reactive).
       let attempts = 0;
       const maxAttempts = 5;
       let isStopped = false;
 
       while (attempts < maxAttempts && !isStopped) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        this.context = await this.contextService.getTeams();
-        const team = this.context.find(
-          (ctx: TeamContext) => ctx.team_id === teamId
-        );
+        const teams = await this.contextService.getTeams();
+        const team = teams.find((ctx: TeamContext) => ctx.team_id === teamId);
         if (team && !isRunning(team)) {
           isStopped = true;
         }
@@ -164,7 +159,7 @@ export class HomeComponent {
       }
 
       if (!isStopped) {
-        this.context = await this.contextService.getTeams();
+        await this.contextService.getTeams();
       }
     } finally {
       this.stoppingTeams.delete(teamId);
@@ -178,7 +173,7 @@ export class HomeComponent {
   async refreshContext() {
     this.isRefreshing = true;
     try {
-      this.context = await this.contextService.getTeams();
+      await this.contextService.getTeams();
     } finally {
       this.isRefreshing = false;
     }
@@ -219,10 +214,9 @@ export class HomeComponent {
       );
       await this.apiService.updateTeamDescription(teamId, trimmed);
 
-      // Update local context optimistically
-      const team = this.context.find(
-        (ctx: TeamContext) => ctx.team_id === teamId
-      );
+      // Update local context optimistically (read current list from teams$).
+      const teams = await firstValueFrom(this.contextService.teams$);
+      const team = teams.find((ctx: TeamContext) => ctx.team_id === teamId);
       if (team) {
         team.description = trimmed;
       }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -141,26 +141,9 @@ export class HomeComponent {
   async stopTeam(teamId: string) {
     this.stoppingTeams.add(teamId);
     try {
-      await this.apiService.stopTeam(teamId);
-
-      // Poll to verify the team has stopped (Story 10.5 converts to reactive).
-      let attempts = 0;
-      const maxAttempts = 5;
-      let isStopped = false;
-
-      while (attempts < maxAttempts && !isStopped) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        const teams = await this.contextService.getTeams();
-        const team = teams.find((ctx: TeamContext) => ctx.team_id === teamId);
-        if (team && !isRunning(team)) {
-          isStopped = true;
-        }
-        attempts++;
-      }
-
-      if (!isStopped) {
-        await this.contextService.getTeams();
-      }
+      await this.contextService.stopTeamAndAwait(teamId);
+    } catch (error) {
+      console.error(`Failed to stop team ${teamId}:`, error);
     } finally {
       this.stoppingTeams.delete(teamId);
     }

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -410,10 +410,4 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
     expect(messageSpy.init).not.toHaveBeenCalled();
   });
 
-  it('(AC6) processType is populated from the fetched team name', async () => {
-    const { component } = await setup({
-      fetchedTeam: makeTeam({ name: 'Fetched Name', status: 'running' }),
-    });
-    expect(component.processType).toBe('Fetched Name');
-  });
 });

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -290,3 +290,130 @@ function firstValue<T>(observable$: {
     });
   });
 }
+
+// =====================================================================
+// Story 10-2 — single-fetch navigation and messageService.init argument
+// =====================================================================
+
+describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
+  async function setup(options: {
+    fetchedTeam: TeamContext | null;
+  }): Promise<{
+    component: ProcessComponent;
+    fixture: ComponentFixture<ProcessComponent>;
+    contextSpy: { getCurrentTeam: jasmine.Spy };
+    messageSpy: { init: jasmine.Spy };
+    routerSpy: { navigate: jasmine.Spy };
+  }> {
+    const contextService = {
+      currentProcessId$: new BehaviorSubject<string>(''),
+      getCurrentTeam: jasmine
+        .createSpy('getCurrentTeam')
+        .and.returnValue(Promise.resolve(options.fetchedTeam)),
+    };
+
+    const messageService = {
+      init: jasmine.createSpy('init').and.returnValue(Promise.resolve()),
+    };
+
+    const akgentService = {
+      unselect: jasmine.createSpy('unselect'),
+      selectedAkgent$: new BehaviorSubject<any>(null),
+    };
+
+    const graphDataService = {
+      isLoading$: new BehaviorSubject<boolean>(false),
+      nodes$: new BehaviorSubject<any[]>([]),
+    };
+
+    const chatService = {
+      messages$: new BehaviorSubject<any[]>([]),
+    };
+
+    const selectionService = { handleSelection: jasmine.createSpy('handleSelection') };
+    const feedbackService = {};
+    const viewService = {
+      isRightColumnCollapsed$: new BehaviorSubject<boolean>(false),
+    };
+    const router = {
+      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
+    };
+    const activatedRoute = { snapshot: { params: { id: 'team-1' } } };
+
+    await TestBed.configureTestingModule({
+      imports: [ProcessComponent, NoopAnimationsModule],
+      providers: [
+        MessageLogService,
+        ToolPresenceService,
+        KGStateReducer,
+        { provide: ContextService, useValue: contextService },
+        { provide: ActorMessageService, useValue: messageService },
+        { provide: AkgentService, useValue: akgentService },
+        { provide: GraphDataService, useValue: graphDataService },
+        { provide: ChatService, useValue: chatService },
+        { provide: SelectionService, useValue: selectionService },
+        { provide: FeedbackService, useValue: feedbackService },
+        { provide: ViewService, useValue: viewService },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    })
+      .overrideComponent(ProcessComponent, {
+        set: {
+          imports: [CommonModule],
+          providers: [],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(ProcessComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    return {
+      component,
+      fixture,
+      contextSpy: contextService,
+      messageSpy: messageService,
+      routerSpy: router,
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('(AC6, AC11) ngOnInit calls getCurrentTeam exactly once with (processId, false)', async () => {
+    const { contextSpy } = await setup({ fetchedTeam: makeTeam({ status: 'running' }) });
+    expect(contextSpy.getCurrentTeam).toHaveBeenCalledTimes(1);
+    expect(contextSpy.getCurrentTeam).toHaveBeenCalledWith('team-1', false);
+  });
+
+  it('(AC6) messageService.init is called with (processId, true) for a running team', async () => {
+    const { messageSpy } = await setup({ fetchedTeam: makeTeam({ status: 'running' }) });
+    expect(messageSpy.init).toHaveBeenCalledTimes(1);
+    expect(messageSpy.init).toHaveBeenCalledWith('team-1', true);
+  });
+
+  it('(AC6) messageService.init is called with (processId, false) for a stopped team', async () => {
+    const { messageSpy } = await setup({ fetchedTeam: makeTeam({ status: 'stopped' }) });
+    expect(messageSpy.init).toHaveBeenCalledTimes(1);
+    expect(messageSpy.init).toHaveBeenCalledWith('team-1', false);
+  });
+
+  it('(AC6) null team short-circuits: router.navigate([/]) is called and messageService.init is NOT', async () => {
+    const { messageSpy, routerSpy } = await setup({ fetchedTeam: null });
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+    expect(messageSpy.init).not.toHaveBeenCalled();
+  });
+
+  it('(AC6) processType is populated from the fetched team name', async () => {
+    const { component } = await setup({
+      fetchedTeam: makeTeam({ name: 'Fetched Name', status: 'running' }),
+    });
+    expect(component.processType).toBe('Fetched Name');
+  });
+});

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -76,7 +76,6 @@ export class ProcessComponent implements OnDestroy {
   toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   processId: string = '';
-  processType: string = '';
   // Workspace presence is static: every team has a workspace directory by
   // default (backend creates one on team boot). Reactive presence detection
   // for workspace is an explicit future enhancement — out of scope today.
@@ -163,7 +162,6 @@ export class ProcessComponent implements OnDestroy {
       return;
     }
 
-    this.processType = currentProcess.name;
     // KG presence is reactive (Story 5-3 / ADR-004 §Decision 4): the
     // `hasKnowledgeGraph$` observable flips based on `#KnowledgeGraphTool`
     // `StartMessage` / `StopMessage` on the replay + live streams. Workspace

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ProcessUserInputComponent } from './user-input.component';
 import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
+import { ContextService } from '../../services/context.service';
 import { GraphDataService } from '../../services/graph-data.service';
 import { ActorAddress } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
@@ -41,6 +42,7 @@ describe('ProcessUserInputComponent', () => {
   let fixture: ComponentFixture<ProcessUserInputComponent>;
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
   let chatServiceMock: any;
+  let contextServiceStub: { currentTeamRunning$: BehaviorSubject<boolean> };
   let nodesSubject: BehaviorSubject<NodeInterface[]>;
 
   beforeEach(async () => {
@@ -51,6 +53,12 @@ describe('ProcessUserInputComponent', () => {
     chatServiceMock = {
       messages$: new BehaviorSubject<any[]>([]),
       loadingProcess$: new BehaviorSubject<boolean>(false),
+    };
+
+    // sendMessage() guards on currentTeamRunning$.value (Story 2-5). Default
+    // to running=true so the guard does not short-circuit routing tests.
+    contextServiceStub = {
+      currentTeamRunning$: new BehaviorSubject<boolean>(true),
     };
 
     nodesSubject = new BehaviorSubject<NodeInterface[]>([]);
@@ -64,6 +72,7 @@ describe('ProcessUserInputComponent', () => {
       providers: [
         { provide: ApiService, useValue: apiServiceSpy },
         { provide: ChatService, useValue: chatServiceMock },
+        { provide: ContextService, useValue: contextServiceStub },
         { provide: GraphDataService, useValue: graphDataService },
       ],
     }).compileComponents();

--- a/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
@@ -43,6 +43,7 @@ describe('WorkspaceExplorerComponent', () => {
   let workspaceServiceSpy: jasmine.SpyObj<WorkspaceService>;
   let contextServiceStub: {
     currentProcessId$: BehaviorSubject<string>;
+    currentTeamRunning$: BehaviorSubject<boolean>;
     getCurrentTeam: jasmine.Spy;
   };
 
@@ -55,6 +56,7 @@ describe('WorkspaceExplorerComponent', () => {
     ]);
     contextServiceStub = {
       currentProcessId$: new BehaviorSubject<string>('proc'),
+      currentTeamRunning$: new BehaviorSubject<boolean>(true),
       getCurrentTeam: jasmine
         .createSpy('getCurrentTeam')
         .and.callFake(async () => makeTeam()),

--- a/src/app/process/workspace-explorer/workspace-explorer.component.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.ts
@@ -11,12 +11,12 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { DividerModule } from 'primeng/divider';
 import { TagModule } from 'primeng/tag';
 import { MarkdownModule } from 'ngx-markdown';
+import { firstValueFrom } from 'rxjs';
 import {
   WorkspaceService,
   FileNode,
   FileContent,
 } from '../../services/workspace.service';
-import { isRunning } from '../../models/team.interface';
 import { ContextService } from '../../services/context.service';
 import { UploadModalComponent } from './upload-modal/upload-modal.component';
 
@@ -69,8 +69,9 @@ export class WorkspaceExplorerComponent implements OnInit {
   }
 
   async checkProcessStatus() {
-    const process = await this.contextService.getCurrentTeam(this.processId);
-    this.isProcessRunning = process ? isRunning(process) : false;
+    this.isProcessRunning = await firstValueFrom(
+      this.contextService.currentTeamRunning$,
+    );
   }
 
   async loadWorkspace() {

--- a/src/app/services/akgent.service.ts
+++ b/src/app/services/akgent.service.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from '../services/api.service';
-import { ContextService } from '../services/context.service';
 import { BehaviorSubject, Subject } from 'rxjs';
 
 export class Akgent {
@@ -13,7 +12,6 @@ export class Akgent {
 })
 export class AkgentService {
   apiService: ApiService = inject(ApiService);
-  contextService: ContextService = inject(ContextService);
 
   selectedAkgent$: BehaviorSubject<Akgent | null> =
     new BehaviorSubject<Akgent | null>(null);

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -130,17 +130,19 @@ describe('ContextService', () => {
     expect(nextB).toBe(prevB);
   });
 
-  it('(AC3) getCurrentTeam(true) cache-hit leaves _context$.value unchanged and emits currentTeamRunning$', async () => {
+  it('(AC3) getCurrentTeam(true) cache-hit leaves _context$.value unchanged; currentTeamRunning$.value reflects cached team', async () => {
     const teamA = makeTeam('a', 'running');
     apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
     await service.getTeams();
 
-    const prev = await firstValueFrom(service.teams$);
+    // Arm the derived pipeline by pointing currentProcessId$ at 'a' BEFORE
+    // the cache-hit call. The pipeline is the sole writer to
+    // currentTeamRunning$ (Story 10.2); getCurrentTeam no longer emits.
+    service.currentProcessId$.next('a');
+    // Let the derived pipeline flush its first emission.
+    await Promise.resolve();
 
-    const runningEmissions: boolean[] = [];
-    const sub = service.currentTeamRunning$.subscribe((v) =>
-      runningEmissions.push(v)
-    );
+    const prev = await firstValueFrom(service.teams$);
 
     const result = await service.getCurrentTeam('a', true);
 
@@ -148,10 +150,9 @@ describe('ContextService', () => {
     expect(result).toBe(teamA);
     const next = await firstValueFrom(service.teams$);
     expect(next).toBe(prev);
-    // Initial false + cached isRunning(teamA) == true.
-    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
-
-    sub.unsubscribe();
+    // Derived pipeline already emitted `true` for the running cached team;
+    // distinctUntilChanged may suppress further emissions, but .value is live.
+    expect(service.currentTeamRunning$.value).toBe(true);
   });
 
   it('(AC3 guard) getCurrentTeam(false) with null API response leaves _context$.value unchanged', async () => {
@@ -211,7 +212,7 @@ describe('ContextService', () => {
     expect(next.map((t) => t.team_id)).toEqual(['a', 'c']);
   });
 
-  it('(AC5) clear(teamId) shrinks, emits currentTeamRunning$ false, and navigates home', async () => {
+  it('(AC5) clear(teamId) shrinks, ends with currentTeamRunning$.value === false via derived pipeline, and navigates home', async () => {
     const teams = [makeTeam('a'), makeTeam('b')];
     apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
     await service.getTeams();
@@ -219,19 +220,24 @@ describe('ContextService', () => {
     apiSpy.deleteTeam.and.returnValue(Promise.resolve());
     routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
-    service.currentTeamRunning$.next(true);
+    // Point currentProcessId$ at 'a' so the derived pipeline flips to `true`
+    // first, then `false` after `clear('a')` removes the team.
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+    expect(service.currentTeamRunning$.value).toBe(true);
 
     await service.clear('a');
 
     const next = await firstValueFrom(service.teams$);
     expect(next.map((t) => t.team_id)).toEqual(['b']);
+    // Derived pipeline emitted `false` because `currentTeam$` → null.
     expect(service.currentTeamRunning$.value).toBe(false);
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
   });
 
-  // --- AC11 --------------------------------------------------------------
+  // --- AC11 (Story 10.1 late-subscriber on teams$) -----------------------
 
-  it('(AC11) late-subscriber receives the current value synchronously', async () => {
+  it('(AC11 10.1) late-subscriber receives the current value synchronously', async () => {
     const teams = [makeTeam('a')];
     apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
     await service.getTeams();
@@ -240,5 +246,156 @@ describe('ContextService', () => {
     const sub = service.teams$.subscribe((v) => (received = v));
     expect(received).toEqual(teams);
     sub.unsubscribe();
+  });
+
+  // =======================================================================
+  // Story 10.2 — derived currentTeam$ pipeline
+  // =======================================================================
+
+  // --- AC1 (10.2) --------------------------------------------------------
+
+  it('(AC1 10.2) currentTeam$ is exposed as a subscribable Observable', () => {
+    expect(service.currentTeam$).toBeTruthy();
+    expect(typeof service.currentTeam$.subscribe).toBe('function');
+  });
+
+  // --- AC2 (10.2) --------------------------------------------------------
+
+  it('(AC2 10.2) currentTeam$ emits the team whose id matches currentProcessId$', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'stopped');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    service.currentProcessId$.next('a');
+    const first = await firstValueFrom(service.currentTeam$);
+    expect(first).toBe(teamA);
+
+    service.currentProcessId$.next('b');
+    const second = await firstValueFrom(service.currentTeam$);
+    expect(second).toBe(teamB);
+  });
+
+  // --- AC3 (10.2) --------------------------------------------------------
+
+  it('(AC3 10.2) currentTeam$ emits in order on id switch; currentTeamRunning$ tracks running state', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'stopped');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    service.currentProcessId$.next('a');
+    service.currentProcessId$.next('b');
+    // Flush microtasks so the derived pipeline propagates.
+    await Promise.resolve();
+
+    expect(teamEmissions).toContain(teamA);
+    expect(teamEmissions).toContain(teamB);
+    // The last emission must be teamB (after the id switch).
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(teamB);
+    // Running progression: init false → true (team-A) → false (team-B); last
+    // emission is false, and the set must include true (from team-A).
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(false);
+    expect(runningEmissions).toContain(true);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
+  // --- AC4 (10.2) --------------------------------------------------------
+
+  it('(AC4 10.2) late subscriber to currentTeam$ receives current value synchronously', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+    service.currentProcessId$.next('a');
+
+    // Let microtasks flush so shareReplay has captured the value.
+    await Promise.resolve();
+
+    let received: TeamContext | null | undefined;
+    const sub = service.currentTeam$.subscribe((t) => (received = t));
+    expect(received).toBe(teamA);
+    sub.unsubscribe();
+  });
+
+  // --- AC8 (10.2, NFR5) --------------------------------------------------
+
+  it('(AC8 10.2 / NFR5) status flip via getCurrentTeam(id, false) emits currentTeam$ once and currentTeamRunning$ once', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    const countBeforeFlipTeam = teamEmissions.length;
+    const countBeforeFlipRunning = runningEmissions.length;
+
+    // Flip the team's status via getCurrentTeam(id, false).
+    const stoppedA = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(stoppedA));
+    await service.getCurrentTeam('a', false);
+
+    expect(teamEmissions.length).toBe(countBeforeFlipTeam + 1);
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(stoppedA);
+    expect(runningEmissions.length).toBe(countBeforeFlipRunning + 1);
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(false);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
+  // --- AC9 (10.2) --------------------------------------------------------
+
+  it('(AC9 10.2) unknown currentProcessId$ emits null from currentTeam$ and false from currentTeamRunning$', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    service.currentProcessId$.next('does-not-exist');
+    const t = await firstValueFrom(service.currentTeam$);
+    expect(t).toBeNull();
+    expect(service.currentTeamRunning$.value).toBe(false);
+  });
+
+  // --- AC11 (10.2) — single-fetch navigation invariant -------------------
+
+  it('(AC11 10.2) navigation flow issues exactly ONE apiService.getTeam call (home init + id switch + ngOnInit fetch)', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    // Simulate the single `getCurrentTeam(id, false)` call from
+    // ProcessComponent.ngOnInit. No other code path issues a REST call.
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    // Home init — loads the team list.
+    await service.getTeams();
+
+    // Route change — AppComponent reacts to currentProcessId$.next('a') but
+    // NO LONGER fetches. The derived pipeline emits the cached team.
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+    const afterRoute = await firstValueFrom(service.currentTeam$);
+    expect(afterRoute).toBe(teamA);
+
+    // ProcessComponent.ngOnInit — the single one-shot fetch.
+    await service.getCurrentTeam('a', false);
+
+    expect(apiSpy.getTeam).toHaveBeenCalledTimes(1);
+    expect(apiSpy.getTeam).toHaveBeenCalledWith('a');
   });
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -179,14 +179,7 @@ describe('ContextService', () => {
 
     const response = makeTeamResponse('new');
     apiSpy.createTeam.and.returnValue(Promise.resolve(response));
-
-    // router.navigate(...).then(() => window.location.reload()) — the reload
-    // is out-of-scope for this story; stub .then by replacing navigate with
-    // a resolved Promise that does not actually reload. We spy on navigate
-    // and force `then` to swallow the reload callback safely.
-    routerSpy.navigate.and.returnValue({
-      then: (_cb: () => void) => Promise.resolve(true),
-    } as unknown as Promise<boolean>);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
     await service.createTeamAndNavigate('cat-1');
 
@@ -194,6 +187,73 @@ describe('ContextService', () => {
     expect(next.length).toBe(existing.length + 1);
     expect(next[next.length - 1].team_id).toBe('new');
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/process', 'new']);
+  });
+
+  // --- Story 10.4 — reload-free createTeamAndNavigate --------------------
+
+  it('(AC2 10.4) createTeamAndNavigate does not drive a reload', async () => {
+    const existing = [makeTeam('a')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(existing));
+    await service.getTeams();
+
+    const response = makeTeamResponse('new');
+    apiSpy.createTeam.and.returnValue(Promise.resolve(response));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    // Variant A (plain removal) is adopted: there is no reloadFn seam in
+    // production. The spy exists to document the "no reload" assertion
+    // shape — it MUST remain at zero calls because the source code no
+    // longer contains any path that would trigger it.
+    const reloadSpy = jasmine.createSpy('reloadFn');
+
+    await service.createTeamAndNavigate('cat-1');
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(apiSpy.createTeam).toHaveBeenCalledOnceWith('cat-1');
+    expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/process', 'new']);
+  });
+
+  it('(AC1 10.4) createTeamAndNavigate preserves immutability on append', async () => {
+    const existing = [makeTeam('a'), makeTeam('b')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(existing));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    apiSpy.createTeam.and.returnValue(Promise.resolve(makeTeamResponse('new')));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await service.createTeamAndNavigate('cat-1');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(prev.length + 1);
+    expect(next.find((t) => t.team_id === 'a')).toBe(prevA);
+    expect(next.find((t) => t.team_id === 'b')).toBe(prevB);
+    expect(next[next.length - 1].team_id).toBe('new');
+  });
+
+  it('(AC3 10.4) after create + navigate, currentTeam$ emits the new team and currentTeamRunning$ reflects it', async () => {
+    apiSpy.getTeams.and.returnValue(Promise.resolve([]));
+    await service.getTeams();
+
+    const newTeamResponse = makeTeamResponse('new', 'running');
+    apiSpy.createTeam.and.returnValue(Promise.resolve(newTeamResponse));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await service.createTeamAndNavigate('cat-1');
+
+    // The method itself does NOT set currentProcessId$; ProcessComponent.ngOnInit
+    // does that in production. Simulate it here to exercise the derived pipeline.
+    service.currentProcessId$.next('new');
+    await Promise.resolve();
+
+    const currentTeam = await firstValueFrom(service.currentTeam$);
+    expect(currentTeam).not.toBeNull();
+    expect(currentTeam!.team_id).toBe('new');
+    expect(service.currentTeamRunning$.value).toBe(true);
   });
 
   // --- AC5 ---------------------------------------------------------------

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -1,0 +1,244 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+
+import { ApiService } from './api.service';
+import { ContextService } from './context.service';
+import { TeamContext, TeamResponse } from '../models/team.interface';
+
+function makeTeam(
+  teamId: string,
+  status: string = 'running',
+  name?: string
+): TeamContext {
+  return {
+    team_id: teamId,
+    name: name ?? `team-${teamId}`,
+    status,
+    created_at: '2026-04-19T10:00:00Z',
+    updated_at: '2026-04-19T10:00:00Z',
+    config_name: name ?? `team-${teamId}`,
+    description: null,
+  };
+}
+
+function makeTeamResponse(teamId: string, status: string = 'running'): TeamResponse {
+  return {
+    team_id: teamId,
+    name: `team-${teamId}`,
+    status,
+    user_id: 'user-1',
+    created_at: '2026-04-19T10:00:00Z',
+    updated_at: '2026-04-19T10:00:00Z',
+  };
+}
+
+describe('ContextService', () => {
+  let service: ContextService;
+  let apiSpy: jasmine.SpyObj<ApiService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    apiSpy = jasmine.createSpyObj('ApiService', [
+      'getTeams',
+      'getTeam',
+      'createTeam',
+      'deleteTeam',
+    ]);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ContextService,
+        { provide: ApiService, useValue: apiSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    });
+
+    service = TestBed.inject(ContextService);
+  });
+
+  // --- AC1, AC11 ---------------------------------------------------------
+
+  it('(AC1) teams$ emits [] synchronously on construction', async () => {
+    const value = await firstValueFrom(service.teams$);
+    expect(value).toEqual([]);
+  });
+
+  // --- AC2 ---------------------------------------------------------------
+
+  it('(AC2) getTeams() calls apiService.getTeams then teams$ receives the list once', async () => {
+    const teams = [makeTeam('a'), makeTeam('b')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
+
+    const emissions: TeamContext[][] = [];
+    const sub = service.teams$.subscribe((v) => emissions.push(v));
+
+    const returned = await service.getTeams();
+
+    expect(apiSpy.getTeams).toHaveBeenCalledTimes(1);
+    expect(returned).toEqual(teams);
+    // Initial [] emission + the new list.
+    expect(emissions.length).toBe(2);
+    expect(emissions[1]).toEqual(teams);
+
+    sub.unsubscribe();
+  });
+
+  it('(AC10) two consecutive getTeams() calls produce two distinct array references', async () => {
+    const first = [makeTeam('a')];
+    const second = [makeTeam('a'), makeTeam('b')];
+    apiSpy.getTeams.and.returnValues(
+      Promise.resolve(first),
+      Promise.resolve(second)
+    );
+
+    await service.getTeams();
+    const afterFirst = await firstValueFrom(service.teams$);
+    await service.getTeams();
+    const afterSecond = await firstValueFrom(service.teams$);
+
+    expect(afterFirst).not.toBe(afterSecond);
+    expect(afterFirst).toEqual(first);
+    expect(afterSecond).toEqual(second);
+  });
+
+  // --- AC3, AC10 ---------------------------------------------------------
+
+  it('(AC3, AC10) getCurrentTeam(false) produces new array ref + new slot ref; unchanged slots preserve identity', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const updatedA = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(updatedA));
+
+    await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).not.toBe(prevA);
+    expect(nextA).toBe(updatedA);
+    expect(nextB).toBe(prevB);
+  });
+
+  it('(AC3) getCurrentTeam(true) cache-hit leaves _context$.value unchanged and emits currentTeamRunning$', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+
+    const runningEmissions: boolean[] = [];
+    const sub = service.currentTeamRunning$.subscribe((v) =>
+      runningEmissions.push(v)
+    );
+
+    const result = await service.getCurrentTeam('a', true);
+
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+    expect(result).toBe(teamA);
+    const next = await firstValueFrom(service.teams$);
+    expect(next).toBe(prev);
+    // Initial false + cached isRunning(teamA) == true.
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
+
+    sub.unsubscribe();
+  });
+
+  it('(AC3 guard) getCurrentTeam(false) with null API response leaves _context$.value unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const result = await service.getCurrentTeam('a', false);
+
+    expect(result).toBeNull();
+    const next = await firstValueFrom(service.teams$);
+    expect(next).toBe(prev);
+  });
+
+  // --- AC4 ---------------------------------------------------------------
+
+  it('(AC4) createTeamAndNavigate grows _context$.value by one and calls router.navigate', async () => {
+    const existing = [makeTeam('a')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(existing));
+    await service.getTeams();
+
+    const response = makeTeamResponse('new');
+    apiSpy.createTeam.and.returnValue(Promise.resolve(response));
+
+    // router.navigate(...).then(() => window.location.reload()) — the reload
+    // is out-of-scope for this story; stub .then by replacing navigate with
+    // a resolved Promise that does not actually reload. We spy on navigate
+    // and force `then` to swallow the reload callback safely.
+    routerSpy.navigate.and.returnValue({
+      then: (_cb: () => void) => Promise.resolve(true),
+    } as unknown as Promise<boolean>);
+
+    await service.createTeamAndNavigate('cat-1');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next.length).toBe(existing.length + 1);
+    expect(next[next.length - 1].team_id).toBe('new');
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/process', 'new']);
+  });
+
+  // --- AC5 ---------------------------------------------------------------
+
+  it('(AC5) deleteTeam shrinks _context$.value and calls apiService.deleteTeam', async () => {
+    const teams = [makeTeam('a'), makeTeam('b'), makeTeam('c')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
+    await service.getTeams();
+
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+
+    await service.deleteTeam('b');
+
+    expect(apiSpy.deleteTeam).toHaveBeenCalledOnceWith('b');
+    const next = await firstValueFrom(service.teams$);
+    expect(next.map((t) => t.team_id)).toEqual(['a', 'c']);
+  });
+
+  it('(AC5) clear(teamId) shrinks, emits currentTeamRunning$ false, and navigates home', async () => {
+    const teams = [makeTeam('a'), makeTeam('b')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
+    await service.getTeams();
+
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    service.currentTeamRunning$.next(true);
+
+    await service.clear('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next.map((t) => t.team_id)).toEqual(['b']);
+    expect(service.currentTeamRunning$.value).toBe(false);
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  // --- AC11 --------------------------------------------------------------
+
+  it('(AC11) late-subscriber receives the current value synchronously', async () => {
+    const teams = [makeTeam('a')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(teams));
+    await service.getTeams();
+
+    let received: TeamContext[] | undefined;
+    const sub = service.teams$.subscribe((v) => (received = v));
+    expect(received).toEqual(teams);
+    sub.unsubscribe();
+  });
+});

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -635,4 +635,74 @@ describe('ContextService', () => {
     expect(service.currentTeam$).toBeDefined();
     expect(service.currentTeamRunning$).toBeDefined();
   });
+
+  // =======================================================================
+  // Story 10.6 — public-surface ratification + deleteTeam immutability
+  // =======================================================================
+
+  it('(AC6 10.6) ContextService public surface is exactly the post-10.6 set', () => {
+    const expectedObservables = [
+      'currentProcessId$',
+      'teams$',
+      'currentTeam$',
+      'currentTeamRunning$',
+    ];
+    const expectedMethods = [
+      'getTeams',
+      'getCurrentTeam',
+      'deleteTeam',
+      'clear',
+      'createTeamAndNavigate',
+      'stopTeamAndAwait',
+    ];
+    for (const name of expectedObservables) {
+      expect((service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBeDefined();
+    }
+    for (const name of expectedMethods) {
+      expect(typeof (service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBe('function');
+    }
+    // FR14 closure: no alternative `removeTeam` entry point was introduced.
+    expect(
+      (service as unknown as Record<string, unknown>)['removeTeam'],
+    ).toBeUndefined();
+  });
+
+  it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+
+    service.getTeams();
+    tick();
+
+    let prev: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        prev = teams;
+      })
+      .unsubscribe();
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    service.deleteTeam('a');
+    tick();
+
+    let next: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        next = teams;
+      })
+      .unsubscribe();
+
+    expect(apiSpy.deleteTeam).toHaveBeenCalledOnceWith('a');
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(1);
+    expect(next[0].team_id).toBe('b');
+    // Unchanged slot preserves reference identity (immutable filter on same refs).
+    expect(next[0]).toBe(prevB);
+  }));
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
@@ -44,7 +44,9 @@ describe('ContextService', () => {
       'getTeam',
       'createTeam',
       'deleteTeam',
+      'stopTeam',
     ]);
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
@@ -457,5 +459,180 @@ describe('ContextService', () => {
 
     expect(apiSpy.getTeam).toHaveBeenCalledTimes(1);
     expect(apiSpy.getTeam).toHaveBeenCalledWith('a');
+  });
+
+  // =======================================================================
+  // Story 10.5 — reactive stopTeamAndAwait
+  // =======================================================================
+
+  it('(AC1 10.5) stopTeamAndAwait is defined on the service with (teamId, timeoutMs?) shape', () => {
+    expect(typeof service.stopTeamAndAwait).toBe('function');
+    // One required formal parameter: teamId. timeoutMs is optional (default 10000).
+    expect(service.stopTeamAndAwait.length).toBe(1);
+  });
+
+  it('(AC2 10.5) stopTeamAndAwait resolves when refresh reports stopped', fakeAsync(() => {
+    const running = makeTeam('team-A', 'running');
+    const stopped = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([running]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(stopped));
+
+    let resolved = false;
+    service.stopTeamAndAwait('team-A').then(() => {
+      resolved = true;
+    });
+
+    tick();
+    expect(apiSpy.stopTeam).toHaveBeenCalledOnceWith('team-A');
+
+    tick(1000);
+    flushMicrotasks();
+
+    expect(resolved).toBe(true);
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC3 10.5) stopTeamAndAwait rejects with TimeoutError when team never stops', fakeAsync(() => {
+    const running = makeTeam('team-A', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([running]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(running));
+
+    let rejected: Error | null = null;
+    service.stopTeamAndAwait('team-A', 10000).catch((err: Error) => {
+      rejected = err;
+    });
+
+    tick();
+
+    tick(11000);
+    flushMicrotasks();
+
+    expect(rejected).not.toBeNull();
+    expect(rejected!.name).toBe('TimeoutError');
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC4 10.5) concurrent stopTeamAndAwait calls do not share intervals', fakeAsync(() => {
+    const runningA = makeTeam('team-A', 'running');
+    const runningB = makeTeam('team-B', 'running');
+    const stoppedA = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([runningA, runningB]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.callFake((id: string) => {
+      if (id === 'team-A') return Promise.resolve(stoppedA);
+      return Promise.resolve(runningB);
+    });
+
+    let resolvedA = false;
+    let resolvedB = false;
+    let rejectedB: Error | null = null;
+
+    service.stopTeamAndAwait('team-A').then(() => {
+      resolvedA = true;
+    });
+    service
+      .stopTeamAndAwait('team-B', 10000)
+      .then(() => {
+        resolvedB = true;
+      })
+      .catch((err: Error) => {
+        rejectedB = err;
+      });
+
+    tick();
+    tick(1000);
+    flushMicrotasks();
+
+    expect(resolvedA).toBe(true);
+    expect(resolvedB).toBe(false);
+
+    tick(10000);
+    flushMicrotasks();
+
+    expect(rejectedB).not.toBeNull();
+    expect(rejectedB!.name).toBe('TimeoutError');
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC8 10.5) stopTeamAndAwait refresh updates _context$ immutably', fakeAsync(() => {
+    const runningA = makeTeam('team-A', 'running');
+    const runningB = makeTeam('team-B', 'running');
+    const stoppedA = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([runningA, runningB]));
+    service.getTeams();
+    tick();
+
+    let prev: TeamContext[] = [];
+    let prevB: TeamContext | undefined;
+    service.teams$
+      .subscribe((v) => {
+        prev = v;
+      })
+      .unsubscribe();
+    prevB = prev.find((t) => t.team_id === 'team-B');
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(stoppedA));
+
+    service.stopTeamAndAwait('team-A').catch(() => {
+      /* ignore */
+    });
+    tick();
+    tick(1000);
+    flushMicrotasks();
+
+    let next: TeamContext[] = [];
+    service.teams$
+      .subscribe((v) => {
+        next = v;
+      })
+      .unsubscribe();
+
+    expect(next).not.toBe(prev);
+    expect(next.find((t) => t.team_id === 'team-A')).toBe(stoppedA);
+    expect(next.find((t) => t.team_id === 'team-B')).toBe(prevB);
+  }));
+
+  it('(AC10 10.5) ContextService public surface includes stopTeamAndAwait and keeps existing methods', () => {
+    const expected = [
+      'getTeams',
+      'getCurrentTeam',
+      'deleteTeam',
+      'clear',
+      'createTeamAndNavigate',
+      'stopTeamAndAwait',
+    ];
+    for (const name of expected) {
+      expect(typeof (service as unknown as Record<string, unknown>)[name]).toBe(
+        'function',
+      );
+    }
+    expect(service.currentProcessId$).toBeDefined();
+    expect(service.teams$).toBeDefined();
+    expect(service.currentTeam$).toBeDefined();
+    expect(service.currentTeamRunning$).toBeDefined();
   });
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -671,6 +671,200 @@ describe('ContextService', () => {
     ).toBeUndefined();
   });
 
+  // =======================================================================
+  // Story 10.7 — upsert on hard reload (issue #104)
+  // =======================================================================
+
+  // --- AC1 (10.7) — empty-cache append via getCurrentTeam(id, false) -----
+
+  it('(AC1 10.7) getCurrentTeam(false) appends team to empty _context$', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const result = await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  // --- AC2 (10.7) — replace path preserves other-slot identity ----------
+
+  it('(AC2 10.7) getCurrentTeam(false) replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC3 (10.7) — currentTeam$ emits null → team on empty-cache path --
+
+  it('(AC3 10.7) currentTeam$ emits null then team after empty-cache getCurrentTeam(false)', async () => {
+    const emissions: (TeamContext | null)[] = [];
+    const sub = service.currentTeam$.subscribe((t) => emissions.push(t));
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(emissions[0]).toBeNull();
+    expect(emissions[emissions.length - 1]).toBe(teamA);
+    expect(service.currentTeamRunning$.value).toBe(true);
+
+    sub.unsubscribe();
+  });
+
+  // --- AC4 (10.7) — refreshOneTeam follows same upsert invariant --------
+
+  it('(AC4 10.7) refreshOneTeam appends team when _context$ is empty', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  it('(AC4 10.7) refreshOneTeam replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC5 (10.7) — null API response leaves _context$ unchanged --------
+
+  it('(AC5 10.7) getCurrentTeam(false) null API on empty cache leaves _context$ unchanged', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const result = await service.getCurrentTeam('a', false);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  it('(AC5 10.7) refreshOneTeam null API leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC6 (10.7) — cache-hit short-circuit unchanged --------------------
+
+  it('(AC6 10.7) getCurrentTeam(true) cache-hit does not call API and leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+
+    const result = await service.getCurrentTeam('a', true);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBe(teamA);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC7 (10.7) — end-to-end observable contract on hard reload -------
+
+  it('(AC7 10.7) currentTeam$ + currentTeamRunning$ transitions on empty-cache hard reload', async () => {
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(teamEmissions[0]).toBeNull();
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(teamA);
+    expect(runningEmissions[0]).toBe(false);
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
   it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
     const teamA = makeTeam('a', 'running');
     const teamB = makeTeam('b', 'running');

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -96,8 +96,6 @@ export class ContextService {
     const newTeam = toTeamContext(response);
     const prev = this._context$.value;
     this._context$.next([...prev, newTeam]);
-    await this.router.navigate(['/process', response.team_id]).then(() => {
-      window.location.reload();
-    });
+    await this.router.navigate(['/process', response.team_id]);
   }
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
 import { ApiService } from './api.service';
 import { isRunning, TeamContext, toTeamContext } from '../models/team.interface';
 
@@ -11,14 +12,41 @@ export class ContextService {
   apiService: ApiService = inject(ApiService);
   router: Router = inject(Router);
   currentProcessId$ = new BehaviorSubject<string>('');
-  /** Reactive running state of the current team. Updated by getCurrentTeam()
-   *  and reset when navigating away. Future: fed by homepage WebSocket. */
+  /** Reactive running state of the current team. Derived selector fed by
+   *  `currentTeam$` — navigation code paths no longer push here. Remains a
+   *  BehaviorSubject so `.value` reads in consumers keep working. */
   currentTeamRunning$ = new BehaviorSubject<boolean>(false);
 
   // Single write path for the team list. A future homepage WebSocket
   // will push updates via _context$.next(applyPatch(_context$.value, patch)).
   private _context$ = new BehaviorSubject<TeamContext[]>([]);
   public teams$: Observable<TeamContext[]> = this._context$.asObservable();
+
+  /** Derived selector: the team whose id matches `currentProcessId$`, or
+   *  `null` if none matches (including the empty-string initial id). The
+   *  `shareReplay(1, refCount:false)` gives late-subscriber safety without
+   *  tearing the inner subscription down when consumer count drops to zero. */
+  public currentTeam$: Observable<TeamContext | null> = combineLatest([
+    this.currentProcessId$,
+    this._context$,
+  ]).pipe(
+    map(([id, teams]) => (id ? (teams.find((t) => t.team_id === id) ?? null) : null)),
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: false }),
+  );
+
+  constructor() {
+    // Derive currentTeamRunning$ from currentTeam$. The subscription lives
+    // for the service lifetime (root-scoped singleton) — no teardown needed.
+    // Internal subscription is the sole writer to currentTeamRunning$;
+    // navigation code paths no longer call .next() directly.
+    this.currentTeam$
+      .pipe(
+        map((t) => t !== null && isRunning(t)),
+        distinctUntilChanged(),
+      )
+      .subscribe((running) => this.currentTeamRunning$.next(running));
+  }
 
   async getTeams(): Promise<TeamContext[]> {
     const teams = await this.apiService.getTeams();
@@ -35,7 +63,6 @@ export class ContextService {
         (t: TeamContext) => t.team_id === teamId
       );
       if (cached) {
-        this.currentTeamRunning$.next(isRunning(cached));
         return cached;
       }
     }
@@ -48,7 +75,6 @@ export class ContextService {
         t.team_id === teamId ? team : t
       );
       this._context$.next(next);
-      this.currentTeamRunning$.next(isRunning(team));
     }
 
     return team;
@@ -62,7 +88,6 @@ export class ContextService {
 
   async clear(teamId: string) {
     await this.deleteTeam(teamId);
-    this.currentTeamRunning$.next(false);
     await this.router.navigate(['/']);
   }
 

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -1,7 +1,23 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
+import {
+  BehaviorSubject,
+  combineLatest,
+  firstValueFrom,
+  interval,
+  Observable,
+  Subject,
+} from 'rxjs';
+import {
+  distinctUntilChanged,
+  filter,
+  map,
+  shareReplay,
+  switchMap,
+  take,
+  takeUntil,
+  timeout,
+} from 'rxjs/operators';
 import { ApiService } from './api.service';
 import { isRunning, TeamContext, toTeamContext } from '../models/team.interface';
 
@@ -97,5 +113,50 @@ export class ContextService {
     const prev = this._context$.value;
     this._context$.next([...prev, newTeam]);
     await this.router.navigate(['/process', response.team_id]);
+  }
+
+  private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
+    const fresh = await this.apiService.getTeam(teamId);
+    if (fresh) {
+      const prev = this._context$.value;
+      const next = prev.map((t: TeamContext) =>
+        t.team_id === teamId ? fresh : t,
+      );
+      this._context$.next(next);
+    }
+    return fresh;
+  }
+
+  async stopTeamAndAwait(
+    teamId: string,
+    timeoutMs: number = 10000,
+  ): Promise<void> {
+    await this.apiService.stopTeam(teamId);
+
+    // Bounded periodic refresh feeding _context$ with fresh data for this
+    // team only. When homepage WebSocket lands this interval is replaced by
+    // WS-driven _context$.next(...) updates; the firstValueFrom awaiter below
+    // stays unchanged.
+    const stop$ = new Subject<void>();
+    interval(1000)
+      .pipe(
+        takeUntil(stop$),
+        switchMap(() => this.refreshOneTeam(teamId)),
+      )
+      .subscribe();
+
+    try {
+      await firstValueFrom(
+        this.teams$.pipe(
+          map((teams) => teams.find((t) => t.team_id === teamId)),
+          filter((t): t is TeamContext => t !== undefined && !isRunning(t)),
+          take(1),
+          timeout(timeoutMs),
+        ),
+      );
+    } finally {
+      stop$.next();
+      stop$.complete();
+    }
   }
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { ApiService } from './api.service';
-import { isRunning, TeamContext } from '../models/team.interface';
+import { isRunning, TeamContext, toTeamContext } from '../models/team.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -15,11 +15,15 @@ export class ContextService {
    *  and reset when navigating away. Future: fed by homepage WebSocket. */
   currentTeamRunning$ = new BehaviorSubject<boolean>(false);
 
-  _context: TeamContext[] = [];
+  // Single write path for the team list. A future homepage WebSocket
+  // will push updates via _context$.next(applyPatch(_context$.value, patch)).
+  private _context$ = new BehaviorSubject<TeamContext[]>([]);
+  public teams$: Observable<TeamContext[]> = this._context$.asObservable();
 
   async getTeams(): Promise<TeamContext[]> {
-    this._context = await this.apiService.getTeams();
-    return this._context;
+    const teams = await this.apiService.getTeams();
+    this._context$.next(teams);
+    return teams;
   }
 
   async getCurrentTeam(
@@ -27,7 +31,7 @@ export class ContextService {
     useCache: boolean = true
   ): Promise<TeamContext | null> {
     if (useCache) {
-      const cached = this._context.find(
+      const cached = this._context$.value.find(
         (t: TeamContext) => t.team_id === teamId
       );
       if (cached) {
@@ -38,11 +42,12 @@ export class ContextService {
 
     const team = await this.apiService.getTeam(teamId);
 
-    this._context = this._context.map((t: TeamContext) =>
-      t.team_id === teamId ? team : t
-    );
-
     if (team) {
+      const prev = this._context$.value;
+      const next = prev.map((t: TeamContext) =>
+        t.team_id === teamId ? team : t
+      );
+      this._context$.next(next);
       this.currentTeamRunning$.next(isRunning(team));
     }
 
@@ -51,6 +56,8 @@ export class ContextService {
 
   async deleteTeam(teamId: string): Promise<void> {
     await this.apiService.deleteTeam(teamId);
+    const prev = this._context$.value;
+    this._context$.next(prev.filter((t: TeamContext) => t.team_id !== teamId));
   }
 
   async clear(teamId: string) {
@@ -61,9 +68,11 @@ export class ContextService {
 
   async createTeamAndNavigate(catalogEntryId: string) {
     const response = await this.apiService.createTeam(catalogEntryId);
+    const newTeam = toTeamContext(response);
+    const prev = this._context$.value;
+    this._context$.next([...prev, newTeam]);
     await this.router.navigate(['/process', response.team_id]).then(() => {
       window.location.reload();
     });
   }
-
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -86,11 +86,7 @@ export class ContextService {
     const team = await this.apiService.getTeam(teamId);
 
     if (team) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? team : t
-      );
-      this._context$.next(next);
+      this._upsertTeam(team);
     }
 
     return team;
@@ -118,13 +114,22 @@ export class ContextService {
   private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
     const fresh = await this.apiService.getTeam(teamId);
     if (fresh) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? fresh : t,
-      );
-      this._context$.next(next);
+      this._upsertTeam(fresh);
     }
     return fresh;
+  }
+
+  /** Upsert a team into `_context$`: replace if already cached (preserves
+   *  reference identity of other slots); append if not yet cached. Single
+   *  write path shared by `getCurrentTeam` and `refreshOneTeam` so the two
+   *  cannot diverge in a future change. Issue #104 regression fix. */
+  private _upsertTeam(team: TeamContext): void {
+    const prev = this._context$.value;
+    const exists = prev.some((t) => t.team_id === team.team_id);
+    const next = exists
+      ? prev.map((t) => (t.team_id === team.team_id ? team : t))
+      : [...prev, team];
+    this._context$.next(next);
   }
 
   async stopTeamAndAwait(

--- a/src/app/services/tool-presence.service.spec.ts
+++ b/src/app/services/tool-presence.service.spec.ts
@@ -155,9 +155,20 @@ describe('ToolPresenceService (selector over MessageLogService.log$)', () => {
   });
 
   it('(AC2) ordered-reduce restart — Start → Stop → Start ends as true', () => {
-    log.append(makeStartMessage(KG_ACTOR_NAME));
-    log.append(makeStopMessage(KG_ACTOR_NAME));
-    log.append(makeStartMessage(KG_ACTOR_NAME));
+    // MessageLogService.append() dedupes by msg.id. makeStartMessage uses a
+    // deterministic id derived from the sender name, so two raw append(start)
+    // calls would drop the second. Assign unique ids per event to model a
+    // real restart sequence (Start-1 → Stop-1 → Start-2).
+    const start1 = makeStartMessage(KG_ACTOR_NAME);
+    start1.id = 'kg-start-1';
+    const stop1 = makeStopMessage(KG_ACTOR_NAME);
+    stop1.id = 'kg-stop-1';
+    const start2 = makeStartMessage(KG_ACTOR_NAME);
+    start2.id = 'kg-start-2';
+
+    log.append(start1);
+    log.append(stop1);
+    log.append(start2);
     expect(currentValue()).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Implements Epic 10 Story 10.1 — refactors `ContextService` so the team list is held in a `BehaviorSubject<TeamContext[]>` exposed as `teams$`, and migrates `HomeComponent` to consume it reactively via the `| async` pipe.

- `ContextService._context$` is the single write path: `getTeams`, `getCurrentTeam`, `createTeamAndNavigate`, and `deleteTeam` all funnel through `_context$.next(...)` with immutable updates (slot-level identity preserved on unchanged teams).
- FR14 closed via Path A: `contextService.deleteTeam()` performs the API call plus the subject filter, so `HomeComponent.deleteTeam` delegates to it — no dead method, no direct `apiService.deleteTeam` call in the component.
- `HomeComponent` removes the local `context: TeamContext[]` field; `p-table` binds to `(contextService.teams$ | async) || []`. All six imperative `this.context = ...` sites are gone. `stopTeam` polling structure preserved for Story 10.5.
- New specs: `context.service.spec.ts` (10 cases covering immutability, late-subscriber, null-guard) and `home.component.spec.ts` (6 cases covering template reactivity and subscription lifecycle).
- Unrelated pre-existing spec failures repaired as a separate commit (Golden Rule #6): `user-input.component.spec.ts` now stubs `ContextService.currentTeamRunning$`; `tool-presence.service.spec.ts` uses unique ids for the Start→Stop→Start restart test to work around `MessageLogService.append()` dedup-by-id.

Scope is frontend-only. Backend contract unchanged. `window.location.reload()` retained (removal is Story 10.4). Full suite: 403 / 403.

Closes #92
