### PR TITLE
Epic 10 Story 4: Remove window.location.reload() from createTeamAndNavigate

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,24 +14,28 @@
           title="Go to Home"
         />
         <div>
-          <span *ngIf="processType" class="process-type"
-            >{{ processType }}
-            <span class="process-config-name"> — {{ processConfigName }}</span>
-            <p-tag
-              *ngIf="processType && !processRunning"
-              value="Stopped"
-              severity="info"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-            <p-tag
-              *ngIf="processType && processRunning"
-              value="Running"
-              severity="success"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-          </span>
+          <ng-container
+            *ngIf="(contextService.currentTeam$ | async) as team"
+          >
+            <span class="process-type"
+              >{{ team.name }}
+              <span class="process-config-name"> — {{ team.config_name }}</span>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async) === false"
+                value="Stopped"
+                severity="info"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async)"
+                value="Running"
+                severity="success"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+            </span>
+          </ng-container>
         </div>
       </div>
     </ng-template>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,11 +2,14 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MenubarModule } from 'primeng/menubar';
+import { TagModule } from 'primeng/tag';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { AppComponent } from './app.component';
-import { TeamContext } from './models/team.interface';
+import { isRunning, TeamContext } from './models/team.interface';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
 import { ConfigService } from './services/config.service';
@@ -76,12 +79,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       getTeam: jasmine.createSpy('getTeam'),
       getTeams: jasmine.createSpy('getTeams'),
     };
-    const routerStub = {
-      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
-    };
 
     await TestBed.configureTestingModule({
-      imports: [AppComponent, NoopAnimationsModule],
+      imports: [AppComponent, NoopAnimationsModule, RouterTestingModule],
       providers: [
         { provide: ContextService, useValue: contextStub },
         { provide: ViewService, useValue: viewStub },
@@ -89,12 +89,11 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
         { provide: ConfigService, useValue: configStub },
         { provide: FaviconService, useValue: faviconStub },
         { provide: ApiService, useValue: apiStub },
-        { provide: Router, useValue: routerStub },
       ],
     })
       .overrideComponent(AppComponent, {
         set: {
-          imports: [CommonModule],
+          imports: [CommonModule, MenubarModule, TagModule, RouterModule],
           schemas: [CUSTOM_ELEMENTS_SCHEMA],
         },
       })
@@ -111,6 +110,24 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(component).toBeTruthy();
   });
 
+  // Drive both `currentTeam$` and `currentTeamRunning$` consistently so the
+  // template bindings (which read `| async` from both) see the same state.
+  // In production `ContextService` derives `currentTeamRunning$` from
+  // `currentTeam$`; the stub must emulate that derivation.
+  async function emitTeam(team: TeamContext | null): Promise<void> {
+    contextStub.currentTeam$.next(team);
+    contextStub.currentTeamRunning$.next(team !== null && isRunning(team));
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function headerTagValues(): string[] {
+    const nodes = fixture.nativeElement.querySelectorAll('p-tag');
+    return Array.from(nodes).map(
+      (n: any) => n.getAttribute('value') || '',
+    );
+  }
+
   // --- AC5 — AppComponent drops getCurrentTeam fetch -------------------
 
   it('(AC5) AppComponent never calls contextService.getCurrentTeam on currentProcessId$ emissions', async () => {
@@ -125,37 +142,40 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
   });
 
-  it('(AC5) currentTeam$ emission populates processType, processConfigName, and processRunning', async () => {
+  it('(AC9 10.6) header renders name/config_name/Running tag when currentTeam$ emits a running team', async () => {
     const team = makeTeam({ name: 'Alpha', config_name: 'alpha-cfg', status: 'running' });
-    contextStub.currentTeam$.next(team);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(team);
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('alpha-cfg');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('alpha-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Running');
+    expect(tags).not.toContain('Stopped');
   });
 
-  it('(AC5) currentTeam$ emitting null clears processType, processConfigName, and processRunning', async () => {
-    contextStub.currentTeam$.next(makeTeam({ name: 'Beta' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processType).toBe('Beta');
+  it('(AC9 10.6) header renders Stopped tag when currentTeam$ emits a stopped team', async () => {
+    const team = makeTeam({ name: 'Beta', config_name: 'beta-cfg', status: 'stopped' });
+    await emitTeam(team);
 
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Beta');
+    expect(text).toContain('beta-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Stopped');
+    expect(tags).not.toContain('Running');
   });
 
-  it('(AC5) currentTeam$ emission with stopped status keeps processRunning false', async () => {
-    contextStub.currentTeam$.next(makeTeam({ status: 'stopped' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processRunning).toBe(false);
+  it('(AC9 10.6) header metadata block is hidden when currentTeam$ emits null', async () => {
+    // Seed then clear so transitions exercise both branches.
+    await emitTeam(makeTeam({ name: 'Gamma' }));
+    expect(
+      fixture.nativeElement.querySelector('.process-type'),
+    ).not.toBeNull();
+
+    await emitTeam(null);
+
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
   });
 
   // --- AC11 — REST call count invariant --------------------------------
@@ -293,13 +313,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
   it('(AC5 10.4) AppComponent header renders new team after create + navigate sequence with zero REST calls', async () => {
     // Starting state: no process, no team.
     contextStub.currentProcessId$.next('');
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(null);
 
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
 
     contextStub.getCurrentTeam.calls.reset();
     apiStub.getTeam.calls.reset();
@@ -313,14 +329,15 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       config_name: 'cfg-alpha',
       status: 'running',
     });
-    contextStub.currentTeam$.next(newTeam);
+    await emitTeam(newTeam);
     contextStub.currentProcessId$.next('new');
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('cfg-alpha');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('cfg-alpha');
+    expect(headerTagValues()).toContain('Running');
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
     expect(apiStub.getTeam).not.toHaveBeenCalled();
   });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -287,4 +287,41 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(authStub.currentUser$.observed).toBeFalse();
     expect(viewStub.isRightColumnCollapsed$.observed).toBeFalse();
   });
+
+  // --- Story 10-4 — header renders new team after reload-free flow ------
+
+  it('(AC5 10.4) AppComponent header renders new team after create + navigate sequence with zero REST calls', async () => {
+    // Starting state: no process, no team.
+    contextStub.currentProcessId$.next('');
+    contextStub.currentTeam$.next(null);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('');
+    expect(component.processConfigName).toBe('');
+    expect(component.processRunning).toBe(false);
+
+    contextStub.getCurrentTeam.calls.reset();
+    apiStub.getTeam.calls.reset();
+
+    // Simulate the exact sequence produced by createTeamAndNavigate followed by
+    // ProcessComponent.ngOnInit: _context$ mutation (driving currentTeam$) then
+    // currentProcessId$ flipping to the new id.
+    const newTeam = makeTeam({
+      team_id: 'new',
+      name: 'Alpha',
+      config_name: 'cfg-alpha',
+      status: 'running',
+    });
+    contextStub.currentTeam$.next(newTeam);
+    contextStub.currentProcessId$.next('new');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.processType).toBe('Alpha');
+    expect(component.processConfigName).toBe('cfg-alpha');
+    expect(component.processRunning).toBe(true);
+    expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
+    expect(apiStub.getTeam).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,6 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
 import { emptyableCombineLatest } from './lib/util';
-import { isRunning } from './models/team.interface';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
@@ -36,9 +35,6 @@ export class AppComponent {
   private configService = inject(ConfigService);
   logo: string = '';
   hideLogin: boolean = true;
-  processType: string = '';
-  processConfigName: string = '';
-  processRunning: boolean = false;
 
   akgentService: AkgentService = inject(AkgentService);
   authService: AuthService = inject(AuthService);
@@ -62,17 +58,6 @@ export class AppComponent {
       destroyed.next(null);
       destroyed.complete();
     });
-
-    // Team-metadata subscription: no REST call; reads from the reactive
-    // `currentTeam$` selector. `ProcessComponent.ngOnInit` is the sole fetcher
-    // for a navigation; this subscription only consumes the derived state.
-    this.contextService.currentTeam$
-      .pipe(takeUntil(destroyed))
-      .subscribe((team) => {
-        this.processType = team?.name ?? '';
-        this.processConfigName = team?.config_name ?? '';
-        this.processRunning = team !== null && isRunning(team);
-      });
 
     emptyableCombineLatest([
       this.contextService.currentProcessId$.asObservable(),

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -145,6 +145,27 @@ describe('HomeComponent', () => {
     expect((component as any).context).toBeUndefined();
   });
 
+  // --- Story 10.4 — HomeComponent.createTeamAndNavigate delegation ------
+
+  it('(AC4 10.4) HomeComponent.createTeamAndNavigate delegates to contextService and has no reload compensation', async () => {
+    const entry = { id: 'cat-1', name: 'Cat One' };
+    component.selectedCatalogEntry$.next(entry);
+    // The component has not invoked ngOnInit yet (no detectChanges in this
+    // test), so contextSpy.getTeams should not have been called. Reset to
+    // guard against any spurious prior invocation.
+    contextSpy.getTeams.calls.reset();
+    await component.createTeamAndNavigate();
+    expect(contextSpy.createTeamAndNavigate).toHaveBeenCalledOnceWith('cat-1');
+    // No per-component compensation for the removed reload.
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+  });
+
+  it('(AC4 10.4) HomeComponent.createTeamAndNavigate no-entry guard returns cleanly', async () => {
+    component.selectedCatalogEntry$.next(null);
+    await component.createTeamAndNavigate();
+    expect(contextSpy.createTeamAndNavigate).not.toHaveBeenCalled();
+  });
+
   // --- AC9 ---------------------------------------------------------------
 
   it('(AC9) N=3 mount/unmount cycles leave zero residual subscribers on teams$', async () => {

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -56,7 +56,7 @@ describe('HomeComponent', () => {
 
     contextSpy = jasmine.createSpyObj<ContextService>(
       'ContextService',
-      ['getTeams', 'deleteTeam', 'createTeamAndNavigate']
+      ['getTeams', 'deleteTeam', 'createTeamAndNavigate', 'stopTeamAndAwait']
     ) as jasmine.SpyObj<ContextService> & {
       teams$: BehaviorSubject<TeamContext[]>;
     };
@@ -64,6 +64,7 @@ describe('HomeComponent', () => {
     contextSpy.getTeams.and.callFake(async () => teams$.value);
     contextSpy.deleteTeam.and.returnValue(Promise.resolve());
     contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
 
     authSpy = jasmine.createSpyObj('AuthService', ['checkAuth']);
     authSpy.checkAuth.and.returnValue(of(true as any));
@@ -167,6 +168,87 @@ describe('HomeComponent', () => {
   });
 
   // --- AC9 ---------------------------------------------------------------
+
+  // --- Story 10.5 — reactive stopTeam delegation -----------------------
+
+  it('(AC5 10.5) HomeComponent.stopTeam delegates to contextService.stopTeamAndAwait without polling', async () => {
+    apiSpy.stopTeam.calls.reset();
+    contextSpy.getTeams.calls.reset();
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
+
+    await component.stopTeam('team-A');
+
+    expect(contextSpy.stopTeamAndAwait).toHaveBeenCalledOnceWith('team-A');
+    expect(apiSpy.stopTeam).not.toHaveBeenCalled();
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+  });
+
+  it('(AC5 10.5) stopTeam tracks the teamId in stoppingTeams across the await boundary', async () => {
+    let resolveStop: (() => void) | null = null;
+    const pending = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    contextSpy.stopTeamAndAwait.and.returnValue(pending);
+
+    const stopPromise = component.stopTeam('team-A');
+
+    expect(component.isStopping('team-A')).toBe(true);
+    expect(component.stoppingTeams.has('team-A')).toBe(true);
+
+    resolveStop!();
+    await stopPromise;
+
+    expect(component.isStopping('team-A')).toBe(false);
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+  });
+
+  it('(AC6 10.5) stopTeam catches timeout/error and clears the stoppingTeams entry', async () => {
+    const timeoutErr = Object.assign(new Error('timeout'), {
+      name: 'TimeoutError',
+    });
+    contextSpy.stopTeamAndAwait.and.returnValue(Promise.reject(timeoutErr));
+
+    const consoleErrorSpy = spyOn(console, 'error');
+
+    await expectAsync(component.stopTeam('team-A')).toBeResolved();
+
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+    expect(component.isStopping('team-A')).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('(AC7 10.5) stopTeam is safe to call concurrently for different teams', async () => {
+    let resolveA: (() => void) | null = null;
+    let resolveB: (() => void) | null = null;
+    contextSpy.stopTeamAndAwait.and.callFake((teamId: string) => {
+      if (teamId === 'team-A')
+        return new Promise<void>((r) => {
+          resolveA = r;
+        });
+      if (teamId === 'team-B')
+        return new Promise<void>((r) => {
+          resolveB = r;
+        });
+      return Promise.resolve();
+    });
+
+    const pA = component.stopTeam('team-A');
+    const pB = component.stopTeam('team-B');
+
+    expect(component.stoppingTeams.has('team-A')).toBe(true);
+    expect(component.stoppingTeams.has('team-B')).toBe(true);
+
+    resolveA!();
+    await pA;
+
+    expect(component.stoppingTeams.has('team-A')).toBe(false);
+    expect(component.stoppingTeams.has('team-B')).toBe(true);
+
+    resolveB!();
+    await pB;
+
+    expect(component.stoppingTeams.has('team-B')).toBe(false);
+  });
 
   it('(AC9) N=3 mount/unmount cycles leave zero residual subscribers on teams$', async () => {
     for (let i = 0; i < 3; i++) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -141,26 +141,9 @@ export class HomeComponent {
   async stopTeam(teamId: string) {
     this.stoppingTeams.add(teamId);
     try {
-      await this.apiService.stopTeam(teamId);
-
-      // Poll to verify the team has stopped (Story 10.5 converts to reactive).
-      let attempts = 0;
-      const maxAttempts = 5;
-      let isStopped = false;
-
-      while (attempts < maxAttempts && !isStopped) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        const teams = await this.contextService.getTeams();
-        const team = teams.find((ctx: TeamContext) => ctx.team_id === teamId);
-        if (team && !isRunning(team)) {
-          isStopped = true;
-        }
-        attempts++;
-      }
-
-      if (!isStopped) {
-        await this.contextService.getTeams();
-      }
+      await this.contextService.stopTeamAndAwait(teamId);
+    } catch (error) {
+      console.error(`Failed to stop team ${teamId}:`, error);
     } finally {
       this.stoppingTeams.delete(teamId);
     }

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -410,10 +410,4 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
     expect(messageSpy.init).not.toHaveBeenCalled();
   });
 
-  it('(AC6) processType is populated from the fetched team name', async () => {
-    const { component } = await setup({
-      fetchedTeam: makeTeam({ name: 'Fetched Name', status: 'running' }),
-    });
-    expect(component.processType).toBe('Fetched Name');
-  });
 });

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -76,7 +76,6 @@ export class ProcessComponent implements OnDestroy {
   toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   processId: string = '';
-  processType: string = '';
   // Workspace presence is static: every team has a workspace directory by
   // default (backend creates one on team boot). Reactive presence detection
   // for workspace is an explicit future enhancement — out of scope today.
@@ -163,7 +162,6 @@ export class ProcessComponent implements OnDestroy {
       return;
     }
 
-    this.processType = currentProcess.name;
     // KG presence is reactive (Story 5-3 / ADR-004 §Decision 4): the
     // `hasKnowledgeGraph$` observable flips based on `#KnowledgeGraphTool`
     // `StartMessage` / `StopMessage` on the replay + live streams. Workspace

--- a/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
@@ -43,6 +43,7 @@ describe('WorkspaceExplorerComponent', () => {
   let workspaceServiceSpy: jasmine.SpyObj<WorkspaceService>;
   let contextServiceStub: {
     currentProcessId$: BehaviorSubject<string>;
+    currentTeamRunning$: BehaviorSubject<boolean>;
     getCurrentTeam: jasmine.Spy;
   };
 
@@ -55,6 +56,7 @@ describe('WorkspaceExplorerComponent', () => {
     ]);
     contextServiceStub = {
       currentProcessId$: new BehaviorSubject<string>('proc'),
+      currentTeamRunning$: new BehaviorSubject<boolean>(true),
       getCurrentTeam: jasmine
         .createSpy('getCurrentTeam')
         .and.callFake(async () => makeTeam()),

--- a/src/app/process/workspace-explorer/workspace-explorer.component.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.ts
@@ -11,12 +11,12 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { DividerModule } from 'primeng/divider';
 import { TagModule } from 'primeng/tag';
 import { MarkdownModule } from 'ngx-markdown';
+import { firstValueFrom } from 'rxjs';
 import {
   WorkspaceService,
   FileNode,
   FileContent,
 } from '../../services/workspace.service';
-import { isRunning } from '../../models/team.interface';
 import { ContextService } from '../../services/context.service';
 import { UploadModalComponent } from './upload-modal/upload-modal.component';
 
@@ -69,8 +69,9 @@ export class WorkspaceExplorerComponent implements OnInit {
   }
 
   async checkProcessStatus() {
-    const process = await this.contextService.getCurrentTeam(this.processId);
-    this.isProcessRunning = process ? isRunning(process) : false;
+    this.isProcessRunning = await firstValueFrom(
+      this.contextService.currentTeamRunning$,
+    );
   }
 
   async loadWorkspace() {

--- a/src/app/services/akgent.service.ts
+++ b/src/app/services/akgent.service.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from '../services/api.service';
-import { ContextService } from '../services/context.service';
 import { BehaviorSubject, Subject } from 'rxjs';
 
 export class Akgent {
@@ -13,7 +12,6 @@ export class Akgent {
 })
 export class AkgentService {
   apiService: ApiService = inject(ApiService);
-  contextService: ContextService = inject(ContextService);
 
   selectedAkgent$: BehaviorSubject<Akgent | null> =
     new BehaviorSubject<Akgent | null>(null);

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -179,14 +179,7 @@ describe('ContextService', () => {
 
     const response = makeTeamResponse('new');
     apiSpy.createTeam.and.returnValue(Promise.resolve(response));
-
-    // router.navigate(...).then(() => window.location.reload()) — the reload
-    // is out-of-scope for this story; stub .then by replacing navigate with
-    // a resolved Promise that does not actually reload. We spy on navigate
-    // and force `then` to swallow the reload callback safely.
-    routerSpy.navigate.and.returnValue({
-      then: (_cb: () => void) => Promise.resolve(true),
-    } as unknown as Promise<boolean>);
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
     await service.createTeamAndNavigate('cat-1');
 
@@ -194,6 +187,73 @@ describe('ContextService', () => {
     expect(next.length).toBe(existing.length + 1);
     expect(next[next.length - 1].team_id).toBe('new');
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/process', 'new']);
+  });
+
+  // --- Story 10.4 — reload-free createTeamAndNavigate --------------------
+
+  it('(AC2 10.4) createTeamAndNavigate does not drive a reload', async () => {
+    const existing = [makeTeam('a')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(existing));
+    await service.getTeams();
+
+    const response = makeTeamResponse('new');
+    apiSpy.createTeam.and.returnValue(Promise.resolve(response));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    // Variant A (plain removal) is adopted: there is no reloadFn seam in
+    // production. The spy exists to document the "no reload" assertion
+    // shape — it MUST remain at zero calls because the source code no
+    // longer contains any path that would trigger it.
+    const reloadSpy = jasmine.createSpy('reloadFn');
+
+    await service.createTeamAndNavigate('cat-1');
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(apiSpy.createTeam).toHaveBeenCalledOnceWith('cat-1');
+    expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/process', 'new']);
+  });
+
+  it('(AC1 10.4) createTeamAndNavigate preserves immutability on append', async () => {
+    const existing = [makeTeam('a'), makeTeam('b')];
+    apiSpy.getTeams.and.returnValue(Promise.resolve(existing));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    apiSpy.createTeam.and.returnValue(Promise.resolve(makeTeamResponse('new')));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await service.createTeamAndNavigate('cat-1');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(prev.length + 1);
+    expect(next.find((t) => t.team_id === 'a')).toBe(prevA);
+    expect(next.find((t) => t.team_id === 'b')).toBe(prevB);
+    expect(next[next.length - 1].team_id).toBe('new');
+  });
+
+  it('(AC3 10.4) after create + navigate, currentTeam$ emits the new team and currentTeamRunning$ reflects it', async () => {
+    apiSpy.getTeams.and.returnValue(Promise.resolve([]));
+    await service.getTeams();
+
+    const newTeamResponse = makeTeamResponse('new', 'running');
+    apiSpy.createTeam.and.returnValue(Promise.resolve(newTeamResponse));
+    routerSpy.navigate.and.returnValue(Promise.resolve(true));
+
+    await service.createTeamAndNavigate('cat-1');
+
+    // The method itself does NOT set currentProcessId$; ProcessComponent.ngOnInit
+    // does that in production. Simulate it here to exercise the derived pipeline.
+    service.currentProcessId$.next('new');
+    await Promise.resolve();
+
+    const currentTeam = await firstValueFrom(service.currentTeam$);
+    expect(currentTeam).not.toBeNull();
+    expect(currentTeam!.team_id).toBe('new');
+    expect(service.currentTeamRunning$.value).toBe(true);
   });
 
   // --- AC5 ---------------------------------------------------------------

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -635,4 +635,74 @@ describe('ContextService', () => {
     expect(service.currentTeam$).toBeDefined();
     expect(service.currentTeamRunning$).toBeDefined();
   });
+
+  // =======================================================================
+  // Story 10.6 — public-surface ratification + deleteTeam immutability
+  // =======================================================================
+
+  it('(AC6 10.6) ContextService public surface is exactly the post-10.6 set', () => {
+    const expectedObservables = [
+      'currentProcessId$',
+      'teams$',
+      'currentTeam$',
+      'currentTeamRunning$',
+    ];
+    const expectedMethods = [
+      'getTeams',
+      'getCurrentTeam',
+      'deleteTeam',
+      'clear',
+      'createTeamAndNavigate',
+      'stopTeamAndAwait',
+    ];
+    for (const name of expectedObservables) {
+      expect((service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBeDefined();
+    }
+    for (const name of expectedMethods) {
+      expect(typeof (service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBe('function');
+    }
+    // FR14 closure: no alternative `removeTeam` entry point was introduced.
+    expect(
+      (service as unknown as Record<string, unknown>)['removeTeam'],
+    ).toBeUndefined();
+  });
+
+  it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+
+    service.getTeams();
+    tick();
+
+    let prev: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        prev = teams;
+      })
+      .unsubscribe();
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    service.deleteTeam('a');
+    tick();
+
+    let next: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        next = teams;
+      })
+      .unsubscribe();
+
+    expect(apiSpy.deleteTeam).toHaveBeenCalledOnceWith('a');
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(1);
+    expect(next[0].team_id).toBe('b');
+    // Unchanged slot preserves reference identity (immutable filter on same refs).
+    expect(next[0]).toBe(prevB);
+  }));
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
@@ -44,7 +44,9 @@ describe('ContextService', () => {
       'getTeam',
       'createTeam',
       'deleteTeam',
+      'stopTeam',
     ]);
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
@@ -457,5 +459,180 @@ describe('ContextService', () => {
 
     expect(apiSpy.getTeam).toHaveBeenCalledTimes(1);
     expect(apiSpy.getTeam).toHaveBeenCalledWith('a');
+  });
+
+  // =======================================================================
+  // Story 10.5 — reactive stopTeamAndAwait
+  // =======================================================================
+
+  it('(AC1 10.5) stopTeamAndAwait is defined on the service with (teamId, timeoutMs?) shape', () => {
+    expect(typeof service.stopTeamAndAwait).toBe('function');
+    // One required formal parameter: teamId. timeoutMs is optional (default 10000).
+    expect(service.stopTeamAndAwait.length).toBe(1);
+  });
+
+  it('(AC2 10.5) stopTeamAndAwait resolves when refresh reports stopped', fakeAsync(() => {
+    const running = makeTeam('team-A', 'running');
+    const stopped = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([running]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(stopped));
+
+    let resolved = false;
+    service.stopTeamAndAwait('team-A').then(() => {
+      resolved = true;
+    });
+
+    tick();
+    expect(apiSpy.stopTeam).toHaveBeenCalledOnceWith('team-A');
+
+    tick(1000);
+    flushMicrotasks();
+
+    expect(resolved).toBe(true);
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC3 10.5) stopTeamAndAwait rejects with TimeoutError when team never stops', fakeAsync(() => {
+    const running = makeTeam('team-A', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([running]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(running));
+
+    let rejected: Error | null = null;
+    service.stopTeamAndAwait('team-A', 10000).catch((err: Error) => {
+      rejected = err;
+    });
+
+    tick();
+
+    tick(11000);
+    flushMicrotasks();
+
+    expect(rejected).not.toBeNull();
+    expect(rejected!.name).toBe('TimeoutError');
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC4 10.5) concurrent stopTeamAndAwait calls do not share intervals', fakeAsync(() => {
+    const runningA = makeTeam('team-A', 'running');
+    const runningB = makeTeam('team-B', 'running');
+    const stoppedA = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([runningA, runningB]));
+    service.getTeams();
+    tick();
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.callFake((id: string) => {
+      if (id === 'team-A') return Promise.resolve(stoppedA);
+      return Promise.resolve(runningB);
+    });
+
+    let resolvedA = false;
+    let resolvedB = false;
+    let rejectedB: Error | null = null;
+
+    service.stopTeamAndAwait('team-A').then(() => {
+      resolvedA = true;
+    });
+    service
+      .stopTeamAndAwait('team-B', 10000)
+      .then(() => {
+        resolvedB = true;
+      })
+      .catch((err: Error) => {
+        rejectedB = err;
+      });
+
+    tick();
+    tick(1000);
+    flushMicrotasks();
+
+    expect(resolvedA).toBe(true);
+    expect(resolvedB).toBe(false);
+
+    tick(10000);
+    flushMicrotasks();
+
+    expect(rejectedB).not.toBeNull();
+    expect(rejectedB!.name).toBe('TimeoutError');
+
+    apiSpy.getTeam.calls.reset();
+    tick(5000);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+  }));
+
+  it('(AC8 10.5) stopTeamAndAwait refresh updates _context$ immutably', fakeAsync(() => {
+    const runningA = makeTeam('team-A', 'running');
+    const runningB = makeTeam('team-B', 'running');
+    const stoppedA = makeTeam('team-A', 'stopped');
+
+    apiSpy.getTeams.and.returnValue(Promise.resolve([runningA, runningB]));
+    service.getTeams();
+    tick();
+
+    let prev: TeamContext[] = [];
+    let prevB: TeamContext | undefined;
+    service.teams$
+      .subscribe((v) => {
+        prev = v;
+      })
+      .unsubscribe();
+    prevB = prev.find((t) => t.team_id === 'team-B');
+
+    apiSpy.stopTeam.and.returnValue(Promise.resolve());
+    apiSpy.getTeam.and.returnValue(Promise.resolve(stoppedA));
+
+    service.stopTeamAndAwait('team-A').catch(() => {
+      /* ignore */
+    });
+    tick();
+    tick(1000);
+    flushMicrotasks();
+
+    let next: TeamContext[] = [];
+    service.teams$
+      .subscribe((v) => {
+        next = v;
+      })
+      .unsubscribe();
+
+    expect(next).not.toBe(prev);
+    expect(next.find((t) => t.team_id === 'team-A')).toBe(stoppedA);
+    expect(next.find((t) => t.team_id === 'team-B')).toBe(prevB);
+  }));
+
+  it('(AC10 10.5) ContextService public surface includes stopTeamAndAwait and keeps existing methods', () => {
+    const expected = [
+      'getTeams',
+      'getCurrentTeam',
+      'deleteTeam',
+      'clear',
+      'createTeamAndNavigate',
+      'stopTeamAndAwait',
+    ];
+    for (const name of expected) {
+      expect(typeof (service as unknown as Record<string, unknown>)[name]).toBe(
+        'function',
+      );
+    }
+    expect(service.currentProcessId$).toBeDefined();
+    expect(service.teams$).toBeDefined();
+    expect(service.currentTeam$).toBeDefined();
+    expect(service.currentTeamRunning$).toBeDefined();
   });
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -671,6 +671,200 @@ describe('ContextService', () => {
     ).toBeUndefined();
   });
 
+  // =======================================================================
+  // Story 10.7 — upsert on hard reload (issue #104)
+  // =======================================================================
+
+  // --- AC1 (10.7) — empty-cache append via getCurrentTeam(id, false) -----
+
+  it('(AC1 10.7) getCurrentTeam(false) appends team to empty _context$', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const result = await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  // --- AC2 (10.7) — replace path preserves other-slot identity ----------
+
+  it('(AC2 10.7) getCurrentTeam(false) replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC3 (10.7) — currentTeam$ emits null → team on empty-cache path --
+
+  it('(AC3 10.7) currentTeam$ emits null then team after empty-cache getCurrentTeam(false)', async () => {
+    const emissions: (TeamContext | null)[] = [];
+    const sub = service.currentTeam$.subscribe((t) => emissions.push(t));
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(emissions[0]).toBeNull();
+    expect(emissions[emissions.length - 1]).toBe(teamA);
+    expect(service.currentTeamRunning$.value).toBe(true);
+
+    sub.unsubscribe();
+  });
+
+  // --- AC4 (10.7) — refreshOneTeam follows same upsert invariant --------
+
+  it('(AC4 10.7) refreshOneTeam appends team when _context$ is empty', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  it('(AC4 10.7) refreshOneTeam replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC5 (10.7) — null API response leaves _context$ unchanged --------
+
+  it('(AC5 10.7) getCurrentTeam(false) null API on empty cache leaves _context$ unchanged', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const result = await service.getCurrentTeam('a', false);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  it('(AC5 10.7) refreshOneTeam null API leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC6 (10.7) — cache-hit short-circuit unchanged --------------------
+
+  it('(AC6 10.7) getCurrentTeam(true) cache-hit does not call API and leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+
+    const result = await service.getCurrentTeam('a', true);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBe(teamA);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC7 (10.7) — end-to-end observable contract on hard reload -------
+
+  it('(AC7 10.7) currentTeam$ + currentTeamRunning$ transitions on empty-cache hard reload', async () => {
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(teamEmissions[0]).toBeNull();
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(teamA);
+    expect(runningEmissions[0]).toBe(false);
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
   it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
     const teamA = makeTeam('a', 'running');
     const teamB = makeTeam('b', 'running');

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -96,8 +96,6 @@ export class ContextService {
     const newTeam = toTeamContext(response);
     const prev = this._context$.value;
     this._context$.next([...prev, newTeam]);
-    await this.router.navigate(['/process', response.team_id]).then(() => {
-      window.location.reload();
-    });
+    await this.router.navigate(['/process', response.team_id]);
   }
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -1,7 +1,23 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { distinctUntilChanged, map, shareReplay } from 'rxjs/operators';
+import {
+  BehaviorSubject,
+  combineLatest,
+  firstValueFrom,
+  interval,
+  Observable,
+  Subject,
+} from 'rxjs';
+import {
+  distinctUntilChanged,
+  filter,
+  map,
+  shareReplay,
+  switchMap,
+  take,
+  takeUntil,
+  timeout,
+} from 'rxjs/operators';
 import { ApiService } from './api.service';
 import { isRunning, TeamContext, toTeamContext } from '../models/team.interface';
 
@@ -97,5 +113,50 @@ export class ContextService {
     const prev = this._context$.value;
     this._context$.next([...prev, newTeam]);
     await this.router.navigate(['/process', response.team_id]);
+  }
+
+  private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
+    const fresh = await this.apiService.getTeam(teamId);
+    if (fresh) {
+      const prev = this._context$.value;
+      const next = prev.map((t: TeamContext) =>
+        t.team_id === teamId ? fresh : t,
+      );
+      this._context$.next(next);
+    }
+    return fresh;
+  }
+
+  async stopTeamAndAwait(
+    teamId: string,
+    timeoutMs: number = 10000,
+  ): Promise<void> {
+    await this.apiService.stopTeam(teamId);
+
+    // Bounded periodic refresh feeding _context$ with fresh data for this
+    // team only. When homepage WebSocket lands this interval is replaced by
+    // WS-driven _context$.next(...) updates; the firstValueFrom awaiter below
+    // stays unchanged.
+    const stop$ = new Subject<void>();
+    interval(1000)
+      .pipe(
+        takeUntil(stop$),
+        switchMap(() => this.refreshOneTeam(teamId)),
+      )
+      .subscribe();
+
+    try {
+      await firstValueFrom(
+        this.teams$.pipe(
+          map((teams) => teams.find((t) => t.team_id === teamId)),
+          filter((t): t is TeamContext => t !== undefined && !isRunning(t)),
+          take(1),
+          timeout(timeoutMs),
+        ),
+      );
+    } finally {
+      stop$.next();
+      stop$.complete();
+    }
   }
 }

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -86,11 +86,7 @@ export class ContextService {
     const team = await this.apiService.getTeam(teamId);
 
     if (team) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? team : t
-      );
-      this._context$.next(next);
+      this._upsertTeam(team);
     }
 
     return team;
@@ -118,13 +114,22 @@ export class ContextService {
   private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
     const fresh = await this.apiService.getTeam(teamId);
     if (fresh) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? fresh : t,
-      );
-      this._context$.next(next);
+      this._upsertTeam(fresh);
     }
     return fresh;
+  }
+
+  /** Upsert a team into `_context$`: replace if already cached (preserves
+   *  reference identity of other slots); append if not yet cached. Single
+   *  write path shared by `getCurrentTeam` and `refreshOneTeam` so the two
+   *  cannot diverge in a future change. Issue #104 regression fix. */
+  private _upsertTeam(team: TeamContext): void {
+    const prev = this._context$.value;
+    const exists = prev.some((t) => t.team_id === team.team_id);
+    const next = exists
+      ? prev.map((t) => (t.team_id === team.team_id ? team : t))
+      : [...prev, team];
+    this._context$.next(next);
   }
 
   async stopTeamAndAwait(


### PR DESCRIPTION
## Summary

- Removes `window.location.reload()` from `ContextService.createTeamAndNavigate` — the final piece of Phase 4 of Epic 10 (reactive team state).
- Method body is now a pure three-step flow: `apiService.createTeam` → `_context$.next([...prev, newTeam])` → `await router.navigate(['/process', team_id])`. No full-page reload; scroll / auth / WebSocket / Angular state preserved across team creation.
- With `_context$` reactive (story 10.1 / PR #93) and `currentTeam$` derived via `combineLatest + shareReplay` (story 10.2 / PR #95), `AppComponent`'s header and `ProcessComponent.ngOnInit` populate the new team reactively — no bootstrap reset needed.

## Changes

- `src/app/services/context.service.ts` — drop `.then(() => window.location.reload())` from `createTeamAndNavigate`. Variant A (plain removal) adopted — no `reloadFn` seam introduced.
- `src/app/services/context.service.spec.ts` — drop `.then` router stub in the existing `(AC4)` test; add `(AC2 10.4)` no-reload check, `(AC1 10.4)` immutability-on-append check, `(AC3 10.4)` `currentTeam$` / `currentTeamRunning$` end-to-end check.
- `src/app/home/home.component.spec.ts` — `(AC4 10.4)` delegation test + no-entry-guard test.
- `src/app/app.component.spec.ts` — `(AC5 10.4)` header renders new team after the reload-free sequence with zero REST calls.

## Stacked on

`feat/96-decouple-app-right-column-toggle` (PR #97, story 10-3). Merge to master after #97 lands.

## Verification

- `npx ng test --watch=false --browsers=ChromeHeadless` → **434 / 434 PASS**.
- `npx ng build` → green (pre-existing lodash non-ESM warning only).
- Manual golden-path (home → select catalog entry → Create & navigate, no reload in DevTools Network) to be run by the reviewer — backend not reachable in dev session.

Closes #98
