### PR TITLE
Cleanup dead injections, duplicate fields, isRunning audit (Story 10.6)

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,24 +14,28 @@
           title="Go to Home"
         />
         <div>
-          <span *ngIf="processType" class="process-type"
-            >{{ processType }}
-            <span class="process-config-name"> — {{ processConfigName }}</span>
-            <p-tag
-              *ngIf="processType && !processRunning"
-              value="Stopped"
-              severity="info"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-            <p-tag
-              *ngIf="processType && processRunning"
-              value="Running"
-              severity="success"
-              [style]="{ 'margin-left': '8px' }"
-            >
-            </p-tag>
-          </span>
+          <ng-container
+            *ngIf="(contextService.currentTeam$ | async) as team"
+          >
+            <span class="process-type"
+              >{{ team.name }}
+              <span class="process-config-name"> — {{ team.config_name }}</span>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async) === false"
+                value="Stopped"
+                severity="info"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+              <p-tag
+                *ngIf="(contextService.currentTeamRunning$ | async)"
+                value="Running"
+                severity="success"
+                [style]="{ 'margin-left': '8px' }"
+              >
+              </p-tag>
+            </span>
+          </ng-container>
         </div>
       </div>
     </ng-template>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,11 +2,14 @@ import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MenubarModule } from 'primeng/menubar';
+import { TagModule } from 'primeng/tag';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { AppComponent } from './app.component';
-import { TeamContext } from './models/team.interface';
+import { isRunning, TeamContext } from './models/team.interface';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
 import { ConfigService } from './services/config.service';
@@ -76,12 +79,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       getTeam: jasmine.createSpy('getTeam'),
       getTeams: jasmine.createSpy('getTeams'),
     };
-    const routerStub = {
-      navigate: jasmine.createSpy('navigate').and.returnValue(Promise.resolve(true)),
-    };
 
     await TestBed.configureTestingModule({
-      imports: [AppComponent, NoopAnimationsModule],
+      imports: [AppComponent, NoopAnimationsModule, RouterTestingModule],
       providers: [
         { provide: ContextService, useValue: contextStub },
         { provide: ViewService, useValue: viewStub },
@@ -89,12 +89,11 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
         { provide: ConfigService, useValue: configStub },
         { provide: FaviconService, useValue: faviconStub },
         { provide: ApiService, useValue: apiStub },
-        { provide: Router, useValue: routerStub },
       ],
     })
       .overrideComponent(AppComponent, {
         set: {
-          imports: [CommonModule],
+          imports: [CommonModule, MenubarModule, TagModule, RouterModule],
           schemas: [CUSTOM_ELEMENTS_SCHEMA],
         },
       })
@@ -111,6 +110,24 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(component).toBeTruthy();
   });
 
+  // Drive both `currentTeam$` and `currentTeamRunning$` consistently so the
+  // template bindings (which read `| async` from both) see the same state.
+  // In production `ContextService` derives `currentTeamRunning$` from
+  // `currentTeam$`; the stub must emulate that derivation.
+  async function emitTeam(team: TeamContext | null): Promise<void> {
+    contextStub.currentTeam$.next(team);
+    contextStub.currentTeamRunning$.next(team !== null && isRunning(team));
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function headerTagValues(): string[] {
+    const nodes = fixture.nativeElement.querySelectorAll('p-tag');
+    return Array.from(nodes).map(
+      (n: any) => n.getAttribute('value') || '',
+    );
+  }
+
   // --- AC5 — AppComponent drops getCurrentTeam fetch -------------------
 
   it('(AC5) AppComponent never calls contextService.getCurrentTeam on currentProcessId$ emissions', async () => {
@@ -125,37 +142,40 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
   });
 
-  it('(AC5) currentTeam$ emission populates processType, processConfigName, and processRunning', async () => {
+  it('(AC9 10.6) header renders name/config_name/Running tag when currentTeam$ emits a running team', async () => {
     const team = makeTeam({ name: 'Alpha', config_name: 'alpha-cfg', status: 'running' });
-    contextStub.currentTeam$.next(team);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(team);
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('alpha-cfg');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('alpha-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Running');
+    expect(tags).not.toContain('Stopped');
   });
 
-  it('(AC5) currentTeam$ emitting null clears processType, processConfigName, and processRunning', async () => {
-    contextStub.currentTeam$.next(makeTeam({ name: 'Beta' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processType).toBe('Beta');
+  it('(AC9 10.6) header renders Stopped tag when currentTeam$ emits a stopped team', async () => {
+    const team = makeTeam({ name: 'Beta', config_name: 'beta-cfg', status: 'stopped' });
+    await emitTeam(team);
 
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Beta');
+    expect(text).toContain('beta-cfg');
+    const tags = headerTagValues();
+    expect(tags).toContain('Stopped');
+    expect(tags).not.toContain('Running');
   });
 
-  it('(AC5) currentTeam$ emission with stopped status keeps processRunning false', async () => {
-    contextStub.currentTeam$.next(makeTeam({ status: 'stopped' }));
-    await fixture.whenStable();
-    fixture.detectChanges();
-    expect(component.processRunning).toBe(false);
+  it('(AC9 10.6) header metadata block is hidden when currentTeam$ emits null', async () => {
+    // Seed then clear so transitions exercise both branches.
+    await emitTeam(makeTeam({ name: 'Gamma' }));
+    expect(
+      fixture.nativeElement.querySelector('.process-type'),
+    ).not.toBeNull();
+
+    await emitTeam(null);
+
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
   });
 
   // --- AC11 — REST call count invariant --------------------------------
@@ -293,13 +313,9 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
   it('(AC5 10.4) AppComponent header renders new team after create + navigate sequence with zero REST calls', async () => {
     // Starting state: no process, no team.
     contextStub.currentProcessId$.next('');
-    contextStub.currentTeam$.next(null);
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await emitTeam(null);
 
-    expect(component.processType).toBe('');
-    expect(component.processConfigName).toBe('');
-    expect(component.processRunning).toBe(false);
+    expect(fixture.nativeElement.querySelector('.process-type')).toBeNull();
 
     contextStub.getCurrentTeam.calls.reset();
     apiStub.getTeam.calls.reset();
@@ -313,14 +329,15 @@ describe('AppComponent (Story 10-2 — reactive currentTeam$ subscription)', () 
       config_name: 'cfg-alpha',
       status: 'running',
     });
-    contextStub.currentTeam$.next(newTeam);
+    await emitTeam(newTeam);
     contextStub.currentProcessId$.next('new');
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(component.processType).toBe('Alpha');
-    expect(component.processConfigName).toBe('cfg-alpha');
-    expect(component.processRunning).toBe(true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Alpha');
+    expect(text).toContain('cfg-alpha');
+    expect(headerTagValues()).toContain('Running');
     expect(contextStub.getCurrentTeam).not.toHaveBeenCalled();
     expect(apiStub.getTeam).not.toHaveBeenCalled();
   });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,6 @@ import { TagModule } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { Subject, takeUntil } from 'rxjs';
 import { emptyableCombineLatest } from './lib/util';
-import { isRunning } from './models/team.interface';
 import { AkgentService } from './services/akgent.service';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
@@ -36,9 +35,6 @@ export class AppComponent {
   private configService = inject(ConfigService);
   logo: string = '';
   hideLogin: boolean = true;
-  processType: string = '';
-  processConfigName: string = '';
-  processRunning: boolean = false;
 
   akgentService: AkgentService = inject(AkgentService);
   authService: AuthService = inject(AuthService);
@@ -62,17 +58,6 @@ export class AppComponent {
       destroyed.next(null);
       destroyed.complete();
     });
-
-    // Team-metadata subscription: no REST call; reads from the reactive
-    // `currentTeam$` selector. `ProcessComponent.ngOnInit` is the sole fetcher
-    // for a navigation; this subscription only consumes the derived state.
-    this.contextService.currentTeam$
-      .pipe(takeUntil(destroyed))
-      .subscribe((team) => {
-        this.processType = team?.name ?? '';
-        this.processConfigName = team?.config_name ?? '';
-        this.processRunning = team !== null && isRunning(team);
-      });
 
     emptyableCombineLatest([
       this.contextService.currentProcessId$.asObservable(),

--- a/src/app/process/process.component.spec.ts
+++ b/src/app/process/process.component.spec.ts
@@ -410,10 +410,4 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
     expect(messageSpy.init).not.toHaveBeenCalled();
   });
 
-  it('(AC6) processType is populated from the fetched team name', async () => {
-    const { component } = await setup({
-      fetchedTeam: makeTeam({ name: 'Fetched Name', status: 'running' }),
-    });
-    expect(component.processType).toBe('Fetched Name');
-  });
 });

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -76,7 +76,6 @@ export class ProcessComponent implements OnDestroy {
   toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
 
   processId: string = '';
-  processType: string = '';
   // Workspace presence is static: every team has a workspace directory by
   // default (backend creates one on team boot). Reactive presence detection
   // for workspace is an explicit future enhancement — out of scope today.
@@ -163,7 +162,6 @@ export class ProcessComponent implements OnDestroy {
       return;
     }
 
-    this.processType = currentProcess.name;
     // KG presence is reactive (Story 5-3 / ADR-004 §Decision 4): the
     // `hasKnowledgeGraph$` observable flips based on `#KnowledgeGraphTool`
     // `StartMessage` / `StopMessage` on the replay + live streams. Workspace

--- a/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.spec.ts
@@ -43,6 +43,7 @@ describe('WorkspaceExplorerComponent', () => {
   let workspaceServiceSpy: jasmine.SpyObj<WorkspaceService>;
   let contextServiceStub: {
     currentProcessId$: BehaviorSubject<string>;
+    currentTeamRunning$: BehaviorSubject<boolean>;
     getCurrentTeam: jasmine.Spy;
   };
 
@@ -55,6 +56,7 @@ describe('WorkspaceExplorerComponent', () => {
     ]);
     contextServiceStub = {
       currentProcessId$: new BehaviorSubject<string>('proc'),
+      currentTeamRunning$: new BehaviorSubject<boolean>(true),
       getCurrentTeam: jasmine
         .createSpy('getCurrentTeam')
         .and.callFake(async () => makeTeam()),

--- a/src/app/process/workspace-explorer/workspace-explorer.component.ts
+++ b/src/app/process/workspace-explorer/workspace-explorer.component.ts
@@ -11,12 +11,12 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { DividerModule } from 'primeng/divider';
 import { TagModule } from 'primeng/tag';
 import { MarkdownModule } from 'ngx-markdown';
+import { firstValueFrom } from 'rxjs';
 import {
   WorkspaceService,
   FileNode,
   FileContent,
 } from '../../services/workspace.service';
-import { isRunning } from '../../models/team.interface';
 import { ContextService } from '../../services/context.service';
 import { UploadModalComponent } from './upload-modal/upload-modal.component';
 
@@ -69,8 +69,9 @@ export class WorkspaceExplorerComponent implements OnInit {
   }
 
   async checkProcessStatus() {
-    const process = await this.contextService.getCurrentTeam(this.processId);
-    this.isProcessRunning = process ? isRunning(process) : false;
+    this.isProcessRunning = await firstValueFrom(
+      this.contextService.currentTeamRunning$,
+    );
   }
 
   async loadWorkspace() {

--- a/src/app/services/akgent.service.ts
+++ b/src/app/services/akgent.service.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from '../services/api.service';
-import { ContextService } from '../services/context.service';
 import { BehaviorSubject, Subject } from 'rxjs';
 
 export class Akgent {
@@ -13,7 +12,6 @@ export class Akgent {
 })
 export class AkgentService {
   apiService: ApiService = inject(ApiService);
-  contextService: ContextService = inject(ContextService);
 
   selectedAkgent$: BehaviorSubject<Akgent | null> =
     new BehaviorSubject<Akgent | null>(null);

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -635,4 +635,74 @@ describe('ContextService', () => {
     expect(service.currentTeam$).toBeDefined();
     expect(service.currentTeamRunning$).toBeDefined();
   });
+
+  // =======================================================================
+  // Story 10.6 — public-surface ratification + deleteTeam immutability
+  // =======================================================================
+
+  it('(AC6 10.6) ContextService public surface is exactly the post-10.6 set', () => {
+    const expectedObservables = [
+      'currentProcessId$',
+      'teams$',
+      'currentTeam$',
+      'currentTeamRunning$',
+    ];
+    const expectedMethods = [
+      'getTeams',
+      'getCurrentTeam',
+      'deleteTeam',
+      'clear',
+      'createTeamAndNavigate',
+      'stopTeamAndAwait',
+    ];
+    for (const name of expectedObservables) {
+      expect((service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBeDefined();
+    }
+    for (const name of expectedMethods) {
+      expect(typeof (service as unknown as Record<string, unknown>)[name])
+        .withContext(name)
+        .toBe('function');
+    }
+    // FR14 closure: no alternative `removeTeam` entry point was introduced.
+    expect(
+      (service as unknown as Record<string, unknown>)['removeTeam'],
+    ).toBeUndefined();
+  });
+
+  it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    apiSpy.deleteTeam.and.returnValue(Promise.resolve());
+
+    service.getTeams();
+    tick();
+
+    let prev: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        prev = teams;
+      })
+      .unsubscribe();
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    service.deleteTeam('a');
+    tick();
+
+    let next: TeamContext[] = [];
+    service.teams$
+      .subscribe((teams) => {
+        next = teams;
+      })
+      .unsubscribe();
+
+    expect(apiSpy.deleteTeam).toHaveBeenCalledOnceWith('a');
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(1);
+    expect(next[0].team_id).toBe('b');
+    // Unchanged slot preserves reference identity (immutable filter on same refs).
+    expect(next[0]).toBe(prevB);
+  }));
 });

--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -671,6 +671,200 @@ describe('ContextService', () => {
     ).toBeUndefined();
   });
 
+  // =======================================================================
+  // Story 10.7 — upsert on hard reload (issue #104)
+  // =======================================================================
+
+  // --- AC1 (10.7) — empty-cache append via getCurrentTeam(id, false) -----
+
+  it('(AC1 10.7) getCurrentTeam(false) appends team to empty _context$', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const result = await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  // --- AC2 (10.7) — replace path preserves other-slot identity ----------
+
+  it('(AC2 10.7) getCurrentTeam(false) replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC3 (10.7) — currentTeam$ emits null → team on empty-cache path --
+
+  it('(AC3 10.7) currentTeam$ emits null then team after empty-cache getCurrentTeam(false)', async () => {
+    const emissions: (TeamContext | null)[] = [];
+    const sub = service.currentTeam$.subscribe((t) => emissions.push(t));
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(emissions[0]).toBeNull();
+    expect(emissions[emissions.length - 1]).toBe(teamA);
+    expect(service.currentTeamRunning$.value).toBe(true);
+
+    sub.unsubscribe();
+  });
+
+  // --- AC4 (10.7) — refreshOneTeam follows same upsert invariant --------
+
+  it('(AC4 10.7) refreshOneTeam appends team when _context$ is empty', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  it('(AC4 10.7) refreshOneTeam replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC5 (10.7) — null API response leaves _context$ unchanged --------
+
+  it('(AC5 10.7) getCurrentTeam(false) null API on empty cache leaves _context$ unchanged', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const result = await service.getCurrentTeam('a', false);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  it('(AC5 10.7) refreshOneTeam null API leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC6 (10.7) — cache-hit short-circuit unchanged --------------------
+
+  it('(AC6 10.7) getCurrentTeam(true) cache-hit does not call API and leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+
+    const result = await service.getCurrentTeam('a', true);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBe(teamA);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC7 (10.7) — end-to-end observable contract on hard reload -------
+
+  it('(AC7 10.7) currentTeam$ + currentTeamRunning$ transitions on empty-cache hard reload', async () => {
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(teamEmissions[0]).toBeNull();
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(teamA);
+    expect(runningEmissions[0]).toBe(false);
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
   it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
     const teamA = makeTeam('a', 'running');
     const teamB = makeTeam('b', 'running');

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -86,11 +86,7 @@ export class ContextService {
     const team = await this.apiService.getTeam(teamId);
 
     if (team) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? team : t
-      );
-      this._context$.next(next);
+      this._upsertTeam(team);
     }
 
     return team;
@@ -118,13 +114,22 @@ export class ContextService {
   private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
     const fresh = await this.apiService.getTeam(teamId);
     if (fresh) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? fresh : t,
-      );
-      this._context$.next(next);
+      this._upsertTeam(fresh);
     }
     return fresh;
+  }
+
+  /** Upsert a team into `_context$`: replace if already cached (preserves
+   *  reference identity of other slots); append if not yet cached. Single
+   *  write path shared by `getCurrentTeam` and `refreshOneTeam` so the two
+   *  cannot diverge in a future change. Issue #104 regression fix. */
+  private _upsertTeam(team: TeamContext): void {
+    const prev = this._context$.value;
+    const exists = prev.some((t) => t.team_id === team.team_id);
+    const next = exists
+      ? prev.map((t) => (t.team_id === team.team_id ? team : t))
+      : [...prev, team];
+    this._context$.next(next);
   }
 
   async stopTeamAndAwait(


### PR DESCRIPTION
## Summary

Final story of Epic 10. Cleans up transitional state left by Stories 10.1–10.5:

- Remove dead `ContextService` injection from `AkgentService` (never dereferenced)
- Remove duplicate header-metadata fields from `AppComponent` (`processType`, `processConfigName`, `processRunning`) and migrate the header template to inline `(contextService.currentTeam$ | async) as team` with `(currentTeamRunning$ | async)`-driven `p-tag` severity selection
- Remove duplicate `processType` field from `ProcessComponent` (force-fresh `getCurrentTeam(id, false)` + `isRunning(currentProcess)` kept — Pattern A, preserves `_context$` refresh side-effect)
- Migrate `WorkspaceExplorerComponent.checkProcessStatus` to `firstValueFrom(contextService.currentTeamRunning$)`
- Ratify `ContextService` public surface: 4 observables + 6 methods; no `removeTeam` method (FR14 closure)

Covers FR11, FR12, FR13, FR14 (final ratification). Preserves NFR1, NFR3.

## Notes

- Zero edits to `UserInputComponent` / `AkgentChatComponent` (Story 8-2 / 8-3 contract preserved — AC8 invariant)
- Zero edits to `ContextService` itself
- Stacked on `feat/100-reactive-stop-team-stream` (PR #101, Story 10.5)

Relates to #102. Links: [Story 10.6](../blob/chore/102-cleanup-dead-injections-duplicate-fields/_bmad-output/akgentic-frontend/stories/10-6-cleanup-dead-injections-duplicate-fields.md)
