### PR TITLE
fix: upsert team in ContextService on hard reload (issue #104)

### DIFF
--- a/src/app/services/context.service.spec.ts
+++ b/src/app/services/context.service.spec.ts
@@ -671,6 +671,200 @@ describe('ContextService', () => {
     ).toBeUndefined();
   });
 
+  // =======================================================================
+  // Story 10.7 — upsert on hard reload (issue #104)
+  // =======================================================================
+
+  // --- AC1 (10.7) — empty-cache append via getCurrentTeam(id, false) -----
+
+  it('(AC1 10.7) getCurrentTeam(false) appends team to empty _context$', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const result = await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  // --- AC2 (10.7) — replace path preserves other-slot identity ----------
+
+  it('(AC2 10.7) getCurrentTeam(false) replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    await service.getCurrentTeam('a', false);
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC3 (10.7) — currentTeam$ emits null → team on empty-cache path --
+
+  it('(AC3 10.7) currentTeam$ emits null then team after empty-cache getCurrentTeam(false)', async () => {
+    const emissions: (TeamContext | null)[] = [];
+    const sub = service.currentTeam$.subscribe((t) => emissions.push(t));
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(emissions[0]).toBeNull();
+    expect(emissions[emissions.length - 1]).toBe(teamA);
+    expect(service.currentTeamRunning$.value).toBe(true);
+
+    sub.unsubscribe();
+  });
+
+  // --- AC4 (10.7) — refreshOneTeam follows same upsert invariant --------
+
+  it('(AC4 10.7) refreshOneTeam appends team when _context$ is empty', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBe(teamA);
+    expect(next).toEqual([teamA]);
+    expect(next).not.toBe(prev);
+  });
+
+  it('(AC4 10.7) refreshOneTeam replace path: array ref changes, unchanged slot ref preserved', async () => {
+    const teamA = makeTeam('a', 'running');
+    const teamB = makeTeam('b', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA, teamB]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    const prevA = prev.find((t) => t.team_id === 'a')!;
+    const prevB = prev.find((t) => t.team_id === 'b')!;
+
+    const teamAPrime = makeTeam('a', 'stopped');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamAPrime));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(next).not.toBe(prev);
+    expect(next.length).toBe(2);
+    const nextA = next.find((t) => t.team_id === 'a')!;
+    const nextB = next.find((t) => t.team_id === 'b')!;
+    expect(nextA).toBe(teamAPrime);
+    expect(nextA).not.toBe(prevA);
+    expect(nextB).toBe(prevB);
+  });
+
+  // --- AC5 (10.7) — null API response leaves _context$ unchanged --------
+
+  it('(AC5 10.7) getCurrentTeam(false) null API on empty cache leaves _context$ unchanged', async () => {
+    const prev = await firstValueFrom(service.teams$);
+    expect(prev).toEqual([]);
+
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const result = await service.getCurrentTeam('a', false);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  it('(AC5 10.7) refreshOneTeam null API leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+    apiSpy.getTeam.and.returnValue(Promise.resolve(null as unknown as TeamContext));
+
+    const refreshOneTeam = (
+      service as unknown as { refreshOneTeam: (id: string) => Promise<TeamContext | null> }
+    ).refreshOneTeam.bind(service);
+    const result = await refreshOneTeam('a');
+
+    const next = await firstValueFrom(service.teams$);
+    expect(result).toBeNull();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC6 (10.7) — cache-hit short-circuit unchanged --------------------
+
+  it('(AC6 10.7) getCurrentTeam(true) cache-hit does not call API and leaves _context$ unchanged', async () => {
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeams.and.returnValue(Promise.resolve([teamA]));
+    await service.getTeams();
+
+    const prev = await firstValueFrom(service.teams$);
+
+    const result = await service.getCurrentTeam('a', true);
+    const next = await firstValueFrom(service.teams$);
+
+    expect(result).toBe(teamA);
+    expect(apiSpy.getTeam).not.toHaveBeenCalled();
+    expect(next).toBe(prev);
+  });
+
+  // --- AC7 (10.7) — end-to-end observable contract on hard reload -------
+
+  it('(AC7 10.7) currentTeam$ + currentTeamRunning$ transitions on empty-cache hard reload', async () => {
+    const teamEmissions: (TeamContext | null)[] = [];
+    const runningEmissions: boolean[] = [];
+    const sub1 = service.currentTeam$.subscribe((t) => teamEmissions.push(t));
+    const sub2 = service.currentTeamRunning$.subscribe((r) =>
+      runningEmissions.push(r)
+    );
+
+    service.currentProcessId$.next('a');
+    await Promise.resolve();
+
+    const teamA = makeTeam('a', 'running');
+    apiSpy.getTeam.and.returnValue(Promise.resolve(teamA));
+    await service.getCurrentTeam('a', false);
+    await Promise.resolve();
+
+    expect(teamEmissions[0]).toBeNull();
+    expect(teamEmissions[teamEmissions.length - 1]).toBe(teamA);
+    expect(runningEmissions[0]).toBe(false);
+    expect(runningEmissions[runningEmissions.length - 1]).toBe(true);
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+  });
+
   it('(AC7 10.6) deleteTeam removes the team immutably from _context$', fakeAsync(() => {
     const teamA = makeTeam('a', 'running');
     const teamB = makeTeam('b', 'running');

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -86,11 +86,7 @@ export class ContextService {
     const team = await this.apiService.getTeam(teamId);
 
     if (team) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? team : t
-      );
-      this._context$.next(next);
+      this._upsertTeam(team);
     }
 
     return team;
@@ -118,13 +114,22 @@ export class ContextService {
   private async refreshOneTeam(teamId: string): Promise<TeamContext | null> {
     const fresh = await this.apiService.getTeam(teamId);
     if (fresh) {
-      const prev = this._context$.value;
-      const next = prev.map((t: TeamContext) =>
-        t.team_id === teamId ? fresh : t,
-      );
-      this._context$.next(next);
+      this._upsertTeam(fresh);
     }
     return fresh;
+  }
+
+  /** Upsert a team into `_context$`: replace if already cached (preserves
+   *  reference identity of other slots); append if not yet cached. Single
+   *  write path shared by `getCurrentTeam` and `refreshOneTeam` so the two
+   *  cannot diverge in a future change. Issue #104 regression fix. */
+  private _upsertTeam(team: TeamContext): void {
+    const prev = this._context$.value;
+    const exists = prev.some((t) => t.team_id === team.team_id);
+    const next = exists
+      ? prev.map((t) => (t.team_id === team.team_id ? team : t))
+      : [...prev, team];
+    this._context$.next(next);
   }
 
   async stopTeamAndAwait(


### PR DESCRIPTION
## Hotfix — regression fix for `getCurrentTeam` upsert on hard reload

**Story:** `_bmad-output/akgentic-frontend/stories/10-7-fix-getcurrentteam-upsert-on-hard-reload.md`
**Epic:** 10 — Reactive Team State in ContextService
**Issue:** #104
**Stacked on:** `chore/102-cleanup-dead-injections-duplicate-fields` (PR #103)

### What went wrong

On a hard reload of `/process/{teamId}` (CMD+R or direct URL), `HomeComponent` never mounts, so `_context$` stays at its initial `[]`. `ProcessComponent.ngOnInit` then called `contextService.getCurrentTeam(teamId, false)`, whose update path was `prev.map(...)`. `[].map(...)` is a no-op, so `_context$.next([])` was emitted, `currentTeam$` stayed `null`, and the `AppComponent` header silently disappeared (team name, config, running badge all bound to `undefined`).

### Fix

- Replace `prev.map(...)` in both `getCurrentTeam` (context.service.ts:88-94) and `refreshOneTeam` (context.service.ts:120-126) with an upsert: append if not cached, replace if cached.
- Extract private helper `_upsertTeam(team)` so the two call sites share one write path and can't diverge again in a future change.
- Preserve `useCache=true` cache-hit short-circuit, `if (team)` null-response guard, and the immutability invariant (new array reference, same-id-slot reference changes, other-slot references preserved).

### Tests (8 new, under `Story 10.7` section in `context.service.spec.ts`)

- `(AC1 10.7)` empty-cache append via `getCurrentTeam(false)`.
- `(AC2 10.7)` replace path preserves other-slot reference identity.
- `(AC3 10.7)` `currentTeam$` emits `null → team`.
- `(AC4 10.7)` `refreshOneTeam` append + replace paths.
- `(AC5 10.7)` null API leaves `_context$` unchanged (both methods).
- `(AC6 10.7)` cache-hit short-circuit: no API call, `_context$` ref unchanged.
- `(AC7 10.7)` observable contract: `currentTeam$` and `currentTeamRunning$` transition correctly on empty-cache hard reload.

Local results: **454/454** Jasmine tests pass (`npx ng test --watch=false --browsers=ChromeHeadless`); `npx ng build` succeeds.

### Scope guardrails

Confined to `packages/akgentic-frontend/` (Golden Rule #4). No cross-submodule touches. No public-surface changes to `ContextService` (FR14 preserved).
