### PR TITLE
Fix catalog teams endpoint path

### DIFF
--- a/src/app/app.theme.ts
+++ b/src/app/app.theme.ts
@@ -3,6 +3,14 @@ import { definePreset } from '@primeng/themes';
 import Aura from '@primeng/themes/aura';
 
 const MyPreset = definePreset(Aura, {
+  components: {
+    datatable: {
+      headerCellBackground: 'transparent',
+      headerCellColor: '{text.color}',
+      headerCellSelectedBackground: 'transparent',
+      headerCellSelectedColor: '{text.color}',
+    },
+  },
   semantic: {
     primary: {
       50: '{sky.50}',

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -155,7 +155,7 @@ export class ApiService {
 
   async getTeamConfigs(): Promise<any> {
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/catalog/api/teams`,
+      url: `${this.apiUrl}/admin/catalog/teams`,
     });
   }
 


### PR DESCRIPTION
## Summary

- Fix `getTeamConfigs()` endpoint from `/catalog/api/teams` to `/admin/catalog/teams`
- Remove blue background from datatable header cells via PrimeNG theme preset tokens

Closes #106