### PR TITLE
feat(akgentic-frontend): 1.9 home namespace picker uses /catalog/namespaces

### DIFF
--- a/src/app/home/config-editor/config-editor.component.html
+++ b/src/app/home/config-editor/config-editor.component.html
@@ -11,13 +11,13 @@
     <i class="pi pi-spinner pi-spin" style="font-size: 2rem"></i>
   </div>
 
-  <div *ngIf="!loading && (catalogEntries$ | async) as entries">
-    <h4>Available Catalog Entries</h4>
-    <ul *ngIf="entries.length > 0">
-      <li *ngFor="let entry of entries">
-        {{ entry.name || entry.id }}
+  <div *ngIf="!loading && (namespaces$ | async) as namespaces">
+    <h4>Available Catalog Namespaces</h4>
+    <ul *ngIf="namespaces.length > 0">
+      <li *ngFor="let ns of namespaces" [attr.title]="ns.description">
+        {{ ns.name }}
       </li>
     </ul>
-    <p *ngIf="entries.length === 0">No catalog entries found.</p>
+    <p *ngIf="namespaces.length === 0">No catalog namespaces found.</p>
   </div>
 </div>

--- a/src/app/home/config-editor/config-editor.component.ts
+++ b/src/app/home/config-editor/config-editor.component.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ApiService } from '../../services/api.service';
 import { ButtonModule } from 'primeng/button';
 import { TagModule } from 'primeng/tag';
+import { NamespaceSummary } from '../../models/catalog.interface';
 
 @Component({
   selector: 'app-config-editor',
@@ -23,23 +24,20 @@ import { TagModule } from 'primeng/tag';
 export class ConfigEditorComponent implements OnInit {
   apiService: ApiService = inject(ApiService);
 
-  catalogEntries$ = new BehaviorSubject<any[]>([]);
+  namespaces$ = new BehaviorSubject<NamespaceSummary[]>([]);
   loading = false;
 
   ngOnInit() {
-    this.loadCatalogEntries();
+    this.loadNamespaces();
   }
 
-  async loadCatalogEntries() {
+  async loadNamespaces() {
     this.loading = true;
     try {
-      const response = await this.apiService.getTeamConfigs();
-      const entries = Array.isArray(response)
-        ? response
-        : Object.keys(response).map((key) => ({ id: key, name: key }));
-      this.catalogEntries$.next(entries);
+      const namespaces = await this.apiService.getNamespaces();
+      this.namespaces$.next(namespaces);
     } catch (error) {
-      console.error('Failed to load catalog entries:', error);
+      console.error('Failed to load namespaces:', error);
     } finally {
       this.loading = false;
     }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -3,12 +3,19 @@
   <div class="main-container">
     <p-select
       size="small"
-      [options]="(catalogEntries$ | async) || []"
-      [ngModel]="selectedCatalogEntry$ | async"
-      (ngModelChange)="selectedCatalogEntry$.next($event)"
+      [options]="(namespaces$ | async) || []"
+      [ngModel]="selectedNamespace$ | async"
+      (ngModelChange)="selectedNamespace$.next($event)"
       optionLabel="name"
       placeholder="Select a team type"
-    />
+    >
+      <ng-template let-ns pTemplate="item">
+        <div [attr.title]="ns.description">{{ ns.name }}</div>
+      </ng-template>
+      <ng-template let-ns pTemplate="selectedItem">
+        <div [attr.title]="ns.description">{{ ns.name }}</div>
+      </ng-template>
+    </p-select>
     &nbsp;
     <button
       pButton
@@ -16,7 +23,7 @@
       type="button"
       label="Create"
       [icon]="isCreatingTeam ? 'pi pi-spinner pi-spin' : 'pi pi-plus'"
-      [disabled]="isCreatingTeam"
+      [disabled]="isCreatingTeam || ((namespaces$ | async) || []).length === 0"
       (click)="createTeam()"
       class="extra-small-button"
     ></button>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -40,14 +40,14 @@ describe('HomeComponent', () => {
     teams$ = new BehaviorSubject<TeamContext[]>([]);
 
     apiSpy = jasmine.createSpyObj('ApiService', [
-      'getTeamConfigs',
+      'getNamespaces',
       'createTeam',
       'deleteTeam',
       'restoreTeam',
       'stopTeam',
       'updateTeamDescription',
     ]);
-    apiSpy.getTeamConfigs.and.returnValue(Promise.resolve([]));
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve([]));
     apiSpy.createTeam.and.returnValue(Promise.resolve({} as any));
     apiSpy.deleteTeam.and.returnValue(Promise.resolve());
     apiSpy.restoreTeam.and.returnValue(Promise.resolve({} as any));
@@ -149,8 +149,8 @@ describe('HomeComponent', () => {
   // --- Story 10.4 — HomeComponent.createTeamAndNavigate delegation ------
 
   it('(AC4 10.4) HomeComponent.createTeamAndNavigate delegates to contextService and has no reload compensation', async () => {
-    const entry = { id: 'cat-1', name: 'Cat One' };
-    component.selectedCatalogEntry$.next(entry);
+    const ns = { namespace: 'cat-1', name: 'Cat One', description: 'first cat' };
+    component.selectedNamespace$.next(ns);
     // The component has not invoked ngOnInit yet (no detectChanges in this
     // test), so contextSpy.getTeams should not have been called. Reset to
     // guard against any spurious prior invocation.
@@ -162,9 +162,61 @@ describe('HomeComponent', () => {
   });
 
   it('(AC4 10.4) HomeComponent.createTeamAndNavigate no-entry guard returns cleanly', async () => {
-    component.selectedCatalogEntry$.next(null);
+    component.selectedNamespace$.next(null);
     await component.createTeamAndNavigate();
     expect(contextSpy.createTeamAndNavigate).not.toHaveBeenCalled();
+  });
+
+  // --- Story 1.9 — namespace picker wiring --------------------------------
+
+  it('(AC1 1.9) ngOnInit loads namespaces via getNamespaces and selects the first', async () => {
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([
+        { namespace: 'agent-team-v1', name: 'Agent Team', description: 'Default' },
+        { namespace: 'rag-team-v1', name: 'RAG Team', description: 'With RAG' },
+      ]),
+    );
+    await component.ngOnInit();
+    expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
+    expect(component.namespaces$.value.length).toBe(2);
+    expect(component.selectedNamespace$.value?.namespace).toBe('agent-team-v1');
+  });
+
+  it('(AC3 1.9) createTeam sends the selected namespace to apiService.createTeam', async () => {
+    component.selectedNamespace$.next({
+      namespace: 'agent-team-v1',
+      name: 'Agent Team',
+      description: 'Default',
+    });
+    apiSpy.createTeam.calls.reset();
+    await component.createTeam();
+    expect(apiSpy.createTeam).toHaveBeenCalledOnceWith('agent-team-v1');
+  });
+
+  it('(AC3 1.9) createTeamAndNavigate passes selected.namespace (not an id lookup)', async () => {
+    component.selectedNamespace$.next({
+      namespace: 'rag-team-v1',
+      name: 'RAG Team',
+      description: 'With RAG',
+    });
+    contextSpy.createTeamAndNavigate.calls.reset();
+    await component.createTeamAndNavigate();
+    expect(contextSpy.createTeamAndNavigate).toHaveBeenCalledOnceWith('rag-team-v1');
+  });
+
+  it('(AC5 1.9) empty namespace list leaves the dropdown empty and no selection', async () => {
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve([]));
+    await component.ngOnInit();
+    expect(component.namespaces$.value).toEqual([]);
+    expect(component.selectedNamespace$.value).toBeNull();
+  });
+
+  it('(AC5 1.9) getNamespaces failure does not crash ngOnInit', async () => {
+    apiSpy.getNamespaces.and.returnValue(Promise.reject(new Error('boom')));
+    const consoleErrorSpy = spyOn(console, 'error');
+    await expectAsync(component.ngOnInit()).toBeResolved();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(component.namespaces$.value).toEqual([]);
   });
 
   // --- AC9 ---------------------------------------------------------------

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, firstValueFrom } from 'rxjs';
 
 import { ApiService } from '../services/api.service';
 import { TeamContext, isRunning } from '../models/team.interface';
+import { NamespaceSummary } from '../models/catalog.interface';
 
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
@@ -40,9 +41,9 @@ export class HomeComponent {
   authService: AuthService = inject(AuthService);
   private config = inject(ConfigService);
 
-  // Catalog entries for the team creation dropdown
-  catalogEntries$ = new BehaviorSubject<any[]>([]);
-  selectedCatalogEntry$ = new BehaviorSubject<any>(null);
+  // Catalog namespaces for the team creation dropdown
+  namespaces$ = new BehaviorSubject<NamespaceSummary[]>([]);
+  selectedNamespace$ = new BehaviorSubject<NamespaceSummary | null>(null);
   isCreatingTeam = false;
   isRefreshing = false;
   stoppingTeams = new Set<string>();
@@ -56,30 +57,28 @@ export class HomeComponent {
   isRunning = isRunning;
 
   async ngOnInit() {
-    // Load catalog entries for team creation dropdown
+    // Load catalog namespaces for the team creation dropdown.
+    // The endpoint always returns a list (possibly empty); no defensive
+    // branching needed for dict/array shape.
     try {
-      const catalogResponse = await this.apiService.getTeamConfigs();
-      const entries = Array.isArray(catalogResponse)
-        ? catalogResponse
-        : Object.keys(catalogResponse).map((key) => ({ id: key, name: key }));
-      this.catalogEntries$.next(entries);
-      if (entries.length > 0) {
-        this.selectedCatalogEntry$.next(entries[0]);
+      const namespaces = await this.apiService.getNamespaces();
+      this.namespaces$.next(namespaces);
+      if (namespaces.length > 0) {
+        this.selectedNamespace$.next(namespaces[0]);
       }
     } catch (error) {
-      console.error('Failed to load catalog entries:', error);
+      console.error('Failed to load namespaces:', error);
     }
 
     // Populate _context$; return value reused for the hideHome branch.
     const teams = await this.contextService.getTeams();
 
     if (this.config.hideHome) {
-      // If no team exists, create one using the first catalog entry.
+      // If no team exists, create one using the first namespace.
       if (!teams || teams.length === 0) {
-        const entry = this.selectedCatalogEntry$.value;
-        if (entry) {
-          const catalogEntryId = entry.id ?? entry.name ?? '';
-          await this.contextService.createTeamAndNavigate(catalogEntryId);
+        const selected = this.selectedNamespace$.value;
+        if (selected) {
+          await this.contextService.createTeamAndNavigate(selected.namespace);
         }
       }
       // If a team exists, navigate to its process page.
@@ -95,13 +94,12 @@ export class HomeComponent {
   async createTeam() {
     this.isCreatingTeam = true;
     try {
-      const entry = this.selectedCatalogEntry$.value;
-      if (!entry) {
-        console.warn('No catalog entry selected');
+      const selected = this.selectedNamespace$.value;
+      if (!selected) {
+        console.warn('No namespace selected');
         return;
       }
-      const catalogEntryId = entry.id ?? entry.name ?? '';
-      await this.apiService.createTeam(catalogEntryId);
+      await this.apiService.createTeam(selected.namespace);
       await this.contextService.getTeams();
     } catch (error) {
       console.error('Failed to create team:', error);
@@ -111,13 +109,12 @@ export class HomeComponent {
   }
 
   async createTeamAndNavigate() {
-    const entry = this.selectedCatalogEntry$.value;
-    if (!entry) {
-      console.warn('No catalog entry selected');
+    const selected = this.selectedNamespace$.value;
+    if (!selected) {
+      console.warn('No namespace selected');
       return;
     }
-    const catalogEntryId = entry.id ?? entry.name ?? '';
-    await this.contextService.createTeamAndNavigate(catalogEntryId);
+    await this.contextService.createTeamAndNavigate(selected.namespace);
   }
 
   async deleteTeam(teamId: string) {

--- a/src/app/models/catalog.interface.ts
+++ b/src/app/models/catalog.interface.ts
@@ -1,0 +1,16 @@
+/**
+ * Catalog data models — map to catalog-service DTOs.
+ */
+
+/**
+ * Flat summary of a catalog namespace, returned by `GET /catalog/namespaces`.
+ *
+ * Maps to the catalog backend's `NamespaceSummary` DTO (catalog Story 16.6):
+ * a purpose-built, picker-friendly shape — no `Entry` envelope, no payload,
+ * no user/parent/model metadata.
+ */
+export interface NamespaceSummary {
+  namespace: string;
+  name: string;
+  description: string;
+}

--- a/src/app/models/team.interface.ts
+++ b/src/app/models/team.interface.ts
@@ -31,9 +31,9 @@ export interface EventListResponse {
   events: EventResponse[];
 }
 
-// Maps to Python CreateTeamRequest
+// Maps to Python CreateTeamRequest (akgentic.infra.server.models)
 export interface CreateTeamRequest {
-  catalog_entry_id: string;
+  catalog_namespace: string;
   params?: Record<string, string>;
 }
 

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -42,6 +42,36 @@ describe('ApiService', () => {
     });
   });
 
+  describe('getNamespaces (Story 1.9)', () => {
+    it('hits GET /catalog/namespaces and returns the array', async () => {
+      const payload = [
+        { namespace: 'agent-team-v1', name: 'Agent Team', description: 'Default' },
+      ];
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(payload));
+
+      const result = await service.getNamespaces();
+
+      expect(fetchServiceSpy.fetch).toHaveBeenCalledTimes(1);
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/catalog\/namespaces$/);
+      expect(result).toEqual(payload);
+    });
+  });
+
+  describe('createTeam (Story 1.9)', () => {
+    it('POSTs {catalog_namespace, params:{}} — not catalog_entry_id', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve({} as any));
+
+      await service.createTeam('agent-team-v1');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/teams$/);
+      expect(callArgs.options?.method).toBe('POST');
+      const body = JSON.parse(callArgs.options?.body as string);
+      expect(body).toEqual({ catalog_namespace: 'agent-team-v1', params: {} });
+    });
+  });
+
   describe('sendMessage (existing)', () => {
     it('should broadcast when no agentName provided', async () => {
       await service.sendMessage('team-1', 'broadcast msg');

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -162,7 +162,7 @@ export class ApiService {
    */
   async getNamespaces(): Promise<NamespaceSummary[]> {
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/catalog/namespaces`,
+      url: `${this.apiUrl}/admin/catalog/namespaces`,
     });
   }
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -11,6 +11,7 @@ import {
   EventListResponse,
   toTeamContext,
 } from '../models/team.interface';
+import { NamespaceSummary } from '../models/catalog.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -40,12 +41,12 @@ export class ApiService {
     return toTeamContext(response);
   }
 
-  async createTeam(catalogEntryId: string): Promise<TeamResponse> {
+  async createTeam(namespace: string): Promise<TeamResponse> {
     return await this.fetchService.fetch({
       url: `${this.apiUrl}/teams`,
       options: {
         method: 'POST',
-        body: JSON.stringify({ catalog_entry_id: catalogEntryId }),
+        body: JSON.stringify({ catalog_namespace: namespace, params: {} }),
         headers: { 'Content-Type': 'application/json' },
       },
     });
@@ -151,11 +152,17 @@ export class ApiService {
     return response?.events ?? [];
   }
 
-  // --- Catalog (AC4) ---
+  // --- Catalog ---
 
-  async getTeamConfigs(): Promise<any> {
+  /**
+   * List catalog namespaces (flat summary) — powers the home-screen team
+   * creation dropdown. Consumes catalog Story 16.6's `GET /catalog/namespaces`
+   * endpoint, which returns `NamespaceSummary[]` directly (always a list,
+   * even when empty).
+   */
+  async getNamespaces(): Promise<NamespaceSummary[]> {
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/admin/catalog/teams`,
+      url: `${this.apiUrl}/catalog/namespaces`,
     });
   }
 

--- a/src/app/services/context.service.ts
+++ b/src/app/services/context.service.ts
@@ -103,8 +103,8 @@ export class ContextService {
     await this.router.navigate(['/']);
   }
 
-  async createTeamAndNavigate(catalogEntryId: string) {
-    const response = await this.apiService.createTeam(catalogEntryId);
+  async createTeamAndNavigate(namespace: string) {
+    const response = await this.apiService.createTeam(namespace);
     const newTeam = toTeamContext(response);
     const prev = this._context$.value;
     this._context$.next([...prev, newTeam]);


### PR DESCRIPTION
## Summary

- Switches the home-screen team-creation dropdown to the new `GET /catalog/namespaces` endpoint (catalog Story 16.6), replacing the broken `/admin/catalog/teams` call.
- Fixes the `createTeam` POST body contract: now sends `{ catalog_namespace, params: {} }` to match the backend `CreateTeamRequest` (was sending the obsolete `catalog_entry_id`).
- Adds `NamespaceSummary` TS model, renames `catalogEntries$` → `namespaces$` in `HomeComponent`, migrates the unreferenced `ConfigEditorComponent`, and deletes `getTeamConfigs()` (no shim).
- Dropdown now uses `p-select` item/selectedItem templates to bind `name` as label with `description` as hover title; create button disabled when the list is empty.
- Full suite: 461/461 passing under `ng test --watch=false`; `ng build` clean.

Closes #108
