### PR TITLE
feat(akgentic-frontend): 1-8 complete API-key login — wire to backend

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { ConfigService } from '../services/config.service';
+import { LoginComponent } from './login.component';
+
+/**
+ * Specs for {@link LoginComponent.loginWithApiKey} (Story 1.8).
+ *
+ * `AuthService` and `Router` are replaced with `jasmine.SpyObj` stubs — no
+ * real navigation or backend call occurs.
+ */
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let authSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  function setup(): void {
+    authSpy = jasmine.createSpyObj('AuthService', ['loginWithApiKey']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: Router, useValue: routerSpy },
+        {
+          provide: ConfigService,
+          useValue: {
+            api: 'http://backend.test',
+            logo: '',
+            welcomeMessage: '',
+            loginProviders: ['apikey'],
+          },
+        },
+      ],
+    });
+
+    component = TestBed.createComponent(LoginComponent).componentInstance;
+  }
+
+  beforeEach(() => setup());
+
+  describe('loginWithApiKey — success (AC #1)', () => {
+    it('calls AuthService.loginWithApiKey and navigates to / on success', () => {
+      authSpy.loginWithApiKey.and.returnValue(of({ user_id: 'u1' }));
+      component.apiKey = 'valid-key';
+
+      component.loginWithApiKey();
+
+      expect(authSpy.loginWithApiKey).toHaveBeenCalledWith('valid-key');
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+      expect(component.loading).toBe(false);
+      expect(component.error).toBeNull();
+    });
+  });
+
+  describe('loginWithApiKey — empty key', () => {
+    it('sets the error and does not call the service', () => {
+      component.apiKey = '';
+
+      component.loginWithApiKey();
+
+      expect(component.error).toBe('Please enter an API key');
+      expect(authSpy.loginWithApiKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loginWithApiKey — error (AC #4)', () => {
+    it('surfaces the backend message, resets loading, and does not navigate', () => {
+      authSpy.loginWithApiKey.and.returnValue(
+        throwError(() => new Error('Invalid API key')),
+      );
+      component.apiKey = 'bad-key';
+
+      component.loginWithApiKey();
+
+      expect(component.error).toBe('Invalid API key');
+      expect(component.loading).toBe(false);
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -95,21 +95,17 @@ export class LoginComponent {
     this.error = null;
 
     this.authService.loginWithApiKey(this.apiKey).subscribe({
-      next: (response) => {
+      next: () => {
+        // A non-error response means the backend established the session
+        // cookie — the API key is never persisted client-side.
         this.loading = false;
-        if (response.success) {
-          // Store the API key for future requests
-          this.authService.setApiKey(this.apiKey);
-          // Navigate to home page
-          this.router.navigate(['/']);
-        } else {
-          this.error = response.error || 'Unknown authentication error';
-        }
+        this.router.navigate(['/']);
       },
       error: (err) => {
         this.loading = false;
         this.error =
-          err.error?.error ||
+          err?.error?.error ||
+          err?.message ||
           'Failed to authenticate with the provided API key';
       },
     });

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,124 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { AuthService } from './auth.service';
+import { ConfigService } from './config.service';
+
+/**
+ * Specs for {@link AuthService.loginWithApiKey} (Story 1.8).
+ *
+ * The network boundary is the global `fetch`, which is stubbed via a Jasmine
+ * spy — no real server is contacted. Both the API-key login request and the
+ * follow-up `GET /auth/me` (issued by `checkAuth()`) go through the same spy.
+ */
+describe('AuthService', () => {
+  let service: AuthService;
+  let fetchSpy: jasmine.Spy;
+
+  const API = 'http://backend.test';
+
+  function makeResponse(
+    ok: boolean,
+    body: unknown = null,
+  ): Response {
+    return {
+      ok,
+      json: () => Promise.resolve(body),
+    } as unknown as Response;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: ConfigService,
+          useValue: { api: API, hideLogin: false },
+        },
+      ],
+    });
+    service = TestBed.inject(AuthService);
+    fetchSpy = spyOn(window, 'fetch');
+  });
+
+  describe('loginWithApiKey — success path (AC #1, #3)', () => {
+    it('calls /auth/login/apikey with the key URL-encoded and credentials: include', async () => {
+      // First call: the apikey login. Second call: checkAuth() -> /auth/me.
+      fetchSpy.and.returnValues(
+        Promise.resolve(makeResponse(true)),
+        Promise.resolve(makeResponse(true, { user_id: 'u1', name: 'Op' })),
+      );
+
+      await firstValueFrom(service.loginWithApiKey('secret key/+&'));
+
+      const loginCall = fetchSpy.calls.argsFor(0);
+      expect(loginCall[0]).toBe(
+        `${API}/auth/login/apikey?apikey=${encodeURIComponent('secret key/+&')}`,
+      );
+      expect((loginCall[1] as RequestInit).credentials).toBe('include');
+    });
+
+    it('triggers checkAuth() so currentUser$ reflects the resolved user', async () => {
+      const resolvedUser = { user_id: 'u1', email: 'op@test', name: 'Operator' };
+      fetchSpy.and.returnValues(
+        Promise.resolve(makeResponse(true)),
+        Promise.resolve(makeResponse(true, resolvedUser)),
+      );
+
+      await firstValueFrom(service.loginWithApiKey('valid-key'));
+
+      // checkAuth() hits GET /auth/me with credentials.
+      const meCall = fetchSpy.calls.argsFor(1);
+      expect(meCall[0]).toBe(`${API}/auth/me`);
+      expect((meCall[1] as RequestInit).credentials).toBe('include');
+      expect(service.currentUserValue).toEqual(resolvedUser);
+    });
+  });
+
+  describe('loginWithApiKey — error path (AC #4)', () => {
+    it('errors the observable on an HTTP 401 response', async () => {
+      fetchSpy.and.returnValue(Promise.resolve(makeResponse(false)));
+
+      await expectAsync(
+        firstValueFrom(service.loginWithApiKey('bad-key')),
+      ).toBeRejected();
+    });
+
+    it('does not establish a session on a 401 (currentUser stays anonymous)', async () => {
+      fetchSpy.and.returnValue(Promise.resolve(makeResponse(false)));
+
+      await expectAsync(
+        firstValueFrom(service.loginWithApiKey('bad-key')),
+      ).toBeRejected();
+
+      // No checkAuth() follow-up — only the failed login call was issued.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(service.currentUserValue.user_id).toBe('anonymous');
+    });
+  });
+
+  describe('no client-side key persistence (AC #2)', () => {
+    it('never writes the API key to localStorage or sessionStorage', async () => {
+      const localSpy = spyOn(Storage.prototype, 'setItem').and.callThrough();
+      fetchSpy.and.returnValues(
+        Promise.resolve(makeResponse(true)),
+        Promise.resolve(makeResponse(true, { user_id: 'u1', name: 'Op' })),
+      );
+
+      await firstValueFrom(service.loginWithApiKey('top-secret-key'));
+
+      const persistedKey = localSpy.calls
+        .allArgs()
+        .some((args) => String(args[1]).includes('top-secret-key'));
+      expect(persistedKey).toBe(false);
+    });
+
+    it('exposes no key-storage methods — the removed stubs are gone', () => {
+      // Regression guard for AC #2: the deprecated stubs were deleted.
+      const s = service as unknown as Record<string, unknown>;
+      expect(s['setApiKey']).toBeUndefined();
+      expect(s['getApiKey']).toBeUndefined();
+      expect(s['clearApiKey']).toBeUndefined();
+      expect(s['getAuthHeaders']).toBeUndefined();
+    });
+  });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject, from, Observable, of } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, switchMap, tap } from 'rxjs/operators';
 import { ConfigService } from './config.service';
 
 const ANONYMOUS_USER = { user_id: 'anonymous', email: '', name: 'Anonymous' };
@@ -52,25 +52,42 @@ export class AuthService {
     return this.currentUserSubject.value;
   }
 
-  /** @deprecated Use OAuth flow instead. */
-  loginWithApiKey(_apiKey: string): Observable<any> {
-    return of({ success: true, user: this.currentUserValue });
-  }
-
-  /** @deprecated */
-  setApiKey(_apiKey: string): void {}
-
-  /** @deprecated */
-  clearApiKey(): void {}
-
-  /** @deprecated */
-  getApiKey(): string | null {
-    return null;
-  }
-
-  /** @deprecated */
-  getAuthHeaders(): any {
-    return {};
+  /**
+   * Authenticate with an API key against the backend.
+   *
+   * Drives `GET /auth/login/apikey?apikey=<key>` with `credentials: 'include'`
+   * so the backend's `Set-Cookie` session response is stored by the browser.
+   * The same endpoint contract is exposed by both the Department and Enterprise
+   * tiers, so this single code path covers both — no tier-specific branching.
+   *
+   * The API key is sent once as a query parameter and is NEVER persisted in the
+   * browser; the session cookie set by the backend is the sole post-login
+   * credential, exactly as on the OAuth path.
+   *
+   * On a successful (non-error) response, `checkAuth()` refreshes
+   * `currentUserSubject` from `GET /auth/me` and the observable completes with
+   * the resolved user. On a non-OK response (e.g. HTTP 401 for an invalid,
+   * unknown, or expired key) the observable errors so the caller can surface
+   * the message.
+   */
+  loginWithApiKey(apiKey: string): Observable<any> {
+    const url = `${this.config.api}/auth/login/apikey?apikey=${encodeURIComponent(apiKey)}`;
+    const options: RequestInit = { credentials: 'include' };
+    return from(
+      fetch(url, options).then((r) => {
+        // The backend 302-redirects on success; `fetch` follows it
+        // transparently, so a non-error final response means the session
+        // cookie was set. A 401 (invalid/unknown/expired key) is not ok.
+        if (!r.ok) {
+          throw new Error('Invalid API key');
+        }
+        return r;
+      })
+    ).pipe(
+      // Refresh currentUserSubject from GET /auth/me using the new session
+      // cookie, then complete with the resolved user.
+      switchMap(() => this.checkAuth())
+    );
   }
 
   /** Logout: redirect to backend logout which clears session and redirects to IdP logout. */


### PR DESCRIPTION
## Summary

Completes the **"Login with API Key"** path for the Department and Enterprise tiers (story 1-8).

- `AuthService.loginWithApiKey()` is rewritten from a `@deprecated` no-op stub into a real call: `GET /auth/login/apikey?apikey=<encoded-key>` with `credentials: 'include'`, so the backend's `Set-Cookie` session response is stored. A successful response chains into `checkAuth()` (`GET /auth/me`) to refresh the current user; a non-OK response (HTTP 401 for an invalid/unknown/expired key) surfaces as an observable error.
- The four deprecated client-side key-storage stubs (`setApiKey`, `getApiKey`, `clearApiKey`, `getAuthHeaders`) are deleted. The API key is **never** persisted in the browser — the backend session cookie is the sole post-login credential, exactly as on the OAuth path.
- `LoginComponent.loginWithApiKey()` drops the `setApiKey()` call and navigates to `/` on success; the error branch surfaces the backend message and resets `loading`.
- One code path covers both tiers — no tier-specific branching. Community tier behaviour is unchanged.
- New `auth.service.spec.ts` and `login.component.spec.ts` cover the success path, the 401 error path, and the no-key-persistence guarantee.

## Bug fixed

Previously, clicking "Login with API Key" established **no session**: the stub returned `{ success: true }` synchronously without contacting the backend, so the subsequent `GET /auth/me` had no session cookie and returned HTTP 401, bouncing the user back to `/login`.

## Scope

All changes are inside `packages/akgentic-frontend/` (4 files under `src/app/`). No backend file is modified — the `/auth/login/apikey` endpoint already exists in both the Department and Enterprise tiers with an identical contract. CLAUDE.md Golden Rule #4 satisfied.

## Review

Adversarial code review performed by Rex. All six acceptance criteria verified as implemented. No HIGH or MEDIUM defects found — no review fixup commit was needed. Local gates green: 636/636 Karma tests pass, production build succeeds (only a pre-existing unrelated lodash CommonJS warning).

## Stacking note

This branch is stacked on `feat/110-epic-11-catalog-namespace-panel` (an in-flight epic-11 branch, not `master`). The PR base is set accordingly so the diff shows only the story-1-8 commit. Merge after the epic-11 branch lands.

Relates to #117
