### PR TITLE
fix(akgentic-frontend): 1-9 API-key login consumes the backend JSON response

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -6,10 +6,12 @@ import { ConfigService } from '../services/config.service';
 import { LoginComponent } from './login.component';
 
 /**
- * Specs for {@link LoginComponent.loginWithApiKey} (Story 1.8).
+ * Specs for {@link LoginComponent.loginWithApiKey} (Stories 1.8, 1.9).
  *
  * `AuthService` and `Router` are replaced with `jasmine.SpyObj` stubs — no
- * real navigation or backend call occurs.
+ * real navigation or backend call occurs. `AuthService.loginWithApiKey` now
+ * emits the authenticated user object on success; the component ignores the
+ * value and navigates to `/`.
  */
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -67,7 +69,7 @@ describe('LoginComponent', () => {
     });
   });
 
-  describe('loginWithApiKey — error (AC #4)', () => {
+  describe('loginWithApiKey — error (AC #3)', () => {
     it('surfaces the backend message, resets loading, and does not navigate', () => {
       authSpy.loginWithApiKey.and.returnValue(
         throwError(() => new Error('Invalid API key')),

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -4,11 +4,13 @@ import { AuthService } from './auth.service';
 import { ConfigService } from './config.service';
 
 /**
- * Specs for {@link AuthService.loginWithApiKey} (Story 1.8).
+ * Specs for {@link AuthService.loginWithApiKey} (Stories 1.8, 1.9).
  *
  * The network boundary is the global `fetch`, which is stubbed via a Jasmine
- * spy — no real server is contacted. Both the API-key login request and the
- * follow-up `GET /auth/me` (issued by `checkAuth()`) go through the same spy.
+ * spy — no real server is contacted. The backend returns a `200` JSON body
+ * (`{"success": true, "user": {...}}`) on success; the body itself is the
+ * success signal — no redirect is followed and no `/auth/me` round-trip is
+ * issued.
  */
 describe('AuthService', () => {
   let service: AuthService;
@@ -40,12 +42,11 @@ describe('AuthService', () => {
     fetchSpy = spyOn(window, 'fetch');
   });
 
-  describe('loginWithApiKey — success path (AC #1, #3)', () => {
+  describe('loginWithApiKey — success path (AC #2, #4, #5)', () => {
     it('calls /auth/login/apikey with the key URL-encoded and credentials: include', async () => {
-      // First call: the apikey login. Second call: checkAuth() -> /auth/me.
-      fetchSpy.and.returnValues(
-        Promise.resolve(makeResponse(true)),
-        Promise.resolve(makeResponse(true, { user_id: 'u1', name: 'Op' })),
+      // One call only — the 200 JSON body is the success signal, no /auth/me.
+      fetchSpy.and.returnValue(
+        Promise.resolve(makeResponse(true, { success: true, user: { user_id: 'u1', name: 'Op' } })),
       );
 
       await firstValueFrom(service.loginWithApiKey('secret key/+&'));
@@ -57,24 +58,22 @@ describe('AuthService', () => {
       expect((loginCall[1] as RequestInit).credentials).toBe('include');
     });
 
-    it('triggers checkAuth() so currentUser$ reflects the resolved user', async () => {
+    it('reads the 200 JSON body so currentUser$ reflects the response user', async () => {
       const resolvedUser = { user_id: 'u1', email: 'op@test', name: 'Operator' };
-      fetchSpy.and.returnValues(
-        Promise.resolve(makeResponse(true)),
-        Promise.resolve(makeResponse(true, resolvedUser)),
+      fetchSpy.and.returnValue(
+        Promise.resolve(makeResponse(true, { success: true, user: resolvedUser })),
       );
 
-      await firstValueFrom(service.loginWithApiKey('valid-key'));
+      const result = await firstValueFrom(service.loginWithApiKey('valid-key'));
 
-      // checkAuth() hits GET /auth/me with credentials.
-      const meCall = fetchSpy.calls.argsFor(1);
-      expect(meCall[0]).toBe(`${API}/auth/me`);
-      expect((meCall[1] as RequestInit).credentials).toBe('include');
+      // Single request — no followed redirect, no /auth/me round-trip.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(resolvedUser);
       expect(service.currentUserValue).toEqual(resolvedUser);
     });
   });
 
-  describe('loginWithApiKey — error path (AC #4)', () => {
+  describe('loginWithApiKey — error path (AC #3)', () => {
     it('errors the observable on an HTTP 401 response', async () => {
       fetchSpy.and.returnValue(Promise.resolve(makeResponse(false)));
 
@@ -96,12 +95,11 @@ describe('AuthService', () => {
     });
   });
 
-  describe('no client-side key persistence (AC #2)', () => {
+  describe('no client-side key persistence (AC #6)', () => {
     it('never writes the API key to localStorage or sessionStorage', async () => {
       const localSpy = spyOn(Storage.prototype, 'setItem').and.callThrough();
-      fetchSpy.and.returnValues(
-        Promise.resolve(makeResponse(true)),
-        Promise.resolve(makeResponse(true, { user_id: 'u1', name: 'Op' })),
+      fetchSpy.and.returnValue(
+        Promise.resolve(makeResponse(true, { success: true, user: { user_id: 'u1', name: 'Op' } })),
       );
 
       await firstValueFrom(service.loginWithApiKey('top-secret-key'));
@@ -113,7 +111,7 @@ describe('AuthService', () => {
     });
 
     it('exposes no key-storage methods — the removed stubs are gone', () => {
-      // Regression guard for AC #2: the deprecated stubs were deleted.
+      // Regression guard for AC #6: the deprecated stubs were deleted.
       const s = service as unknown as Record<string, unknown>;
       expect(s['setApiKey']).toBeUndefined();
       expect(s['getApiKey']).toBeUndefined();

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject, from, Observable, of } from 'rxjs';
-import { catchError, switchMap, tap } from 'rxjs/operators';
+import { catchError, tap } from 'rxjs/operators';
 import { ConfigService } from './config.service';
 
 const ANONYMOUS_USER = { user_id: 'anonymous', email: '', name: 'Anonymous' };
@@ -64,29 +64,31 @@ export class AuthService {
    * browser; the session cookie set by the backend is the sole post-login
    * credential, exactly as on the OAuth path.
    *
-   * On a successful (non-error) response, `checkAuth()` refreshes
-   * `currentUserSubject` from `GET /auth/me` and the observable completes with
-   * the resolved user. On a non-OK response (e.g. HTTP 401 for an invalid,
-   * unknown, or expired key) the observable errors so the caller can surface
-   * the message.
+   * On an HTTP `2xx` response the backend returns a `200` JSON body
+   * (`{"success": true, "user": {...}}`) — no redirect. The JSON body itself
+   * is the success signal: its `user` is used to refresh `currentUserSubject`
+   * and the observable completes with that user. On a non-OK response (e.g.
+   * HTTP 401 for an invalid, unknown, or expired key) the observable errors so
+   * the caller can surface the message.
    */
   loginWithApiKey(apiKey: string): Observable<any> {
     const url = `${this.config.api}/auth/login/apikey?apikey=${encodeURIComponent(apiKey)}`;
     const options: RequestInit = { credentials: 'include' };
     return from(
-      fetch(url, options).then((r) => {
-        // The backend 302-redirects on success; `fetch` follows it
-        // transparently, so a non-error final response means the session
-        // cookie was set. A 401 (invalid/unknown/expired key) is not ok.
+      fetch(url, options).then(async (r) => {
+        // A 401 (invalid/unknown/expired key) is not ok — error the observable.
         if (!r.ok) {
           throw new Error('Invalid API key');
         }
-        return r;
+        // Success: the backend binds the session and returns a 200 JSON body.
+        const body = await r.json();
+        const user = body?.user ?? ANONYMOUS_USER;
+        if (user && !user.name) {
+          user.name = user.email || user.user_id || 'User';
+        }
+        this.currentUserSubject.next(user);
+        return user;
       })
-    ).pipe(
-      // Refresh currentUserSubject from GET /auth/me using the new session
-      // cookie, then complete with the resolved user.
-      switchMap(() => this.checkAuth())
     );
   }
 


### PR DESCRIPTION
## Story 1.9 — API-key login consumes the backend JSON response

### The bug this closes
Story 1.8 wired `AuthService.loginWithApiKey()` to call `GET /auth/login/apikey?apikey=…`
with `fetch(url, {credentials: 'include'})`, assuming the backend would `302`-redirect
on success and that `fetch` would follow it transparently.

That assumption was the bug. The backend answered with a `302` whose `Location`
pointed at a **different origin**. When `fetch()` with `credentials: 'include'`
follows a cross-origin redirect, the browser **blocks it with a CORS error** — the
session cookie was set server-side but the frontend never got a usable response,
so login appeared to fail.

### The fix
`AuthService.loginWithApiKey()` now consumes the backend's `200` JSON body
(`{"success": true, "user": {...}}`) as the success signal:
- On a `2xx` response it reads `r.json()`, updates `currentUserSubject` directly
  from the body's `user` (with the existing empty-name fallback), and the
  observable completes with that user.
- The extra `GET /auth/me` round-trip (`switchMap(() => checkAuth())`) is dropped
  — the login body already carries the user. The now-unused `switchMap` import
  was removed.
- A non-`2xx` (`401` for a bad key) still throws so the observable errors and
  `LoginComponent` shows the message.
- The stale "the backend 302-redirects … fetch follows it" comment block is
  removed; the doc comment now describes the `200`-JSON contract.

No redirect is ever followed; no tier-specific branching; the API key is never
persisted in the browser.

### Specs
`auth.service.spec.ts` success tests mock a single `200` JSON body and assert one
fetch with no `/auth/me` follow-up; the `401` error-path and no-key-persistence
tests are retained. `login.component.spec.ts` doc comment refreshed.

### Gates
- Karma suite: 636/636 SUCCESS
- Production build: succeeds
- This package has no `lint` script.

### Scope
Every changed file is inside `packages/akgentic-frontend/`. No backend file is
touched — the `/auth/login/apikey` JSON contract is delivered by the companion
backend PR.

### Stacking
This PR stacks on **PR #118** (story 1-8) and is opened with `--base feat/117-api-key-login`
so the diff shows only the story-1-9 commit. PR #118 must merge first.

It pairs with the backend PR **#87** in `akgentic-infra-department` (story 2-13),
which delivers the `200`-JSON contract for `/auth/login/apikey`.

Relates to #119
