### PR TITLE
feat(akgentic-frontend): 2-6 render welcome message as system message (Rule 5)

### DIFF
--- a/src/app/chat/chat-message.component.html
+++ b/src/app/chat/chat-message.component.html
@@ -43,7 +43,7 @@
     <div class="bubble-header">
       <button
         class="label-pill"
-        [disabled]="message().rule === 1"
+        [disabled]="message().rule === 1 || message().rule === 5"
         (click)="onLabelClick(); $event.stopPropagation()"
       >
         {{ message().label }}

--- a/src/app/chat/chat-message.component.spec.ts
+++ b/src/app/chat/chat-message.component.spec.ts
@@ -636,6 +636,83 @@ describe('ChatMessageComponent', () => {
     });
   });
 
+  describe('Rule 5 (welcome / system message) — Story 2.6', () => {
+    function makeRule5(): ChatMessage {
+      return makeChatMessage({
+        rule: 5,
+        alignment: 'left',
+        color: '#9ebbcb',
+        collapsed: false,
+        label: 'System message',
+        sender: makeAddress({ name: '@Orchestrator', role: 'Orchestrator' }),
+        content: 'Welcome to the agent team !',
+      });
+    }
+
+    it('renders as a left-aligned expanded bubble (no collapsed line)', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.message.left')).toBeTruthy();
+      expect(el.querySelector('.message-bubble')).toBeTruthy();
+      expect(el.querySelector('.collapsed-line')).toBeNull();
+    });
+
+    it('renders the label pill disabled', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.detectChanges();
+
+      const btn = fixture.nativeElement.querySelector('.label-pill');
+      expect(btn.textContent.trim()).toBe('System message');
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('shows no notification icon and no Reply button', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.componentRef.setInput('notification', true);
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.notification-icon')).toBeNull();
+      expect(el.querySelector('.pi-bell')).toBeNull();
+      expect(el.querySelector('.open-button')).toBeNull();
+    });
+
+    it('onBubbleClick is a no-op for Rule 5', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.detectChanges();
+
+      spyOn(component.bubbleClicked, 'emit');
+      spyOn(component.toggleCollapse, 'emit');
+      const messageEl = fixture.nativeElement.querySelector('.message');
+      messageEl.click();
+
+      expect(component.bubbleClicked.emit).not.toHaveBeenCalled();
+      expect(component.toggleCollapse.emit).not.toHaveBeenCalled();
+    });
+
+    it('onLabelClick is a no-op for Rule 5', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.detectChanges();
+
+      spyOn(component.messageSelected, 'emit');
+      component.onLabelClick();
+
+      expect(component.messageSelected.emit).not.toHaveBeenCalled();
+    });
+
+    it('onToggleCollapse is a no-op for Rule 5', () => {
+      fixture.componentRef.setInput('message', makeRule5());
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      component.onToggleCollapse();
+
+      expect(component.toggleCollapse.emit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Rule 2 label — @Sender ⇒ You (Story 4.3)', () => {
     it('renders label pill ending with "⇒ You" for Rule 2', () => {
       const msg = makeChatMessage({

--- a/src/app/chat/chat-message.component.ts
+++ b/src/app/chat/chat-message.component.ts
@@ -24,6 +24,8 @@ export class ChatMessageComponent {
 
   onToggleCollapse(): void {
     const msg = this.message();
+    // Rule 5 (welcome) is behaviourally inert (ADR-011 Decision 3).
+    if (msg.rule === 5) return;
     if (msg.rule === 3 || msg.rule === 4) {
       this.toggleCollapse.emit(msg);
     }
@@ -31,6 +33,8 @@ export class ChatMessageComponent {
 
   onLabelClick(): void {
     const msg = this.message();
+    // Rule 5 (welcome) is behaviourally inert (ADR-011 Decision 3).
+    if (msg.rule === 5) return;
     if (msg.rule !== 1) {
       this.messageSelected.emit(msg);
     }
@@ -39,6 +43,8 @@ export class ChatMessageComponent {
   onBubbleClick(event: Event): void {
     event.stopPropagation();
     const msg = this.message();
+    // Rule 5 (welcome) is behaviourally inert (ADR-011 Decision 3).
+    if (msg.rule === 5) return;
     switch (msg.rule) {
       case 1:
       case 2:

--- a/src/app/models/chat-message.model.spec.ts
+++ b/src/app/models/chat-message.model.spec.ts
@@ -5,6 +5,7 @@ import {
   classifyMessage,
   ENTRY_POINT_NAME,
   ChatMessage,
+  SYSTEM_MESSAGE_LABEL,
 } from './chat-message.model';
 import { ActorAddress, SentMessage, BaseMessage } from './message.types';
 
@@ -52,9 +53,34 @@ function makeSentMessage(overrides: Partial<SentMessage> = {}): SentMessage {
   };
 }
 
+/** A welcome `SentMessage`: outer `ActorSystem` sender, inner `WelcomeMessage`
+ *  payload with `display_type === 'other'` (Story 2.6, ADR-011). */
+function makeWelcomeSent(overrides: Partial<SentMessage> = {}): SentMessage {
+  return makeSentMessage({
+    id: 'welcome-outer-1',
+    sender: makeAddress({ name: '@ActorSystem', role: 'ActorSystem' }),
+    recipient: makeAddress({ name: '@Human', role: 'Human' }),
+    display_type: 'other',
+    message: makeBaseMessage({
+      id: 'welcome-inner-1',
+      sender: makeAddress({ name: '@Orchestrator', role: 'Orchestrator' }),
+      display_type: 'other',
+      content: 'Welcome to the agent team !',
+      __model__: 'akgentic.team.messages.WelcomeMessage',
+    }),
+    ...overrides,
+  });
+}
+
 describe('ENTRY_POINT_NAME', () => {
   it('should be @Human', () => {
     expect(ENTRY_POINT_NAME).toBe('@Human');
+  });
+});
+
+describe('SYSTEM_MESSAGE_LABEL', () => {
+  it('should be "System message"', () => {
+    expect(SYSTEM_MESSAGE_LABEL).toBe('System message');
   });
 });
 
@@ -105,6 +131,36 @@ describe('classifyRule', () => {
       recipient: makeAddress({ name: '@Human', role: 'Human' }),
     });
     expect(classifyRule(msg)).toBe(2);
+  });
+
+  // Story 2.6 (AC4) — Rule 5 is checked FIRST
+  it('Rule 5: welcome announcement classifies as 5', () => {
+    expect(classifyRule(makeWelcomeSent())).toBe(5);
+  });
+
+  it('Rule 5 is checked first: outer recipient @Human does NOT make it Rule 2', () => {
+    // The welcome event's outer recipient is @Human — without the first-match
+    // it would classify as Rule 2.
+    expect(classifyRule(makeWelcomeSent())).toBe(5);
+  });
+
+  it('ordinary SentMessage still classifies as Rule 1-4 (Rule 5 unchanged)', () => {
+    expect(
+      classifyRule(
+        makeSentMessage({
+          sender: makeAddress({ name: '@Human', role: 'Human' }),
+          recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+        }),
+      ),
+    ).toBe(1);
+    expect(
+      classifyRule(
+        makeSentMessage({
+          sender: makeAddress({ name: '@Worker', role: 'Worker' }),
+          recipient: makeAddress({ name: '@Manager', role: 'Manager' }),
+        }),
+      ),
+    ).toBe(4);
   });
 });
 
@@ -163,6 +219,12 @@ describe('buildLabel', () => {
     });
     const label = buildLabel(msg, 2);
     expect(label.endsWith('⇒ You')).toBe(true);
+  });
+
+  it('Rule 5: returns the fixed SYSTEM_MESSAGE_LABEL (Story 2.6)', () => {
+    const label = buildLabel(makeWelcomeSent(), 5);
+    expect(label).toBe(SYSTEM_MESSAGE_LABEL);
+    expect(label).not.toContain('⇒');
   });
 });
 
@@ -381,5 +443,40 @@ describe('classifyMessage', () => {
     });
     const result = classifyMessage(msg);
     expect(result.timestamp instanceof Date).toBe(true);
+  });
+
+  // Story 2.6 (AC5) — Rule 5 ChatMessage
+  it('Rule 5: builds a ChatMessage with rule 5, left alignment, Rule-4 blue, not collapsed', () => {
+    const result = classifyMessage(makeWelcomeSent());
+    expect(result.rule).toBe(5);
+    expect(result.alignment).toBe('left');
+    expect(result.color).toBe('#9ebbcb');
+    expect(result.collapsed).toBe(false);
+    expect(result.label).toBe(SYSTEM_MESSAGE_LABEL);
+  });
+
+  it('Rule 5: sender is taken from the INNER WelcomeMessage.sender, not the outer envelope', () => {
+    const result = classifyMessage(makeWelcomeSent());
+    // Inner sender is @Orchestrator; outer envelope sender is @ActorSystem.
+    expect(result.sender.name).toBe('@Orchestrator');
+    expect(result.sender.role).toBe('Orchestrator');
+  });
+
+  it('Rule 5: content is taken from the inner WelcomeMessage.content', () => {
+    const result = classifyMessage(makeWelcomeSent());
+    expect(result.content).toBe('Welcome to the agent team !');
+  });
+
+  it('non-Rule-5 messages still read the OUTER envelope sender', () => {
+    const result = classifyMessage(
+      makeSentMessage({
+        sender: makeAddress({ name: '@Manager', role: 'Manager' }),
+        recipient: makeAddress({ name: '@Human', role: 'Human' }),
+        message: makeBaseMessage({
+          sender: makeAddress({ name: '@Inner', role: 'Worker' }),
+        }),
+      }),
+    );
+    expect(result.sender.name).toBe('@Manager');
   });
 });

--- a/src/app/models/chat-message.model.ts
+++ b/src/app/models/chat-message.model.ts
@@ -1,9 +1,18 @@
-import { ActorAddress, SentMessage } from './message.types';
+import {
+  ActorAddress,
+  isWelcomeAnnouncement,
+  SentMessage,
+} from './message.types';
 import { makeAgentNameUserFriendly } from '../lib/util';
 
 export const ENTRY_POINT_NAME = '@Human';
 
-export type MessageRule = 1 | 2 | 3 | 4;
+/** Fixed label for Rule 5 (welcome) messages. Defined in exactly one place so
+ *  it is updatable / i18n-ready without touching `buildLabel` logic
+ *  (ADR-011 Decision 3, AC6). */
+export const SYSTEM_MESSAGE_LABEL = 'System message';
+
+export type MessageRule = 1 | 2 | 3 | 4 | 5;
 
 export interface ChatMessage {
   /** Outer `SentMessage` envelope id — used to route human replies back to
@@ -28,13 +37,19 @@ export interface ChatMessage {
 }
 
 /**
- * Classify a SentMessage into one of 4 rules (first-match wins):
+ * Classify a SentMessage into one of 5 rules (first-match wins):
+ *   Rule 5: welcome announcement -> left-aligned, system-labelled, inert
  *   Rule 1: sender is @Human -> right-aligned, persona color
  *   Rule 2: recipient is @Human -> left-aligned, blue
  *   Rule 3: recipient role is Human but not @Human -> left-aligned, blue, notification
  *   Rule 4: everything else (AI-to-AI) -> left-aligned, blue, collapsed
+ *
+ * Rule 5 is checked FIRST (ADR-011 Decision 3): the welcome event's outer
+ * `recipient` is `@Human`, so without the first-match it would classify as
+ * Rule 2 and expose the `@ActorSystem` transport envelope.
  */
 export function classifyRule(msg: SentMessage): MessageRule {
+  if (isWelcomeAnnouncement(msg)) return 5;
   if (msg.sender.name === ENTRY_POINT_NAME) return 1;
   if (msg.recipient.name === ENTRY_POINT_NAME) return 2;
   if (msg.recipient.role === 'Human' && msg.recipient.name !== ENTRY_POINT_NAME) return 3;
@@ -47,6 +62,7 @@ export function classifyRule(msg: SentMessage): MessageRule {
  *   Rule 2: "@{sender} ⇒ You" (recipient expanded explicitly for multi-human teams)
  *   Rule 3: "@{sender} ⇒ @{recipient}"
  *   Rule 4: "@{sender} ⇒ @{recipient}"
+ *   Rule 5: fixed `SYSTEM_MESSAGE_LABEL` (ADR-011 Decision 3) — not conversational
  */
 export function buildLabel(msg: SentMessage, rule: MessageRule): string {
   const senderName = makeAgentNameUserFriendly(msg.sender.name);
@@ -60,6 +76,8 @@ export function buildLabel(msg: SentMessage, rule: MessageRule): string {
     case 3:
     case 4:
       return `${senderName} ⇒ ${recipientName}`;
+    case 5:
+      return SYSTEM_MESSAGE_LABEL;
   }
 }
 
@@ -68,6 +86,7 @@ const RULE_COLORS: Record<MessageRule, string> = {
   2: '#9ebbcb',
   3: '#9ebbcb',
   4: '#9ebbcb',
+  5: '#9ebbcb', // reuses the Rule 4 blue (ADR-011 Decision 3)
 };
 
 /**
@@ -126,12 +145,19 @@ export function buildPreview(
  */
 export function classifyMessage(msg: SentMessage): ChatMessage {
   const rule = classifyRule(msg);
+  // ASYMMETRY (ADR-011 Decision 3): every rule reads the OUTER `msg.sender`,
+  // but Rule 5 alone reads the INNER `msg.message.sender` — the welcome
+  // announcement's outer envelope sender is the `@ActorSystem` transport
+  // listener; the semantically meaningful sender is the inner
+  // `WelcomeMessage.sender` (`@Orchestrator`). `recipient` stays on the outer
+  // envelope (unused for Rule 5 rendering).
+  const sender = rule === 5 ? msg.message.sender : msg.sender;
   return {
     id: msg.id,
     message_id: msg.message.id,
     parent_id: msg.message.parent_id,
     content: msg.message.content ?? '',
-    sender: msg.sender,
+    sender,
     recipient: msg.recipient,
     timestamp: new Date(msg.timestamp),
     rule,

--- a/src/app/models/message.types.spec.ts
+++ b/src/app/models/message.types.spec.ts
@@ -1,0 +1,116 @@
+import {
+  ActorAddress,
+  BaseMessage,
+  isWelcomeAnnouncement,
+  isWelcomeMessage,
+  SentMessage,
+  WelcomeMessage,
+} from './message.types';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
+  return {
+    __actor_address__: true,
+    name: '@Agent',
+    role: 'Worker',
+    agent_id: 'agent-1',
+    squad_id: 'squad-1',
+    user_message: false,
+    ...overrides,
+  };
+}
+
+function makeWelcome(overrides: Partial<WelcomeMessage> = {}): WelcomeMessage {
+  return {
+    id: 'welcome-inner-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T10:00:00Z',
+    sender: makeAddress({ name: '@Orchestrator', role: 'Orchestrator' }),
+    display_type: 'other',
+    content: 'Welcome to the agent team !',
+    __model__: 'akgentic.team.messages.WelcomeMessage',
+    ...overrides,
+  };
+}
+
+function makeOrdinaryInner(overrides: Partial<BaseMessage> = {}): BaseMessage {
+  return {
+    id: 'inner-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T10:00:00Z',
+    sender: makeAddress(),
+    display_type: 'ai',
+    content: 'ordinary content',
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    ...overrides,
+  };
+}
+
+function makeSent(inner: BaseMessage, senderRole = 'ActorSystem'): SentMessage {
+  return {
+    id: 'outer-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T10:00:00Z',
+    sender: makeAddress({ name: '@ActorSystem', role: senderRole }),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    message: inner,
+    recipient: makeAddress({ name: '@Human', role: 'Human' }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isWelcomeMessage — inner-payload check
+// ---------------------------------------------------------------------------
+
+describe('isWelcomeMessage', () => {
+  it('returns true for a WelcomeMessage inner payload', () => {
+    expect(isWelcomeMessage(makeWelcome())).toBe(true);
+  });
+
+  it('returns false for an ordinary BaseMessage', () => {
+    expect(isWelcomeMessage(makeOrdinaryInner())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWelcomeAnnouncement — envelope check (BOTH signals required, ADR-011 D1)
+// ---------------------------------------------------------------------------
+
+describe('isWelcomeAnnouncement', () => {
+  it('returns true when inner is a WelcomeMessage AND inner display_type is "other"', () => {
+    const msg = makeSent(makeWelcome({ display_type: 'other' }));
+    expect(isWelcomeAnnouncement(msg)).toBe(true);
+  });
+
+  it('returns false when the inner payload is not a WelcomeMessage (missing __model__ signal)', () => {
+    const msg = makeSent(makeOrdinaryInner({ display_type: 'other' }));
+    expect(isWelcomeAnnouncement(msg)).toBe(false);
+  });
+
+  it('returns false when the inner WelcomeMessage display_type is not "other"', () => {
+    const msg = makeSent(makeWelcome({ display_type: 'ai' }));
+    expect(isWelcomeAnnouncement(msg)).toBe(false);
+  });
+
+  it('returns false for a non-SentMessage envelope', () => {
+    const notSent = makeWelcome({
+      __model__:
+        'akgentic.core.messages.orchestrator.StartMessage' as unknown as WelcomeMessage['__model__'],
+    });
+    expect(isWelcomeAnnouncement(notSent)).toBe(false);
+  });
+
+  it('returns false when the SentMessage has no inner message', () => {
+    const msg = makeSent(makeWelcome());
+    (msg as { message?: BaseMessage }).message = undefined;
+    expect(isWelcomeAnnouncement(msg)).toBe(false);
+  });
+});

--- a/src/app/models/message.types.ts
+++ b/src/app/models/message.types.ts
@@ -103,6 +103,17 @@ export interface ResultMessage extends BaseMessage {
   content: string;
 }
 
+/**
+ * Synthetic team startup greeting announced by the orchestrator on the team
+ * event stream (akgentic-team ADR-17). On the chat path it only ever appears
+ * as the inner `SentMessage.message` payload — see `isWelcomeAnnouncement`.
+ * See ADR-011 (Welcome Message Chat Rendering) Decision 1.
+ */
+export interface WelcomeMessage extends BaseMessage {
+  __model__: 'akgentic.team.messages.WelcomeMessage';
+  content: string;
+}
+
 // Union type for all possible messages
 export type AkgenticMessage =
   | SentMessage
@@ -158,4 +169,27 @@ export function isUserMessage(msg: BaseMessage): msg is UserMessage {
 
 export function isResultMessage(msg: BaseMessage): msg is ResultMessage {
   return msg.__model__.includes('ResultMessage');
+}
+
+/**
+ * Inner-payload check: true when the message itself is a `WelcomeMessage`.
+ * Consistent with the other `is*` guards — matches on `__model__`.
+ */
+export function isWelcomeMessage(msg: BaseMessage): msg is WelcomeMessage {
+  return msg.__model__.includes('WelcomeMessage');
+}
+
+/**
+ * Envelope check (ADR-011 Decision 1): true only when `msg` is a `SentMessage`
+ * whose inner `message` is a `WelcomeMessage` AND that inner payload carries
+ * `display_type === 'other'`. Both signals are required (belt-and-suspenders):
+ * `__model__` is the precise type identity, `display_type === 'other'`
+ * confirms the render category.
+ */
+export function isWelcomeAnnouncement(msg: BaseMessage): boolean {
+  if (!isSentMessage(msg)) return false;
+  const inner = (msg as SentMessage).message;
+  return (
+    !!inner && isWelcomeMessage(inner) && inner.display_type === 'other'
+  );
 }

--- a/src/app/process/message-list/message-list.component.spec.ts
+++ b/src/app/process/message-list/message-list.component.spec.ts
@@ -1,0 +1,158 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+
+import { MessageListComponent } from './message-list.component';
+import { MessageLogService } from '../../services/message-log.service';
+import { AkgenticMessage, SentMessage } from '../../models/message.types';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function workerSent(id: string): SentMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T00:00:00Z',
+    sender: {
+      __actor_address__: true,
+      name: '@Worker',
+      role: 'Worker',
+      agent_id: 'worker-1',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    display_type: 'ai',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    recipient: {
+      __actor_address__: true,
+      name: '@Manager',
+      role: 'Manager',
+      agent_id: 'manager-1',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    message: {
+      id: `${id}-inner`,
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: '2026-05-18T00:00:00Z',
+      sender: {
+        __actor_address__: true,
+        name: '@Worker',
+        role: 'Worker',
+        agent_id: 'worker-1',
+        team_id: 'team-1',
+        squad_id: 's',
+        user_message: false,
+      },
+      display_type: 'ai',
+      content: 'ordinary message',
+      __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    },
+  };
+}
+
+/** A welcome `SentMessage`: outer `ActorSystem` sender, inner `WelcomeMessage`
+ *  payload with `display_type === 'other'` (Story 2.6, ADR-011). */
+function welcomeSent(id: string): SentMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T00:00:00Z',
+    sender: {
+      __actor_address__: true,
+      name: '@ActorSystem',
+      role: 'ActorSystem',
+      agent_id: 'sys',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    recipient: {
+      __actor_address__: true,
+      name: '@Human',
+      role: 'Human',
+      agent_id: 'human',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    message: {
+      id: `${id}-inner`,
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: '2026-05-18T00:00:00Z',
+      sender: {
+        __actor_address__: true,
+        name: '@Orchestrator',
+        role: 'Orchestrator',
+        agent_id: 'orch',
+        team_id: 'team-1',
+        squad_id: 's',
+        user_message: false,
+      },
+      display_type: 'other',
+      content: 'Welcome to the agent team !',
+      __model__: 'akgentic.team.messages.WelcomeMessage',
+    },
+  };
+}
+
+describe('MessageListComponent (Story 2.6, AC8)', () => {
+  let component: MessageListComponent;
+  let fixture: ComponentFixture<MessageListComponent>;
+  let log: MessageLogService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessageListComponent, NoopAnimationsModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+        // MessageLogService is component-scoped in production; provide it at
+        // module level here so the test can drive the log directly.
+        MessageLogService,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MessageListComponent);
+    component = fixture.componentInstance;
+    log = TestBed.inject(MessageLogService);
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('excludes the welcome announcement from filteredMessages', () => {
+    log.appendAll([welcomeSent('w1') as AkgenticMessage]);
+    fixture.detectChanges();
+
+    expect(component.filteredMessages.map((m) => m.id)).not.toContain('w1');
+    expect(component.filteredMessages.length).toBe(0);
+  });
+
+  it('keeps ordinary messages while filtering out the welcome announcement', () => {
+    log.appendAll([
+      welcomeSent('w1') as AkgenticMessage,
+      workerSent('s1') as AkgenticMessage,
+    ]);
+    fixture.detectChanges();
+
+    expect(component.filteredMessages.map((m) => m.id)).toEqual(['s1']);
+  });
+});

--- a/src/app/process/message-list/message-list.component.ts
+++ b/src/app/process/message-list/message-list.component.ts
@@ -13,6 +13,7 @@ import { UtilService } from '../../services/utils.service';
 import { combineLatest, Subscription } from 'rxjs';
 import { AkgentService } from '../../services/akgent.service';
 import { MessageLogService } from '../../services/message-log.service';
+import { isWelcomeAnnouncement } from '../../models/message.types';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
 
 @Component({
@@ -63,11 +64,15 @@ export class MessageListComponent {
       this.messages = messages;
       this.filteredMessages = messages.filter(
         (message) =>
-          !selectedCategories ||
-          (message.sender?.squad_id &&
-            selectedCategories[
-              this.categoryService.squadDict[message.sender.squad_id]
-            ])
+          // ADR-011 Decision 4: the welcome announcement is admitted by
+          // `messageListFold` but excluded from the process message-list
+          // table — it belongs to the chat panel only.
+          !isWelcomeAnnouncement(message) &&
+          (!selectedCategories ||
+            (message.sender?.squad_id &&
+              selectedCategories[
+                this.categoryService.squadDict[message.sender.squad_id]
+              ]))
       );
 
       setTimeout(() => this.scroll(), 0);

--- a/src/app/services/chat.service.spec.ts
+++ b/src/app/services/chat.service.spec.ts
@@ -147,6 +147,38 @@ function makeEvent(
   };
 }
 
+/** A welcome `SentMessage`: outer `ActorSystem` sender, inner `WelcomeMessage`
+ *  payload with `display_type === 'other'` (Story 2.6, ADR-011). */
+function makeWelcomeSent(overrides: Partial<SentMessage> = {}): SentMessage {
+  return {
+    id: 'welcome-outer-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T10:00:00Z',
+    sender: makeAddress({
+      name: '@ActorSystem',
+      role: 'ActorSystem',
+      agent_id: 'sys-1',
+    }),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    message: makeInnerBase({
+      id: 'welcome-inner-1',
+      sender: makeAddress({
+        name: '@Orchestrator',
+        role: 'Orchestrator',
+        agent_id: 'orch-1',
+      }),
+      display_type: 'other',
+      content: 'Welcome to the agent team !',
+      __model__: 'akgentic.team.messages.WelcomeMessage',
+    }),
+    recipient: makeAddress({ name: '@Human', role: 'Human', agent_id: 'human-1' }),
+    ...overrides,
+  };
+}
+
 function makeUnknown(): AkgenticMessage {
   return {
     id: 'unk',
@@ -373,6 +405,41 @@ describe('chatFold / chatStep (pure)', () => {
     const after = chatStep(before, makeStateChanged());
     expect(after).toBe(before);
   });
+
+  // Story 2.6 (AC3) — welcome announcement reaches the chat panel
+  it('welcome announcement is admitted into messages despite ActorSystem outer sender', () => {
+    const state = chatFold([makeWelcomeSent()]);
+    expect(state.messages.length).toBe(1);
+    expect(state.messages[0].id).toBe('welcome-outer-1');
+    expect(state.messages[0].rule).toBe(5);
+  });
+
+  it('welcome announcement with empty content is still dropped (empty-content guard)', () => {
+    const msg = makeWelcomeSent({
+      message: makeInnerBase({
+        content: '',
+        display_type: 'other',
+        __model__: 'akgentic.team.messages.WelcomeMessage',
+      }),
+    });
+    expect(chatFold([msg]).messages.length).toBe(0);
+  });
+
+  it('welcome announcement does NOT spawn or finalise a thinking bubble', () => {
+    const rcv = makeReceived();
+    const state = chatFold([rcv, makeWelcomeSent()]);
+    // The Received agent's thinking bubble is untouched by the welcome message.
+    expect(state.thinkingAgents.length).toBe(1);
+    expect(state.thinkingAgents[0].agent_id).toBe('agent-1');
+    expect(state.thinkingAgents[0].final).toBe(false);
+  });
+
+  it('ordinary ActorSystem SentMessage is still dropped from messages', () => {
+    const msg = makeSent({
+      sender: makeAddress({ role: 'ActorSystem', name: '@ActorSystem' }),
+    });
+    expect(chatFold([msg]).messages.length).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -481,6 +548,13 @@ describe('ChatService (selector over log$)', () => {
     expect((await firstValueFrom(service.thinkingAgents$)).length).toBe(1);
     log.reset();
     expect((await firstValueFrom(service.thinkingAgents$)).length).toBe(0);
+  });
+
+  it('(Story 2.6, AC3) welcome announcement reaches messages$', async () => {
+    log.append(makeWelcomeSent());
+    const msgs = await firstValueFrom(service.messages$);
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].rule).toBe(5);
   });
 
   it('pendingNotifications$ reacts to Rule 3 messages via the derived messages$', async () => {

--- a/src/app/services/chat.service.ts
+++ b/src/app/services/chat.service.ts
@@ -20,6 +20,7 @@ import {
   isProcessedMessage,
   isReceivedMessage,
   isSentMessage,
+  isWelcomeAnnouncement,
   ProcessedMessage,
   ReceivedMessage,
   SentMessage,
@@ -138,7 +139,13 @@ export function computePendingNotifications(
  * the classification previously performed by `ChatPanelComponent.ngOnInit`.
  */
 function messageFromSent(msg: SentMessage): ChatMessage | null {
-  if (msg.sender.role === ACTOR_SYSTEM_ROLE) return null;
+  // ADR-011 Decision 3: the welcome announcement carries an `ActorSystem`
+  // transport sender but must reach the chat panel — admit it via the
+  // structural exception. `applySentToThinking` deliberately keeps the plain
+  // `ACTOR_SYSTEM_ROLE` early-return so the welcome message spawns no
+  // thinking bubble.
+  if (msg.sender.role === ACTOR_SYSTEM_ROLE && !isWelcomeAnnouncement(msg))
+    return null;
   if (msg.message.content == null || msg.message.content === '') return null;
   return classifyMessage(msg);
 }

--- a/src/app/services/message-log.service.spec.ts
+++ b/src/app/services/message-log.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { AkgenticMessage } from '../models/message.types';
+import { AkgenticMessage, SentMessage } from '../models/message.types';
 import { MessageLogService, messageListFold } from './message-log.service';
 
 function msg(
@@ -26,6 +26,56 @@ function msg(
     content: null,
     __model__: `akgentic.core.messages.orchestrator.${model}`,
   } as AkgenticMessage;
+}
+
+/** A welcome `SentMessage`: outer `ActorSystem` sender, inner `WelcomeMessage`
+ *  payload with `display_type === 'other'` (ADR-011 Story 2.6). */
+function welcomeSent(id: string): SentMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-05-18T00:00:00Z',
+    sender: {
+      __actor_address__: true,
+      name: '@ActorSystem',
+      role: 'ActorSystem',
+      agent_id: 'sys',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.SentMessage',
+    recipient: {
+      __actor_address__: true,
+      name: '@Human',
+      role: 'Human',
+      agent_id: 'human',
+      team_id: 'team-1',
+      squad_id: 's',
+      user_message: false,
+    },
+    message: {
+      id: `${id}-inner`,
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: '2026-05-18T00:00:00Z',
+      sender: {
+        __actor_address__: true,
+        name: '@Orchestrator',
+        role: 'Orchestrator',
+        agent_id: 'orch',
+        team_id: 'team-1',
+        squad_id: 's',
+        user_message: false,
+      },
+      display_type: 'other',
+      content: 'Welcome to the agent team !',
+      __model__: 'akgentic.team.messages.WelcomeMessage',
+    },
+  };
 }
 
 describe('MessageLogService (Story 6.1)', () => {
@@ -153,6 +203,21 @@ describe('messageListFold (Story 6.4, AC4)', () => {
       msg('d', 'SentMessage'),
     ];
     expect(messageListFold(log).map((m) => m.id)).toEqual(['a', 'c', 'd']);
+  });
+
+  // Story 2.6 (AC2) — welcome announcement exception
+  it('admits the welcome announcement despite its ActorSystem outer sender', () => {
+    const out = messageListFold([welcomeSent('w1')]);
+    expect(out.map((m) => m.id)).toEqual(['w1']);
+  });
+
+  it('still excludes ordinary ActorSystem-sender messages alongside an admitted welcome', () => {
+    const log: AkgenticMessage[] = [
+      welcomeSent('w1'),
+      msg('s1', 'SentMessage', 'ActorSystem'),
+      msg('s2', 'SentMessage', 'Worker'),
+    ];
+    expect(messageListFold(log).map((m) => m.id)).toEqual(['w1', 's2']);
   });
 });
 

--- a/src/app/services/message-log.service.ts
+++ b/src/app/services/message-log.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, distinctUntilChanged, map, Observable } from 'rxjs';
 
-import { AkgenticMessage } from '../models/message.types';
+import { AkgenticMessage, isWelcomeAnnouncement } from '../models/message.types';
 
 /**
  * Story 6.4 (AC4) — pure selector over the log producing the inputs for
@@ -16,7 +16,9 @@ export function messageListFold(log: AkgenticMessage[]): AkgenticMessage[] {
       !!m.__model__ &&
       (m.__model__.includes('SentMessage') ||
         m.__model__.includes('ErrorMessage')) &&
-      m.sender?.role !== 'ActorSystem',
+      // ADR-011 Decision 2: the welcome announcement carries an `ActorSystem`
+      // transport sender, but is admitted via the structural exception.
+      (m.sender?.role !== 'ActorSystem' || isWelcomeAnnouncement(m)),
   );
 }
 


### PR DESCRIPTION
## Summary

Story 2.6 — adds a fifth message-classification rule (Rule 5) for the synthetic team `WelcomeMessage`, a startup greeting announced by the orchestrator on the team event stream. Rule 5 renders the greeting as a left-aligned, system-labelled, behaviourally-inert chat bubble.

Source of record: ADR-011 (Welcome Message Chat Rendering), Decisions 1–5.

## Changes

- Add `WelcomeMessage` interface and `isWelcomeMessage` / `isWelcomeAnnouncement` dual-signal guards (inner `__model__` includes `WelcomeMessage` AND inner `display_type === 'other'`).
- Widen **both** ingestion paths' `ActorSystem` drops with the `isWelcomeAnnouncement` exception — `messageListFold` (process table) and `messageFromSent` (chat panel). The chat panel renders from `chatService.messages$` → `chatFold` → `messageFromSent`, an independent path from `messageListFold`; both must be widened or the greeting never reaches the chat panel.
- Add Rule 5 to the classifier: `MessageRule` widened to `1|2|3|4|5`; `classifyRule` checks `isWelcomeAnnouncement` first; `buildLabel` returns the new single-source `SYSTEM_MESSAGE_LABEL` constant; `RULE_COLORS[5]` reuses the Rule 4 blue; `classifyMessage` reads the inner `WelcomeMessage.sender` for Rule 5 only (commented asymmetry).
- Make `ChatMessageComponent` inert for Rule 5: `onBubbleClick` / `onLabelClick` / `onToggleCollapse` early-return; label pill rendered `[disabled]`.
- Exclude the welcome announcement from the process message-list table via a view-level filter in `MessageListComponent`.

## Review

Adversarial code review (Rex) of commit `a327022`: all 10 ACs implemented, all 8 tasks verified. The `messageFromSent` widening (Open Question Q1) is an intentional, well-documented deviation from ADR-011's literal Files-Changed list — it is the chat-path counterpart of Decision 2's fold change, required for Decision 3 to take effect; verified end-to-end. No fix-worthy issues found; no fixup commit needed.

## Verification

- Build green (only the pre-existing lodash-not-ESM warning).
- Full Karma suite: 668/668 SUCCESS.
- All changes confined to `packages/akgentic-frontend/src/app/`.

Closes #121
