### PR TITLE
feat: clone-namespace modal pre-fills destination namespace + display name (ADR-012)

### DIFF
--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
@@ -186,7 +186,7 @@
     data-test="clone-dialog"
   >
     <div class="namespace-panel__clone-body">
-      <label for="clone-dest-ns-input">Destination namespace name</label>
+      <label for="clone-dest-ns-input">Destination namespace</label>
       <input
         #cloneDestInput
         id="clone-dest-ns-input"
@@ -196,6 +196,17 @@
         [(ngModel)]="cloneDestNs"
         (ngModelChange)="onCloneDestNsChange()"
         data-test="clone-destns-input"
+        autocomplete="off"
+      />
+      <label for="clone-dest-name-input">Destination name</label>
+      <input
+        id="clone-dest-name-input"
+        type="text"
+        pInputText
+        name="cloneDestName"
+        [(ngModel)]="cloneDestName"
+        (ngModelChange)="onCloneDestNsChange()"
+        data-test="clone-destname-input"
         autocomplete="off"
       />
       <div

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
@@ -27,8 +27,11 @@ import { ApiService } from '../../../services/api.service';
 import { HttpError } from '../../../services/fetch.service';
 import {
   CloneYamlError,
+  extractYamlName,
   extractYamlNamespace,
   rewriteNamespaceInYaml,
+  suggestDestName,
+  suggestDestNamespace,
 } from '../../../services/yaml-clone.helper';
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
@@ -166,6 +169,14 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    * successful clone (AC 3, AC 8, AC 12).
    */
   cloneDestNs: string = '';
+  /**
+   * Destination display name typed into the Clone dialog — rewritten into
+   * the bundle's root `name:` field (the meta header surfaced in the
+   * home-page dropdown). Pre-filled with a `<source>_copy` suggestion when
+   * the modal opens; reset to `''` on dialog dismiss AND on successful
+   * clone, mirroring `cloneDestNs`.
+   */
+  cloneDestName: string = '';
   /**
    * True while a clone-import request is in flight (AC 8 + AC 14). Gates
    * the Confirm button (defence in depth alongside the pre-flight
@@ -800,6 +811,14 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     if (this.cloning) {
       return;
     }
+    // Pre-fill the modal inputs from the current buffer. Source values are
+    // best-effort: `extractYamlName` returns null on a header-less bundle,
+    // in which case the name suggestion falls back to the namespace string
+    // (rare path — meta header is required by the v17.5+ wire format).
+    const srcNs = extractYamlNamespace(this.buffer) ?? this.namespace;
+    const srcName = extractYamlName(this.buffer) ?? srcNs;
+    this.cloneDestNs = suggestDestNamespace(srcNs);
+    this.cloneDestName = suggestDestName(srcName);
     this.cloneDialogVisible = true;
   }
 
@@ -811,6 +830,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   onCloneCancelClick(): void {
     this.cloneDialogVisible = false;
     this.cloneDestNs = '';
+    this.cloneDestName = '';
   }
 
   /**
@@ -824,6 +844,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     this.cloneDialogVisible = visible;
     if (!visible) {
       this.cloneDestNs = '';
+      this.cloneDestName = '';
     }
   }
 
@@ -842,6 +863,9 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       return true;
     }
     if (this.existingNamespaces.includes(trimmed)) {
+      return true;
+    }
+    if (this.cloneDestName.trim() === '') {
       return true;
     }
     if (this.cloning) {
@@ -868,6 +892,9 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     }
     if (this.existingNamespaces.includes(trimmed)) {
       return `Namespace '${trimmed}' already exists`;
+    }
+    if (this.cloneDestName.trim() === '') {
+      return 'Destination name required';
     }
     return null;
   }
@@ -962,6 +989,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    */
   onCloneDialogHide(): void {
     this.cloneDestNs = '';
+    this.cloneDestName = '';
     this.cloneInlineError = null;
     setTimeout(() => {
       this.cloneBtnRef?.nativeElement.focus();
@@ -1008,11 +1036,12 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       return;
     }
     const destNs = this.cloneDestNs.trim();
+    const destName = this.cloneDestName.trim();
     const sourceYaml = this.buffer;
     this.cloning = true;
     this.lastCloneError = null;
     try {
-      const rewrittenYaml = rewriteNamespaceInYaml(sourceYaml, destNs);
+      const rewrittenYaml = rewriteNamespaceInYaml(sourceYaml, destNs, destName);
       await this.apiService.importNamespace(rewrittenYaml);
       if (this.destroyed) {
         return;
@@ -1023,6 +1052,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       // re-exports the bundle and flips mode to view (Story 11.2).
       this.cloneDialogVisible = false;
       this.cloneDestNs = '';
+      this.cloneDestName = '';
       this.cloneInlineError = null;
       this.saved.emit();
       this.namespace = destNs;

--- a/src/app/services/yaml-clone.helper.spec.ts
+++ b/src/app/services/yaml-clone.helper.spec.ts
@@ -2,8 +2,11 @@ import yaml from 'js-yaml';
 
 import {
   CloneYamlError,
+  extractYamlName,
   extractYamlNamespace,
   rewriteNamespaceInYaml,
+  suggestDestName,
+  suggestDestNamespace,
 } from './yaml-clone.helper';
 
 /**
@@ -210,5 +213,104 @@ describe('extractYamlNamespace', () => {
 
   it('returns null when namespace is not a string (e.g. a number)', () => {
     expect(extractYamlNamespace('namespace: 42\nentries: {}\n')).toBeNull();
+  });
+});
+
+describe('rewriteNamespaceInYaml — destName parameter', () => {
+  it('rewrites root `name` when destName is provided', () => {
+    const input = 'namespace: src\nname: Source Display\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(input, 'dst', 'Dest Display');
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['namespace']).toBe('dst');
+    expect(parsed['name']).toBe('Dest Display');
+  });
+
+  it('leaves root `name` unchanged when destName is omitted', () => {
+    const input = 'namespace: src\nname: Source Display\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(input, 'dst');
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['namespace']).toBe('dst');
+    expect(parsed['name']).toBe('Source Display');
+  });
+
+  it('adds a root `name` when the bundle has none and destName is provided', () => {
+    const input = 'namespace: src\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(input, 'dst', 'Dest Display');
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['name']).toBe('Dest Display');
+  });
+
+  it('throws CloneYamlError when destName is the empty string', () => {
+    const valid = 'namespace: src\nname: Source\nentries: {}\n';
+    expect(() => rewriteNamespaceInYaml(valid, 'dst', '')).toThrowError(
+      CloneYamlError,
+      'destName must be a non-empty string when provided',
+    );
+  });
+});
+
+describe('extractYamlName', () => {
+  it('returns the top-level name string on a header-bearing bundle', () => {
+    const input = 'namespace: foo\nname: Foo Display\nentries: {}\n';
+    expect(extractYamlName(input)).toBe('Foo Display');
+  });
+
+  it('returns null when the mapping has no name key', () => {
+    expect(extractYamlName('namespace: foo\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null when name is not a string', () => {
+    expect(extractYamlName('namespace: foo\nname: 42\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null on malformed YAML', () => {
+    expect(extractYamlName('namespace: foo\nentries: [\n  unclosed\n')).toBeNull();
+  });
+
+  it('returns null when the root is not a mapping', () => {
+    expect(extractYamlName('- 1\n- 2\n')).toBeNull();
+  });
+});
+
+describe('suggestDestNamespace', () => {
+  it('appends a fresh _<5 alphanumerics> suffix when none is present', () => {
+    const out = suggestDestNamespace('foo');
+    expect(out).toMatch(/^foo_[A-Za-z0-9]{5}$/);
+  });
+
+  it('strips a trailing _<5 alphanumerics> suffix and appends a fresh one', () => {
+    const out = suggestDestNamespace('foo_a1b2c');
+    expect(out).toMatch(/^foo_[A-Za-z0-9]{5}$/);
+    // The fresh suffix is almost-certainly different from the source's
+    // (collision probability ~1 / 62^5 ≈ 1e-9 — negligible for a unit
+    // test). Asserting inequality guards the strip-then-append behaviour.
+    expect(out).not.toBe('foo_a1b2c');
+  });
+
+  it('does not strip a trailing underscore-suffix of the wrong length', () => {
+    // 4 chars — should not match the strip regex; the whole input becomes the base.
+    const out = suggestDestNamespace('foo_abcd');
+    expect(out).toMatch(/^foo_abcd_[A-Za-z0-9]{5}$/);
+  });
+
+  it('does not strip a trailing suffix containing non-alphanumerics', () => {
+    const out = suggestDestNamespace('foo_a-b2c');
+    expect(out).toMatch(/^foo_a-b2c_[A-Za-z0-9]{5}$/);
+  });
+
+  it('produces different suggestions across calls (randomness sanity-check)', () => {
+    const a = suggestDestNamespace('foo');
+    const b = suggestDestNamespace('foo');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('suggestDestName', () => {
+  it('appends _copy to the source name', () => {
+    expect(suggestDestName('Foo Display')).toBe('Foo Display_copy');
+  });
+
+  it('handles the empty source name', () => {
+    expect(suggestDestName('')).toBe('_copy');
   });
 });

--- a/src/app/services/yaml-clone.helper.ts
+++ b/src/app/services/yaml-clone.helper.ts
@@ -54,12 +54,19 @@ export class CloneYamlError extends Error {
  * inside payload, block-scalar quoting) are invisible to the user after
  * re-export.
  */
-export function rewriteNamespaceInYaml(input: string, destNs: string): string {
+export function rewriteNamespaceInYaml(
+  input: string,
+  destNs: string,
+  destName?: string,
+): string {
   // Defence-in-depth: the panel's Confirm-button disabled rule prevents
   // empty destNs from ever reaching the helper, but mirror Story 11.3's
   // `savedBuffer` pattern and validate the caller-supplied string.
   if (typeof destNs !== 'string' || destNs.length === 0) {
     throw new CloneYamlError('destNs must be a non-empty string');
+  }
+  if (destName !== undefined && (typeof destName !== 'string' || destName.length === 0)) {
+    throw new CloneYamlError('destName must be a non-empty string when provided');
   }
 
   let parsed: unknown;
@@ -86,6 +93,14 @@ export function rewriteNamespaceInYaml(input: string, destNs: string): string {
   // Rewrite only the document-level namespace key — entries and payload
   // subtrees are untouched (ADR-011 D5 step 3; see docstring above).
   doc['namespace'] = destNs;
+
+  // Optionally rewrite the document-level `name` key (the meta header's
+  // display name surfaced in the home-page namespace dropdown). The export
+  // serializer hoists `meta.payload.name` to a root `name:` field, so the
+  // rewrite happens at the same level as `namespace`.
+  if (destName !== undefined) {
+    doc['name'] = destName;
+  }
 
   return yaml.dump(doc, { sortKeys: false, lineWidth: -1, noRefs: true });
 }
@@ -116,4 +131,64 @@ export function extractYamlNamespace(input: string): string | null {
   }
   const ns = (parsed as Record<string, unknown>)['namespace'];
   return typeof ns === 'string' ? ns : null;
+}
+
+/**
+ * Best-effort extraction of the top-level `name:` field (the meta header's
+ * display name) from a bundle YAML string. Returns `null` when the input
+ * cannot be parsed, the root is not a mapping, or the `name` key is missing
+ * or not a string. Used by the Clone modal to pre-fill the destination-name
+ * input with a "<source>_copy" suggestion.
+ */
+export function extractYamlName(input: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(input);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const name = (parsed as Record<string, unknown>)['name'];
+  return typeof name === 'string' ? name : null;
+}
+
+const RANDOM_SUFFIX_RE = /_[A-Za-z0-9]{5}$/;
+const RANDOM_SUFFIX_ALPHABET =
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+function randomAlphanumeric(length: number): string {
+  // crypto.getRandomValues is available in every browser Angular targets and
+  // in jsdom (Karma test env). Avoids Math.random's predictability without
+  // pulling in a dependency.
+  const out: string[] = [];
+  const buf = new Uint32Array(length);
+  crypto.getRandomValues(buf);
+  for (let i = 0; i < length; i++) {
+    out.push(RANDOM_SUFFIX_ALPHABET[buf[i] % RANDOM_SUFFIX_ALPHABET.length]);
+  }
+  return out.join('');
+}
+
+/**
+ * Suggest a destination namespace for a clone: strip a trailing
+ * `_<5 alphanumerics>` suffix from `srcNs` if one is present, then append a
+ * freshly-generated `_<5 alphanumerics>` suffix. So `foo_a1b2c` becomes
+ * `foo_x9k2m`, and `foo` becomes `foo_x9k2m`. The collision check in the
+ * Clone modal still applies, so the operator can re-roll by reopening the
+ * dialog if the suggestion happens to clash with an existing namespace.
+ */
+export function suggestDestNamespace(srcNs: string): string {
+  const base = srcNs.replace(RANDOM_SUFFIX_RE, '');
+  return `${base}_${randomAlphanumeric(5)}`;
+}
+
+/**
+ * Suggest a destination display name for a clone: append `_copy` to the
+ * source name. Returns `'_copy'` for the empty string (rare — the meta
+ * header is required) so the suggestion is always non-empty.
+ */
+export function suggestDestName(srcName: string): string {
+  return `${srcName}_copy`;
 }


### PR DESCRIPTION
## Summary

- Add a second labelled input — **Destination name** — to the clone sub-dialog of `NamespacePanelComponent`, two-way-bound to a new `cloneDestName` field.
- On modal open, pre-fill both inputs from the current buffer: namespace uses strip-then-append a `_<5 alphanumerics>` random suffix; display name appends `_copy`.
- Extend `rewriteNamespaceInYaml` with an optional `destName` argument that rewrites the bundle's root `name:` field in lockstep with the existing `namespace:` rewrite. Backwards-compatible: omitting the argument preserves the prior single-key behaviour.
- Pure helpers `suggestDestNamespace`, `suggestDestName`, and `extractYamlName` live next to the existing helpers in `services/yaml-clone.helper.ts` with full Karma unit coverage (15 new cases).

Relates to #123.

ADR: [adr-012-clone-namespace-modal-suggestions.md](https://github.com/b12consulting/akgentic-quick-start/blob/master/_bmad-output/akgentic-frontend/decisions/adr-012-clone-namespace-modal-suggestions.md)
Epic: [epic-12-clone-namespace-modal-suggestions.md](https://github.com/b12consulting/akgentic-quick-start/blob/master/_bmad-output/akgentic-frontend/epics/epic-12-clone-namespace-modal-suggestions.md)
Story: [12-1-clone-modal-pre-fills-namespace-and-name.md](https://github.com/b12consulting/akgentic-quick-start/blob/master/_bmad-output/akgentic-frontend/stories/12-1-clone-modal-pre-fills-namespace-and-name.md)

## Test plan

- [x] `yaml-clone.helper.spec.ts` — 29/29 cases green (14 pre-existing + 15 new across `rewriteNamespaceInYaml — destName parameter`, `extractYamlName`, `suggestDestNamespace`, `suggestDestName`).
- [x] `namespace-panel.component.spec.ts` — 89/89 cases green (no pre-existing regression).
- [x] Manual smoke: open the clone modal twice on the same namespace; verify the suggested namespace differs each time and the display name is `<source>_copy`.
- [x] Manual smoke: clone with the suggested defaults; verify the new row in the home-page dropdown shows the `_copy`-suffixed label, distinguishable from the source.