### PR TITLE
feat: reorder clone modal fields and add per-field help text

### DIFF
--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
@@ -186,20 +186,9 @@
     data-test="clone-dialog"
   >
     <div class="namespace-panel__clone-body">
-      <label for="clone-dest-ns-input">Destination namespace</label>
-      <input
-        #cloneDestInput
-        id="clone-dest-ns-input"
-        type="text"
-        pInputText
-        name="cloneDestNs"
-        [(ngModel)]="cloneDestNs"
-        (ngModelChange)="onCloneDestNsChange()"
-        data-test="clone-destns-input"
-        autocomplete="off"
-      />
       <label for="clone-dest-name-input">Destination name</label>
       <input
+        #cloneDestInput
         id="clone-dest-name-input"
         type="text"
         pInputText
@@ -208,7 +197,28 @@
         (ngModelChange)="onCloneDestNsChange()"
         data-test="clone-destname-input"
         autocomplete="off"
+        aria-describedby="clone-dest-name-hint"
       />
+      <small id="clone-dest-name-hint" class="namespace-panel__clone-hint">
+        Used to select this team configuration in the dropdown (user-facing).
+        Can be changed later by editing the configuration header.
+      </small>
+      <label for="clone-dest-ns-input">Destination namespace</label>
+      <input
+        id="clone-dest-ns-input"
+        type="text"
+        pInputText
+        name="cloneDestNs"
+        [(ngModel)]="cloneDestNs"
+        (ngModelChange)="onCloneDestNsChange()"
+        data-test="clone-destns-input"
+        autocomplete="off"
+        aria-describedby="clone-dest-ns-hint"
+      />
+      <small id="clone-dest-ns-hint" class="namespace-panel__clone-hint">
+        Technical identifier that uniquely groups all elements of the
+        configuration (DB view). Cannot be changed after cloning.
+      </small>
       <div
         *ngIf="cloneValidationError"
         class="namespace-panel__clone-error"

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.scss
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.scss
@@ -76,6 +76,19 @@
     }
   }
 
+  // Per-field help text under each Clone input. Muted grey + smaller than
+  // body text so it reads as guidance, not an error (which is red). A small
+  // negative top margin pulls the hint close to its input; the bottom margin
+  // separates it from the next field's label.
+  .namespace-panel__clone-hint {
+    display: block;
+    margin-top: -0.25rem;
+    margin-bottom: 0.25rem;
+    color: #6b7280;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+  }
+
   // Pre-flight validation hint (empty / same-as-source / collision).
   // Muted red, smaller than body text so it reads as helper text, not a
   // critical alert — the operator can still re-type.


### PR DESCRIPTION
## Summary
Improves the Clone namespace modal so operators understand the two destination fields.

- Reorder: **Destination name** now appears above **Destination namespace**.
- Per-field help text (muted, `aria-describedby`-linked):
  - **Name** — used to select the team configuration in the dropdown (user-facing); editable later via the configuration header.
  - **Namespace** — technical identifier uniquely grouping all configuration elements (DB view); cannot be changed after cloning.
- Autofocus moves to the name field (now first).

Scope: `namespace-panel` Clone sub-dialog only.

Closes #125