### PR TITLE
feat(akgentic-frontend): epic 13 — Human-Input Modal Sends Inner Message Id (13-1-human-input-modal-emits-inner-message-id)

### DIFF
--- a/src/app/chat/chat-human-modal.component.html
+++ b/src/app/chat/chat-human-modal.component.html
@@ -50,18 +50,18 @@
           pTextarea
           style="width: 100%; min-height: 80px; max-height: 200px"
           [autoResize]="true"
-          [ngModel]="getReplyBuffer(msg.id)"
-          (ngModelChange)="setReplyBuffer(msg.id, $event)"
+          [ngModel]="getReplyBuffer(msg.message_id)"
+          (ngModelChange)="setReplyBuffer(msg.message_id, $event)"
           placeholder="Type your reply..."
-          (keydown.meta.enter)="onSendForRequest(msg.id)"
-          (keydown.control.enter)="onSendForRequest(msg.id)"
+          (keydown.meta.enter)="onSendForRequest(msg.message_id)"
+          (keydown.control.enter)="onSendForRequest(msg.message_id)"
         ></textarea>
         <div class="reply-actions">
           <p-button
             label="Send"
             size="small"
-            [disabled]="!getReplyBuffer(msg.id).trim()"
-            (click)="onSendForRequest(msg.id)"
+            [disabled]="!getReplyBuffer(msg.message_id).trim()"
+            (click)="onSendForRequest(msg.message_id)"
           />
         </div>
       </div>

--- a/src/app/chat/chat-human-modal.component.spec.ts
+++ b/src/app/chat/chat-human-modal.component.spec.ts
@@ -190,6 +190,56 @@ describe('ChatHumanModalComponent', () => {
     });
   });
 
+  describe('inner message id (ADR-027 Decision 2)', () => {
+    it('emits the INNER message_id, not the outer id, when they differ', () => {
+      const msg = makeChatMessage({ id: 'outer-1', message_id: 'inner-1' });
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', [msg]);
+      fixture.detectChanges();
+
+      const emitted: HumanModalReply[] = [];
+      component.reply.subscribe((r: HumanModalReply) => emitted.push(r));
+
+      // Template binds the inner id; buffer is keyed by message_id.
+      component.replyBuffers.set('inner-1', 'inner reply');
+      component.onSendForRequest('inner-1');
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].messageId).toBe('inner-1');
+      expect(emitted[0].messageId).not.toBe('outer-1');
+    });
+
+    it('clicking the rendered Send button emits the inner message_id', () => {
+      const msg = makeChatMessage({ id: 'outer-1', message_id: 'inner-1' });
+      fixture.componentRef.setInput('visible', true);
+      fixture.componentRef.setInput('pendingMessages', [msg]);
+      fixture.detectChanges();
+
+      const emitted: HumanModalReply[] = [];
+      component.reply.subscribe((r: HumanModalReply) => emitted.push(r));
+
+      // Type into the textarea via the inner-id-keyed buffer, then click Send.
+      component.setReplyBuffer('inner-1', 'typed via DOM');
+      fixture.detectChanges();
+
+      const sendButton = document.querySelector(
+        '.pending-request .reply-actions button',
+      ) as HTMLButtonElement | null;
+      expect(sendButton).toBeTruthy();
+      sendButton!.click();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].content).toBe('typed via DOM');
+      expect(emitted[0].messageId).toBe('inner-1');
+      expect(emitted[0].messageId).not.toBe('outer-1');
+    });
+
+    it('trackByRequestId returns the inner message_id', () => {
+      const msg = makeChatMessage({ id: 'outer-1', message_id: 'inner-1' });
+      expect(component.trackByRequestId(0, msg)).toBe('inner-1');
+    });
+  });
+
   describe('DOM rendering', () => {
     it('renders one .pending-request per pending message', () => {
       fixture.componentRef.setInput('visible', true);

--- a/src/app/chat/chat-human-modal.component.ts
+++ b/src/app/chat/chat-human-modal.component.ts
@@ -48,7 +48,8 @@ export class ChatHumanModalComponent {
   @Output() visibleChange = new EventEmitter<boolean>();
   @Output() reply = new EventEmitter<HumanModalReply>();
 
-  /** Per-request reply buffer, keyed on `request.id`. */
+  /** Per-request reply buffer, keyed on the inner `request.message_id`
+   *  (ADR-027 Decision 2) — the id the backend resolves human-input by. */
   replyBuffers: Map<string, string> = new Map();
 
   get headerText(): string {
@@ -83,7 +84,9 @@ export class ChatHumanModalComponent {
   }
 
   trackByRequestId(_index: number, msg: ChatMessage): string {
-    return msg.id;
+    // Reply key is the INNER message id (ADR-027 Decision 2): the backend
+    // resolves human-input by ChatMessage.message_id, not the outer envelope id.
+    return msg.message_id;
   }
 
   trackByAnsweredId(_index: number, a: AnsweredRequest): string {


### PR DESCRIPTION
## Epic 13 — Human-Input Modal Sends Inner Message Id

Brings the last remaining frontend caller of `POST /teams/{id}/human-input` that still sent the **outer** envelope id into line with the converging backend contract, which now resolves `human-input` by the **inner** `Message.id`. This is a one-field correction in the human-input modal: the reply key, reply-buffer key, and `trackByRequestId` switch from `ChatMessage.id` (outer `SentMessage` envelope id) to `ChatMessage.message_id` (inner `BaseMessage.id`). The wire payload shape is unchanged — the same `message_id` field now carries the inner value.

### Stories

- [x] **13-1** — Human-Input Modal Emits Inner Message Id (Relates to #127)

## Review status

| Story | Verdict | Notes |
|-------|---------|-------|
| 13-1-human-input-modal-emits-inner-message-id | done (approved) | All 7 ACs satisfied. 6 template bindings + `trackByRequestId` switched to `msg.message_id`; `onSendForRequest`, `chat-panel.component.ts`, and `api.service.ts` untouched as required. 3 new inner-id specs added (method-level, DOM Send-button click, trackBy), each using a fixture where `id ≠ message_id` and asserting the emitted `messageId` is the inner id (`not.toBe` the outer). Full Karma suite green (687/687). No fix-worthy issues — no fixup commit. |

## Scope guard

All changes stay inside `packages/akgentic-frontend/`. Exactly three files touched:

- `src/app/chat/chat-human-modal.component.html`
- `src/app/chat/chat-human-modal.component.ts`
- `src/app/chat/chat-human-modal.component.spec.ts`

No backend / other-submodule files modified. No service contract, model shape, or dependency changes.

## Sibling coordination

This epic is functionally paired with **akgentic-infra Epic 30** (issue #294, branch `feat/294-epic-30-human-input-resolves-by-inner-message-id`). The backend must resolve `human-input` by the inner `Message.id` **before** this frontend change ships — otherwise human-input replies will 404 with `Message <id> not found`.

**Merge/deploy ordering:** the backend PR (akgentic-infra Epic 30) MUST land and deploy first. This frontend PR is self-contained and testable in isolation (the Karma specs assert the emitted id with no backend), but the end-to-end round-trip only works once both sides agree on the inner id.

## Epic 13 slice complete

13-1 is the only and final story in Epic 13. With it merged, every frontend human-input caller emits the inner `message_id`, fully consistent with the rest of the inner-id model (pending-notification matching, `parent_id` reply linkage). The outer `ChatMessage.id` is retained and still drives visual selection and message-list `trackBy`. Epic 13 is complete pending the coordinated backend merge above.
