### PR TITLE
feat(akgentic-frontend): epic 14 — Delete-Namespace Button (ADR-028)

### DIFF
--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
@@ -89,6 +89,22 @@
         data-test="clone-btn"
       ></button>
 
+      <!-- Delete. VIEW-MODE ONLY (Story 14.1 / ADR-028 frontend leg). Dark-red
+           destructive action; opens a confirm naming the namespace before
+           issuing DELETE. Disabled while a delete is in flight. -->
+      <button
+        *ngIf="mode === 'view'"
+        pButton
+        type="button"
+        size="small"
+        severity="danger"
+        label="Delete"
+        icon="pi pi-trash"
+        [disabled]="deleting"
+        (click)="onDeleteClick()"
+        data-test="delete-ns-btn"
+      ></button>
+
       <!-- EDIT mode: Validate · Save · Reset · Cancel (in that order) -->
 
       <!-- Validate buffer. Same flash pattern as the view-mode counterpart. -->

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -82,6 +82,7 @@ describe('NamespacePanelComponent', () => {
       'importNamespace',
       'validateNamespaceBuffer',
       'validatePersistedNamespace',
+      'deleteNamespace',
     ]);
     messageSpy = jasmine.createSpyObj('MessageService', ['add']);
     // Use a REAL ConfirmationService instance (its `requireConfirmation$`
@@ -1937,4 +1938,239 @@ entries:
     expect(document.activeElement).toBe(stub);
     document.body.removeChild(stub);
   }));
+
+  // ---------------------------------------------------------------------
+  // Story 14.1 — Delete-namespace button + confirmation (ADR-028 frontend leg)
+  // ---------------------------------------------------------------------
+
+  /**
+   * Capture the config object passed to ConfirmationService.confirm and
+   * invoke its `accept` callback — drives the delete-confirm branch
+   * deterministically (mirrors the existing clone/cancel confirm tests).
+   */
+  function acceptLastConfirm(): void {
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    args.accept!();
+  }
+
+  // ----- Button render: view mode vs edit mode (AC 11) -----
+
+  it('(14.1 AC11) Delete button renders in view mode', async () => {
+    await loadedEditMode('foo: 1\n');
+    const btn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    );
+    expect(btn).not.toBeNull();
+  });
+
+  it('(14.1 AC11) Delete button is absent in edit mode', async () => {
+    await loadedEditMode('foo: 1\n');
+    await component.onEditClick();
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    );
+    expect(btn).toBeNull();
+  });
+
+  // ----- Confirm open + accept/cancel (AC 12) -----
+
+  it('(14.1 AC12) clicking Delete opens the confirmation; accepting calls deleteNamespace once with the current namespace', async () => {
+    await loadedEditMode('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+
+    component.onDeleteClick();
+    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    expect(args.header).toBe('Delete namespace');
+    expect(args.icon).toBe('pi pi-trash');
+    expect(args.message as string).toContain('foo');
+
+    acceptLastConfirm();
+    await fixture.whenStable();
+
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
+  });
+
+  it('(14.1 AC12) cancelling the confirm does NOT call deleteNamespace (no reject side effects)', async () => {
+    await loadedEditMode('foo: 1\n');
+
+    component.onDeleteClick();
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    // No reject callback is wired — cancel = pure no-op.
+    expect(args.reject).toBeUndefined();
+    // Simulate cancel: never call accept.
+    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
+  });
+
+  // ----- 204 success path (AC 13, AC 6) -----
+
+  it('(14.1 AC13) 204 success — emits saved + closed and shows a success toast', async () => {
+    await loadedEditMode('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+    const savedEmit = spyOn(component.saved, 'emit');
+    const closedEmit = spyOn(component.closed, 'emit');
+
+    await component.onDeleteConfirm();
+
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
+    expect(savedEmit).toHaveBeenCalledTimes(1);
+    expect(closedEmit).toHaveBeenCalledTimes(1);
+    expect(component.deleting).toBeFalse();
+    const toast = messageSpy.add.calls.mostRecent().args[0];
+    expect(toast.severity).toBe('success');
+    expect(toast.summary).toContain('foo');
+    // a11y live-region announcement set.
+    expect(component.a11yAnnouncement).toBe("Namespace 'foo' deleted");
+  });
+
+  // ----- 403 not-authorized (AC 14) -----
+
+  it('(14.1 AC14) 403 — not-authorized toast, panel open, state unchanged, single call (not retried)', async () => {
+    await loadedEditMode('foo: 1\n');
+    const savedEmit = spyOn(component.saved, 'emit');
+    apiSpy.deleteNamespace.and.returnValue(
+      Promise.reject(makeHttpError(403)),
+    );
+    messageSpy.add.calls.reset();
+
+    await component.onDeleteConfirm();
+
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledTimes(1);
+    expect(savedEmit).not.toHaveBeenCalled();
+    // Panel state untouched.
+    expect(component.mode).toBe('view');
+    expect(component.serverYaml).toBe('foo: 1\n');
+    expect(component.buffer).toBe('foo: 1\n');
+    expect(component.deleting).toBeFalse();
+    // Not-authorized error toast (non-sticky).
+    const toast = messageSpy.add.calls.mostRecent().args[0];
+    expect(toast.severity).toBe('error');
+    expect(toast.summary).toContain('not authorized');
+    expect(toast.sticky).toBeFalsy();
+  });
+
+  // ----- 409 / 422 inbound-reference blocker (AC 15) -----
+
+  it('(14.1 AC15) 422 structured NamespaceValidationReport — findings surfaced, panel open', async () => {
+    await loadedEditMode('foo: 1\n');
+    const report: NamespaceValidationReport = {
+      namespace: 'foo',
+      ok: false,
+      global_errors: ["namespace 'bar' references 'foo'"],
+      entry_issues: [],
+    };
+    apiSpy.deleteNamespace.and.returnValue(
+      Promise.reject(makeHttpError(422, report)),
+    );
+
+    await component.onDeleteConfirm();
+
+    expect(component.lastValidation).toEqual(report);
+    expect(component.rawSaveError).toBeNull();
+    expect(component.mode).toBe('view');
+    expect(component.serverYaml).toBe('foo: 1\n');
+    expect(component.a11yAnnouncement).toBe('Validation found 1 issues');
+  });
+
+  it('(14.1 AC15) 409 with unstructured body — error toast surfaces the detail, panel open', async () => {
+    await loadedEditMode('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(
+      Promise.reject(makeHttpError(409, 'referenced by namespace bar')),
+    );
+    messageSpy.add.calls.reset();
+
+    await component.onDeleteConfirm();
+
+    expect(component.lastValidation).toBeNull();
+    const toast = messageSpy.add.calls.mostRecent().args[0];
+    expect(toast.severity).toBe('error');
+    expect(toast.detail).toContain('referenced by namespace bar');
+    expect(component.mode).toBe('view');
+  });
+
+  // ----- 401 falls through (no panel-specific handling, AC 9) -----
+
+  it('(14.1 AC9) 401 — no panel toast, state unchanged', async () => {
+    await loadedEditMode('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(
+      Promise.reject(makeHttpError(401)),
+    );
+    messageSpy.add.calls.reset();
+
+    await component.onDeleteConfirm();
+
+    expect(messageSpy.add).not.toHaveBeenCalled();
+    expect(component.mode).toBe('view');
+    expect(component.serverYaml).toBe('foo: 1\n');
+    expect(component.deleting).toBeFalse();
+  });
+
+  // ----- In-flight guard (AC 16) -----
+
+  it('(14.1 AC16) in-flight guard — button disabled while deleting; second confirm does not fire a second call', async () => {
+    await loadedEditMode('foo: 1\n');
+    let resolveDelete!: () => void;
+    apiSpy.deleteNamespace.and.returnValue(
+      new Promise<void>((r) => {
+        resolveDelete = r;
+      }),
+    );
+
+    const firstCall = component.onDeleteConfirm();
+    expect(component.deleting).toBeTrue();
+    fixture.detectChanges();
+
+    // Button is disabled while the delete is pending.
+    const btn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBeTrue();
+
+    // A second confirm during the in-flight window is a no-op.
+    void component.onDeleteConfirm();
+    // And clicking again is gated too.
+    component.onDeleteClick();
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+
+    resolveDelete();
+    await firstCall;
+
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledTimes(1);
+    expect(component.deleting).toBeFalse();
+  });
+
+  it('(14.1 AC10) onDeleteClick is a no-op while a delete is in flight', async () => {
+    await loadedEditMode('foo: 1\n');
+    component.deleting = true;
+
+    component.onDeleteClick();
+
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+  });
+
+  // ----- Destroy safety — late-resolving delete does not write state -----
+
+  it('(14.1 AC10) destroy-during-delete — late resolution does not write state', async () => {
+    await loadedEditMode('foo: 1\n');
+    let resolveLate!: () => void;
+    apiSpy.deleteNamespace.and.returnValue(
+      new Promise<void>((r) => {
+        resolveLate = r;
+      }),
+    );
+    const savedEmit = spyOn(component.saved, 'emit');
+    const consoleErrorSpy = spyOn(console, 'error');
+
+    const deletePromise = component.onDeleteConfirm();
+    expect(component.deleting).toBeTrue();
+
+    fixture.destroy();
+    resolveLate();
+    await deletePromise;
+    await Promise.resolve();
+
+    expect(savedEmit).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
@@ -193,6 +193,19 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   lastCloneError: Error | null = null;
 
   // -------------------------------------------------------------------
+  // Story 14.1 — Delete-namespace flow (ADR-028 §Decision 5, frontend leg).
+  // -------------------------------------------------------------------
+
+  /**
+   * True while a `deleteNamespace` request is in flight (AC 4). Mirrors the
+   * `cloning` gate: disables the Delete button (`[disabled]="deleting"`) and
+   * makes both `onDeleteClick()` and `onDeleteConfirm()` no-ops, guarding
+   * against double-submit. Cleared in a `finally` block guarded by the
+   * `destroyed` idiom.
+   */
+  deleting: boolean = false;
+
+  // -------------------------------------------------------------------
   // Story 11.7 — UX-polish state (FR14 gate, FR16 a11y, FR17 Clone modal,
   // FR21 inline error)
   // -------------------------------------------------------------------
@@ -1138,6 +1151,125 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       summary: 'Clone failed',
       detail: this.lastCloneError.message,
       sticky: true,
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Story 14.1 — Delete flow (ADR-028 §Decision 5, frontend leg). The
+  // backend authorizes the request (owner-or-admin); this client only
+  // issues the DELETE and reacts to the status code — no role/ownership
+  // logic lives here (ADR-028 §Decision 6).
+  // -------------------------------------------------------------------
+
+  /**
+   * View-mode Delete handler (AC 3). No-op while a delete is in flight
+   * (defence in depth alongside `[disabled]="deleting"`). Opens the PrimeNG
+   * confirm naming the current namespace; `accept` runs `onDeleteConfirm()`.
+   * No `reject` — cancelling is a no-op (panel unchanged, no network call).
+   */
+  onDeleteClick(): void {
+    if (this.deleting) {
+      return;
+    }
+    this.confirmationService.confirm({
+      header: 'Delete namespace',
+      icon: 'pi pi-trash',
+      message: `Delete namespace "${this.namespace}" and all its entries? This cannot be undone.`,
+      accept: () => {
+        void this.onDeleteConfirm();
+      },
+      // `reject` intentionally omitted — cancelling leaves the panel exactly
+      // as it was and fires no network request (AC 3).
+    });
+  }
+
+  /**
+   * Issues the DELETE and runs the result paths (AC 6–AC 10). No-op while a
+   * delete is in flight. Success (`204`): emit `saved` (host refreshes the
+   * namespace list) AND `closed` (Home dialog dismisses; route-shell ignores
+   * `closed` harmlessly) — Option A, zero host edits. Failure branches
+   * delegate to `handleDeleteError`; in every failure branch `namespace`,
+   * `serverYaml`, `buffer`, and `mode` are unchanged. The `deleting` flag is
+   * always cleared in `finally`, guarded by the `destroyed` idiom.
+   */
+  async onDeleteConfirm(): Promise<void> {
+    if (this.deleting) {
+      return;
+    }
+    this.deleting = true;
+    try {
+      await this.apiService.deleteNamespace(this.namespace);
+      if (this.destroyed) {
+        return;
+      }
+      // Success path mirrors the Clone-success UX (AC 6).
+      this.a11yAnnouncement = `Namespace '${this.namespace}' deleted`;
+      this.saved.emit();
+      this.closed.emit();
+      this.messageService.add({
+        severity: 'success',
+        summary: `Namespace '${this.namespace}' deleted`,
+      });
+    } catch (err) {
+      if (this.destroyed) {
+        return;
+      }
+      this.handleDeleteError(err);
+    } finally {
+      if (!this.destroyed) {
+        this.deleting = false;
+      }
+    }
+  }
+
+  /**
+   * Narrow the caught Delete error (AC 7–AC 9). Branches:
+   *   - `401` → silent return (FetchService already fired the global toast;
+   *     the panel does not mutate `mode` / `buffer` / `serverYaml`).
+   *   - `403` → non-sticky not-authorized toast; panel stays open. NOT
+   *     retried. (Community never returns 403; gated tiers do.)
+   *   - `409` / `422` → inbound-reference blocker. If the body is a
+   *     structured `NamespaceValidationReport`, route it through the findings
+   *     pane (`lastValidation` + `announceValidationOutcome`); otherwise
+   *     surface the raw detail via a non-sticky error toast. Panel stays open.
+   *   - default (other 4xx / 5xx / network) → non-sticky error toast.
+   */
+  private handleDeleteError(err: unknown): void {
+    const status = (err as { status?: number })?.status;
+    if (status === 401) {
+      // Silent — FetchService already fired a global toast.
+      return;
+    }
+    if (status === 403) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'You are not authorized to delete this namespace',
+      });
+      return;
+    }
+    if (status === 409 || status === 422) {
+      const body = (err as HttpError).body;
+      if (this.isValidationReport(body)) {
+        this.lastValidation = body;
+        this.rawSaveError = null;
+        this.announceValidationOutcome(body);
+        return;
+      }
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Cannot delete namespace',
+        detail:
+          typeof body === 'string'
+            ? body
+            : ((err as Error)?.message ?? String(err)),
+      });
+      return;
+    }
+    // Default: other 4xx / 5xx / network.
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Delete failed',
+      detail: (err as Error)?.message ?? String(err),
     });
   }
 

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -168,6 +168,22 @@ describe('ApiService', () => {
     });
   });
 
+  describe('deleteNamespace (Story 14.1)', () => {
+    it('DELETEs /admin/catalog/namespace/{ns} and resolves void', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(undefined));
+
+      const result = await service.deleteNamespace('foo');
+
+      expect(fetchServiceSpy.fetch).toHaveBeenCalledTimes(1);
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/admin\/catalog\/namespace\/foo$/);
+      expect(callArgs.options?.method).toBe('DELETE');
+      // The panel owns the success toast — no successMessage passed here.
+      expect(callArgs.successMessage).toBeUndefined();
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('sendMessage (existing)', () => {
     it('should broadcast when no agentName provided', async () => {
       await service.sendMessage('team-1', 'broadcast msg');

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -237,6 +237,24 @@ export class ApiService {
     });
   }
 
+  /**
+   * Delete a catalog namespace and all its entries.
+   *
+   * Hits `DELETE /admin/catalog/namespace/{namespace}` (ADR-028 §Decision 5).
+   * A `204` resolves with no body (FetchService returns `undefined` for
+   * 204 / empty-body responses). NO `successMessage` is passed — the panel
+   * owns the success toast / live-region announcement so the messaging stays
+   * consistent with the Clone flow. Non-2xx responses reject with an
+   * `HttpError` carrying `.status` / `.body` so the caller can branch on
+   * `403` (not-authorized), `409`/`422` (inbound-reference blocker), etc.
+   */
+  async deleteNamespace(namespace: string): Promise<void> {
+    await this.fetchService.fetch({
+      url: `${this.apiUrl}/admin/catalog/namespace/${namespace}`,
+      options: { method: 'DELETE' },
+    });
+  }
+
   /** No-op stub: description editing is not available in V2. */
   async updateTeamDescription(
     _teamId: string,


### PR DESCRIPTION
# Epic 14 — Delete-Namespace Button + Confirmation (ADR-028 frontend leg)

Adds a dark-red, view-mode-only **Delete** button beside Clone in the catalog namespace panel, gated by a PrimeNG confirmation modal that names the namespace, wired to a new `apiService.deleteNamespace(namespace)` → `DELETE /admin/catalog/namespace/{namespace}`. This is the client-side leg of ADR-028 (owner-or-admin catalog mutation authorization); the backend authorizes, the frontend surfaces success, the `403` not-authorized case, and the inbound-reference blocker.

Closes #129

## Stories in this epic

- [x] 14-1-delete-namespace-button-and-service-call — Delete-namespace button, confirmation modal, and `deleteNamespace` service call (Relates to #129)

## What changed

- `api.service.ts`: `deleteNamespace(namespace): Promise<void>` (`method: 'DELETE'`, `204` → `undefined`; no `successMessage` — panel owns messaging).
- `namespace-panel.component.ts`: `deleting` in-flight gate, `onDeleteClick()` (confirm naming the namespace, no `reject`), `onDeleteConfirm()`, `handleDeleteError()`.
  - Success (`204`): emit `saved` + `closed` (Option A — zero host edits), success toast + a11y announcement.
  - `403`: non-sticky not-authorized toast, panel stays open, not retried.
  - `409`/`422`: structured `NamespaceValidationReport` → findings pane; otherwise error toast. Panel stays open.
  - `401`: falls through to global FetchService handling; panel state untouched.
- `namespace-panel.component.html`: view-mode `data-test="delete-ns-btn"` Delete button (`severity="danger"`, `[disabled]="deleting"`).
- Specs: 16 new Karma cases (button render view/edit, confirm accept/cancel, 204 success, 403, 409/422, 401, in-flight guard, destroy safety) + `deleteNamespace` call-shape test.

## Review status

| Story | Verdict | Notes |
|---|---|---|
| 14-1 | done | All 20 ACs implemented; all 6 tasks genuinely complete. Implementation faithfully mirrors the established Clone/Save patterns (`cloning`→`deleting` gate, `ConfirmationService.confirm` with no `reject`, `HttpError.status/.body` narrowing, `isValidationReport`, `announceValidationOutcome`, destroy-guard `finally`). No HIGH or MEDIUM findings — only LOW/cosmetic notes (test-name AC labels), not fix-worthy. No fixup commit required. |

## Scope guard

All changes in commit `093e7e0` are confined to `packages/akgentic-frontend/` (5 files: 2 component, 1 template, 2 spec). No edits to any other submodule. Golden Rule #4 satisfied. No ADR-string assertions in tests — tests assert behavior (calls, emitted outputs, toast args, DOM `data-test` presence). Golden Rule #8 satisfied.

## Epic 14 slice complete

This is the only/last story of Epic 14. The frontend Delete-Namespace feature is fully implemented and tested. End-to-end function depends on akgentic-catalog Epic 27 (the `DELETE` route) and optionally akgentic-infra Epic 31 (owner-or-admin gate) being deployed — both tracked as separate stories/PRs per the documented contract. Local Karma suite: **700/700 passing**.
