### PR TITLE
feat(akgentic-frontend): epic 12 — Clone-namespace Modal Suggestions (12-2 shareable/public toggles)

### DIFF
--- a/src/app/admin/catalog/namespace-panel/namespace-panel-route.component.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel-route.component.spec.ts
@@ -17,6 +17,7 @@ import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 
 import {
@@ -139,6 +140,7 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
             ConfirmDialogModule,
             DialogModule,
             InputTextModule,
+            ToggleSwitchModule,
             TooltipModule,
             StubMonacoEditorComponent,
             ValidationReportComponent,

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.html
@@ -219,6 +219,33 @@
         Technical identifier that uniquely groups all elements of the
         configuration (DB view). Cannot be changed after cloning.
       </small>
+      <!-- Story 12.2 — Shareable toggle. Controls cross-namespace
+           REFERENCEABILITY (distinct from listing/cloning). -->
+      <label for="clone-shareable-toggle">Shareable</label>
+      <p-toggleswitch
+        [(ngModel)]="cloneShareable"
+        name="cloneShareable"
+        inputId="clone-shareable-toggle"
+        data-test="clone-shareable-toggle"
+        aria-describedby="clone-shareable-hint"
+      ></p-toggleswitch>
+      <small id="clone-shareable-hint" class="namespace-panel__clone-hint">
+        Other namespaces can reference entries in this one (cross-namespace
+        links).
+      </small>
+      <!-- Story 12.2 — Public toggle. Controls LISTABILITY / CLONEABILITY by
+           other users (distinct from referenceability). -->
+      <label for="clone-public-toggle">Public</label>
+      <p-toggleswitch
+        [(ngModel)]="clonePublic"
+        name="clonePublic"
+        inputId="clone-public-toggle"
+        data-test="clone-public-toggle"
+        aria-describedby="clone-public-hint"
+      ></p-toggleswitch>
+      <small id="clone-public-hint" class="namespace-panel__clone-hint">
+        Other users can list, read, and clone this namespace.
+      </small>
       <div
         *ngIf="cloneValidationError"
         class="namespace-panel__clone-error"

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -18,6 +18,7 @@ import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { NamespaceValidationReport } from '../../../models/catalog.interface';
@@ -112,6 +113,7 @@ describe('NamespacePanelComponent', () => {
             ConfirmDialogModule,
             DialogModule,
             InputTextModule,
+            ToggleSwitchModule,
             TooltipModule,
             StubMonacoEditorComponent,
             ValidationReportComponent,
@@ -1937,4 +1939,193 @@ entries:
     expect(document.activeElement).toBe(stub);
     document.body.removeChild(stub);
   }));
+
+  // ---------------------------------------------------------------------
+  // Story 12.2 — Clone modal shareable / public toggles (AC 7–AC 13)
+  // ---------------------------------------------------------------------
+
+  /** Bundle YAML carrying explicit shareable / public flags. */
+  const cloneSrcYamlWithFlags = `namespace: src
+name: Src
+shareable: true
+public: false
+entries: {}
+`;
+
+  // ----- Default state + reset parity (AC 7) -----
+
+  it('(12.2 AC7) cloneShareable / clonePublic initialize to false', async () => {
+    await loadedWithCloneSrc();
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  it('(12.2 AC7) onCloneCancelClick resets both toggles to false', async () => {
+    await loadedWithCloneSrc();
+    component.cloneShareable = true;
+    component.clonePublic = true;
+
+    component.onCloneCancelClick();
+
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  it('(12.2 AC7) onCloneDialogVisibleChange(false) resets both toggles to false', async () => {
+    await loadedWithCloneSrc();
+    component.cloneShareable = true;
+    component.clonePublic = true;
+
+    component.onCloneDialogVisibleChange(false);
+
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  it('(12.2 AC7) onCloneDialogHide resets both toggles to false', async () => {
+    await loadedWithCloneSrc();
+    component.cloneShareable = true;
+    component.clonePublic = true;
+
+    component.onCloneDialogHide();
+
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  // ----- Pre-fill from buffer (AC 8) -----
+
+  it('(12.2 AC8) onCloneClick pre-fills both toggles from the buffer flags', async () => {
+    apiSpy.exportNamespace.and.returnValue(
+      Promise.resolve(cloneSrcYamlWithFlags),
+    );
+    await buildFixture('src');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    component.onCloneClick();
+
+    expect(component.cloneShareable).toBeTrue();
+    expect(component.clonePublic).toBeFalse();
+    // Story 12.1 name/namespace pre-fill remains (additive).
+    expect(component.cloneDestNs).toMatch(/^src_/);
+    expect(component.cloneDestName).toBe('Src_copy');
+  });
+
+  it('(12.2 AC8) onCloneClick defaults both toggles to false when the buffer omits the flags', async () => {
+    // cloneSrcYaml has neither shareable nor public.
+    await loadedWithCloneSrc();
+    component.cloneShareable = true;
+    component.clonePublic = true;
+
+    component.onCloneClick();
+
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  // ----- Confirm wires both toggle values through (AC 9) -----
+
+  it('(12.2 AC9) onCloneConfirmClick passes both toggle values into the import YAML', async () => {
+    await loadedWithCloneSrc(['src']);
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+    apiSpy.exportNamespace.and.callFake((ns: string) =>
+      Promise.resolve(`namespace: ${ns}\nuser_id: null\nentries: {}\n`),
+    );
+
+    component.onCloneClick();
+    component.cloneDestNs = 'dst';
+    component.cloneDestName = 'Dest';
+    component.cloneShareable = true;
+    component.clonePublic = false;
+
+    await component.onCloneConfirmClick();
+    await fixture.whenStable();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    const sent = apiSpy.importNamespace.calls.mostRecent().args[0] as string;
+    const parsed = yaml.load(sent) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(true);
+    expect(parsed['public']).toBe(false);
+    expect(parsed['namespace']).toBe('dst');
+    expect(parsed['name']).toBe('Dest');
+    // Both toggles reset after the successful import.
+    expect(component.cloneShareable).toBeFalse();
+    expect(component.clonePublic).toBeFalse();
+  });
+
+  // ----- Toggles do NOT affect the Confirm gate (AC 10) -----
+
+  it('(12.2 AC10) toggle combinations never change cloneConfirmDisabled or cloneValidationError', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    component.cloneDestNs = 'dst';
+    component.cloneDestName = 'Dest';
+
+    const combos: [boolean, boolean][] = [
+      [true, true],
+      [true, false],
+      [false, true],
+      [false, false],
+    ];
+    for (const [s, p] of combos) {
+      component.cloneShareable = s;
+      component.clonePublic = p;
+      expect(component.cloneConfirmDisabled).toBeFalse();
+      expect(component.cloneValidationError).toBeNull();
+    }
+  });
+
+  // ----- Template render + field order + hints (AC 11, AC 13) -----
+
+  it('(12.2 AC11) both toggles render after the inputs with distinguishing hints', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const shareable = root.querySelector(
+      '[data-test="clone-shareable-toggle"]',
+    );
+    const isPublic = root.querySelector('[data-test="clone-public-toggle"]');
+    expect(shareable).not.toBeNull();
+    expect(isPublic).not.toBeNull();
+
+    // Field order: name → namespace → shareable → public.
+    const ordered = Array.from(
+      root.querySelectorAll(
+        '[data-test="clone-destname-input"],' +
+          '[data-test="clone-destns-input"],' +
+          '[data-test="clone-shareable-toggle"],' +
+          '[data-test="clone-public-toggle"]',
+      ),
+    ).map((el) => el.getAttribute('data-test'));
+    expect(ordered).toEqual([
+      'clone-destname-input',
+      'clone-destns-input',
+      'clone-shareable-toggle',
+      'clone-public-toggle',
+    ]);
+
+    // Each toggle is name-accessible via a label/inputId pair.
+    expect(
+      root.querySelector('label[for="clone-shareable-toggle"]'),
+    ).not.toBeNull();
+    expect(
+      root.querySelector('label[for="clone-public-toggle"]'),
+    ).not.toBeNull();
+
+    // The two hints distinguish referenceability from listing/cloning.
+    const shareableHint =
+      root.querySelector('#clone-shareable-hint')?.textContent?.toLowerCase() ??
+      '';
+    const publicHint =
+      root.querySelector('#clone-public-hint')?.textContent?.toLowerCase() ??
+      '';
+    expect(shareableHint).toContain('reference');
+    expect(shareableHint).not.toContain('clone');
+    expect(publicHint).toContain('clone');
+    expect(publicHint).toMatch(/list|read/);
+  });
 });

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
@@ -20,6 +20,7 @@ import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { NamespaceValidationReport } from '../../../models/catalog.interface';
@@ -29,6 +30,8 @@ import {
   CloneYamlError,
   extractYamlName,
   extractYamlNamespace,
+  extractYamlPublic,
+  extractYamlShareable,
   rewriteNamespaceInYaml,
   suggestDestName,
   suggestDestNamespace,
@@ -76,6 +79,7 @@ import { ValidationReportComponent } from './validation-report/validation-report
     DialogModule,
     InputTextModule,
     NuMonacoEditorModule,
+    ToggleSwitchModule,
     TooltipModule,
     ValidationReportComponent,
   ],
@@ -177,6 +181,24 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    * clone, mirroring `cloneDestNs`.
    */
   cloneDestName: string = '';
+  /**
+   * Story 12.2 — Clone visibility/sharing toggles, two-way bound via
+   * `[(ngModel)]` to the modal's `p-toggleswitch` controls. The two flags
+   * are ORTHOGONAL:
+   *   - `cloneShareable` → root `shareable`: other namespaces may reference
+   *     entries in this one cross-namespace (referenceability).
+   *   - `clonePublic`    → root `public`: non-owner users may list, read, and
+   *     clone this namespace (listability/cloneability).
+   *
+   * Both pre-fill from the source buffer on `onCloneClick` and follow the
+   * SAME reset-parity contract as `cloneDestName`: wherever
+   * `cloneDestName = ''` resets on a dismiss/success path, both toggles reset
+   * to `false` alongside it (`onCloneCancelClick`,
+   * `onCloneDialogVisibleChange(false)`, `onCloneDialogHide`, and the 2xx
+   * success branch of `onCloneConfirmClick`).
+   */
+  cloneShareable: boolean = false;
+  clonePublic: boolean = false;
   /**
    * True while a clone-import request is in flight (AC 8 + AC 14). Gates
    * the Confirm button (defence in depth alongside the pre-flight
@@ -819,6 +841,10 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     const srcName = extractYamlName(this.buffer) ?? srcNs;
     this.cloneDestNs = suggestDestNamespace(srcNs);
     this.cloneDestName = suggestDestName(srcName);
+    // Story 12.2 — pre-fill the visibility/sharing toggles from the same
+    // buffer. Absent / non-boolean / unparseable → default to false.
+    this.cloneShareable = extractYamlShareable(this.buffer) ?? false;
+    this.clonePublic = extractYamlPublic(this.buffer) ?? false;
     this.cloneDialogVisible = true;
   }
 
@@ -831,6 +857,8 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     this.cloneDialogVisible = false;
     this.cloneDestNs = '';
     this.cloneDestName = '';
+    this.cloneShareable = false;
+    this.clonePublic = false;
   }
 
   /**
@@ -845,6 +873,8 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     if (!visible) {
       this.cloneDestNs = '';
       this.cloneDestName = '';
+      this.cloneShareable = false;
+      this.clonePublic = false;
     }
   }
 
@@ -990,6 +1020,8 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   onCloneDialogHide(): void {
     this.cloneDestNs = '';
     this.cloneDestName = '';
+    this.cloneShareable = false;
+    this.clonePublic = false;
     this.cloneInlineError = null;
     setTimeout(() => {
       this.cloneBtnRef?.nativeElement.focus();
@@ -1037,11 +1069,22 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     }
     const destNs = this.cloneDestNs.trim();
     const destName = this.cloneDestName.trim();
+    // Story 12.2 — capture the toggle values once at the top (mirroring the
+    // destNs / destName trim-once capture) so they are stable across the
+    // async boundary. `isPublic` avoids the reserved-ish local name `public`.
+    const shareable = this.cloneShareable;
+    const isPublic = this.clonePublic;
     const sourceYaml = this.buffer;
     this.cloning = true;
     this.lastCloneError = null;
     try {
-      const rewrittenYaml = rewriteNamespaceInYaml(sourceYaml, destNs, destName);
+      const rewrittenYaml = rewriteNamespaceInYaml(
+        sourceYaml,
+        destNs,
+        destName,
+        shareable,
+        isPublic,
+      );
       await this.apiService.importNamespace(rewrittenYaml);
       if (this.destroyed) {
         return;
@@ -1053,6 +1096,8 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       this.cloneDialogVisible = false;
       this.cloneDestNs = '';
       this.cloneDestName = '';
+      this.cloneShareable = false;
+      this.clonePublic = false;
       this.cloneInlineError = null;
       this.saved.emit();
       this.namespace = destNs;

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
@@ -12,6 +12,7 @@ import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { ApiService } from '../../../services/api.service';
@@ -133,6 +134,7 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
             ConfirmDialogModule,
             DialogModule,
             InputTextModule,
+            ToggleSwitchModule,
             TooltipModule,
             StubMonacoEditorComponent,
             ValidationReportComponent,

--- a/src/app/services/yaml-clone.helper.spec.ts
+++ b/src/app/services/yaml-clone.helper.spec.ts
@@ -4,6 +4,8 @@ import {
   CloneYamlError,
   extractYamlName,
   extractYamlNamespace,
+  extractYamlPublic,
+  extractYamlShareable,
   rewriteNamespaceInYaml,
   suggestDestName,
   suggestDestNamespace,
@@ -312,5 +314,153 @@ describe('suggestDestName', () => {
 
   it('handles the empty source name', () => {
     expect(suggestDestName('')).toBe('_copy');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Story 12.2 — shareable / public extractors + flag-write parameters.
+// ---------------------------------------------------------------------
+
+describe('extractYamlShareable', () => {
+  it('returns true when root shareable is the boolean true', () => {
+    expect(
+      extractYamlShareable('namespace: foo\nshareable: true\nentries: {}\n'),
+    ).toBe(true);
+  });
+
+  it('returns false when root shareable is the boolean false', () => {
+    expect(
+      extractYamlShareable('namespace: foo\nshareable: false\nentries: {}\n'),
+    ).toBe(false);
+  });
+
+  it('returns null when the shareable key is absent', () => {
+    expect(extractYamlShareable('namespace: foo\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null when shareable is not a boolean (string "yes")', () => {
+    expect(
+      extractYamlShareable('namespace: foo\nshareable: "yes"\nentries: {}\n'),
+    ).toBeNull();
+  });
+
+  it('returns null when shareable is not a boolean (a number)', () => {
+    expect(
+      extractYamlShareable('namespace: foo\nshareable: 1\nentries: {}\n'),
+    ).toBeNull();
+  });
+
+  it('returns null on malformed YAML', () => {
+    expect(
+      extractYamlShareable('namespace: foo\nentries: [\n  unclosed\n'),
+    ).toBeNull();
+  });
+
+  it('returns null when the root is a sequence, not a mapping', () => {
+    expect(extractYamlShareable('- 1\n- 2\n')).toBeNull();
+  });
+});
+
+describe('extractYamlPublic', () => {
+  it('returns true when root public is the boolean true', () => {
+    expect(
+      extractYamlPublic('namespace: foo\npublic: true\nentries: {}\n'),
+    ).toBe(true);
+  });
+
+  it('returns false when root public is the boolean false', () => {
+    expect(
+      extractYamlPublic('namespace: foo\npublic: false\nentries: {}\n'),
+    ).toBe(false);
+  });
+
+  it('returns null when the public key is absent', () => {
+    expect(extractYamlPublic('namespace: foo\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null when public is not a boolean (string "yes")', () => {
+    expect(
+      extractYamlPublic('namespace: foo\npublic: "yes"\nentries: {}\n'),
+    ).toBeNull();
+  });
+
+  it('returns null when public is not a boolean (a number)', () => {
+    expect(
+      extractYamlPublic('namespace: foo\npublic: 0\nentries: {}\n'),
+    ).toBeNull();
+  });
+
+  it('returns null on malformed YAML', () => {
+    expect(
+      extractYamlPublic('namespace: foo\nentries: [\n  unclosed\n'),
+    ).toBeNull();
+  });
+
+  it('returns null when the root is a sequence, not a mapping', () => {
+    expect(extractYamlPublic('- 1\n- 2\n')).toBeNull();
+  });
+});
+
+describe('rewriteNamespaceInYaml — shareable/public parameters', () => {
+  // AC #3 — writes both flags when provided; destName behaviour unchanged.
+  it('writes root shareable=true and public=false when both args are provided', () => {
+    const out = rewriteNamespaceInYaml(
+      'namespace: src\nname: Source\nentries: {}\n',
+      'dst',
+      'Dest',
+      true,
+      false,
+    );
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(true);
+    expect(parsed['public']).toBe(false);
+    expect(parsed['namespace']).toBe('dst');
+    expect(parsed['name']).toBe('Dest');
+  });
+
+  // AC #4 — the critical case: explicit false overwrites a source true for
+  // BOTH flags. A dropped false would silently inherit the source value.
+  it('writes an explicit false for BOTH flags, overwriting a source true', () => {
+    const source =
+      'namespace: src\nshareable: true\npublic: true\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(source, 'dst', undefined, false, false);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(false);
+    expect(parsed['public']).toBe(false);
+  });
+
+  // AC #5 — omitting BOTH flag args leaves both keys untouched.
+  it('leaves both keys untouched when neither flag arg is passed', () => {
+    const source =
+      'namespace: src\nshareable: true\npublic: true\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(source, 'dst');
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(true);
+    expect(parsed['public']).toBe(true);
+  });
+
+  // AC #5 — the two flags are independent: setting shareable=false (4th arg)
+  // while omitting the 5th leaves public untouched.
+  it('treats the two flags independently — 4th arg false, 5th omitted', () => {
+    const source =
+      'namespace: src\nshareable: true\npublic: true\nentries: {}\n';
+    const out = rewriteNamespaceInYaml(source, 'dst', undefined, false);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(false);
+    expect(parsed['public']).toBe(true);
+  });
+
+  // AC #6 — key-add when the source lacks the keys.
+  it('adds both keys when the source bundle lacks them', () => {
+    const out = rewriteNamespaceInYaml(
+      'namespace: src\nentries: {}\n',
+      'dst',
+      undefined,
+      true,
+      true,
+    );
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed['shareable']).toBe(true);
+    expect(parsed['public']).toBe(true);
   });
 });

--- a/src/app/services/yaml-clone.helper.ts
+++ b/src/app/services/yaml-clone.helper.ts
@@ -53,11 +53,24 @@ export class CloneYamlError extends Error {
  * for the import to succeed — minor cosmetic differences (key ordering
  * inside payload, block-scalar quoting) are invisible to the user after
  * re-export.
+ *
+ * Optional trailing arguments rewrite three further root keys, each the
+ * identical one-key rewrite as `namespace`:
+ *   - `destName`  → root `name` (display name; only when not `undefined`,
+ *     and only when non-empty — empty/non-string throws CloneYamlError).
+ *   - `shareable` → root `shareable` boolean (cross-namespace referenceability).
+ *   - `isPublic`  → root `public` boolean (listability/cloneability by others).
+ *
+ * For the two boolean flags, `undefined` is the ONLY "leave the key
+ * untouched" signal; an explicit `false` is written verbatim (the operator's
+ * deliberate choice MUST land in the output).
  */
 export function rewriteNamespaceInYaml(
   input: string,
   destNs: string,
   destName?: string,
+  shareable?: boolean,
+  isPublic?: boolean,
 ): string {
   // Defence-in-depth: the panel's Confirm-button disabled rule prevents
   // empty destNs from ever reaching the helper, but mirror Story 11.3's
@@ -100,6 +113,22 @@ export function rewriteNamespaceInYaml(
   // rewrite happens at the same level as `namespace`.
   if (destName !== undefined) {
     doc['name'] = destName;
+  }
+
+  // Optionally rewrite the document-level `shareable` / `public` booleans
+  // (the meta header's visibility/sharing flags hoisted to root level by the
+  // export serializer, at the same level as `namespace` / `name`).
+  //
+  // CRITICAL: an explicit `false` is a meaningful value the operator chose
+  // and MUST land in the output — `undefined` is the ONLY "do not touch the
+  // key" signal. A falsy check (`if (shareable)`) would silently drop a
+  // chosen `false`, letting the imported clone inherit the source's `true`
+  // and defeating the toggle. Use an explicit `!== undefined` guard.
+  if (shareable !== undefined) {
+    doc['shareable'] = shareable;
+  }
+  if (isPublic !== undefined) {
+    doc['public'] = isPublic;
   }
 
   return yaml.dump(doc, { sortKeys: false, lineWidth: -1, noRefs: true });
@@ -152,6 +181,51 @@ export function extractYamlName(input: string): string | null {
   }
   const name = (parsed as Record<string, unknown>)['name'];
   return typeof name === 'string' ? name : null;
+}
+
+/**
+ * Best-effort extraction of a top-level boolean key from a bundle YAML
+ * string. Shared implementation behind {@link extractYamlShareable} and
+ * {@link extractYamlPublic}. Returns `null` when the input cannot be parsed,
+ * the root is not a mapping, the key is missing, or the value is not a
+ * boolean (a string `"yes"` or a number all yield `null` — only a genuine
+ * YAML boolean is honoured). Mirrors the `extractYamlName` / `extractYamlNamespace`
+ * defer-to-server contract.
+ */
+function extractYamlRootBool(input: string, key: string): boolean | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(input);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const value = (parsed as Record<string, unknown>)[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+/**
+ * Best-effort extraction of the top-level `shareable:` boolean (the meta
+ * header's cross-namespace referenceability flag) from a bundle YAML string.
+ * Returns `null` when the input cannot be parsed, the root is not a mapping,
+ * the `shareable` key is missing, or the value is not a boolean. Used by the
+ * Clone modal to pre-fill the Shareable toggle from the source bundle.
+ */
+export function extractYamlShareable(input: string): boolean | null {
+  return extractYamlRootBool(input, 'shareable');
+}
+
+/**
+ * Best-effort extraction of the top-level `public:` boolean (the meta
+ * header's listability/cloneability flag) from a bundle YAML string. Returns
+ * `null` when the input cannot be parsed, the root is not a mapping, the
+ * `public` key is missing, or the value is not a boolean. Used by the Clone
+ * modal to pre-fill the Public toggle from the source bundle.
+ */
+export function extractYamlPublic(input: string): boolean | null {
+  return extractYamlRootBool(input, 'public');
 }
 
 const RANDOM_SUFFIX_RE = /_[A-Za-z0-9]{5}$/;


### PR DESCRIPTION
## Epic 12 — Clone-namespace Modal Suggestions

This umbrella PR delivers the remaining slice of Epic 12: the clone modal now
exposes `Shareable` and `Public` visibility/sharing toggles, each with a
distinguishing explanatory hint, so an operator deliberately chooses the
clone's cross-namespace referenceability and listability/cloneability rather
than silently inheriting the source bundle's flags.

### Stories

- [x] 12-2-clone-modal-shareable-and-public-toggles — clone modal exposes `shareable` and `public` toggles, each with an explanatory label (Relates to #131)

(Story 12-1 — clone modal pre-fills namespace and name — was reviewed and
merged to master separately under PR #124; it is not part of this branch.)

### What changed

- **Helper (`yaml-clone.helper.ts`)** — adds `extractYamlShareable` /
  `extractYamlPublic` (best-effort root-boolean extraction, sharing a private
  `extractYamlRootBool`) and two optional trailing args `shareable?` /
  `isPublic?` on `rewriteNamespaceInYaml`. An explicit `false` is written
  verbatim; `undefined` is the only "leave the key untouched" signal — so a
  deliberately-disabled flag cannot silently inherit the source's `true`.
- **Component (`namespace-panel.component.ts`)** — `cloneShareable` /
  `clonePublic` fields default to `false`, pre-fill from the source buffer on
  open, reset on all four dismiss/success paths, are captured-once at the top
  of `onCloneConfirmClick`, and thread through to the helper. The Confirm gate
  is unchanged (booleans are always valid input).
- **Template (`namespace-panel.component.html`)** — two labelled,
  two-way-bound `p-toggleswitch` controls (`ToggleSwitchModule`, PrimeNG v19)
  inserted after the namespace input, field order name → namespace → shareable
  → public; hints distinguish referenceability from listability/cloneability.
- **Tests** — helper extractor + flag-write coverage (true / false / absent /
  non-boolean / malformed / non-mapping-root; explicit-false; omit-leaves-
  untouched; independence; key-add) and component default/reset, pre-fill,
  confirm-wire, gate-independence, and render-order/hint cases. The three
  panel-mounting specs gained `ToggleSwitchModule` in their override import
  lists (NG_VALUE_ACCESSOR for the toggle).

## Review status

**12-2-clone-modal-shareable-and-public-toggles — APPROVED (done).** All 14
acceptance criteria verified against the diff; full Karma suite green locally
(`TOTAL: 715 SUCCESS`). The explicit-`false` write contract (AC #4/#5) is
correctly implemented via `!== undefined` guards, the two flags are
independent, and the Confirm gate is untouched. No HIGH or MEDIUM findings;
two LOW observations (hint `<small>` has no `role`, public mutable fields)
are consistent with the existing Story-12.1 idiom and are not defects — no
fixup commit was required.

## Scope guard

All changes stay inside `packages/akgentic-frontend/`. The 7 touched files are
the helper, helper spec, component, template, and three panel-mounting specs.
No backend / catalog / other-submodule change. No ADR-string assertions in the
tests (Golden Rule #8 respected).

## Epic 12 slice complete

Single-story run. Story 12-1 already merged to master separately (PR #124);
this PR lands 12-2, completing the Epic 12 clone-modal-suggestions feature set
on the frontend.

Closes #131
