### PR TITLE
feat(akgentic-frontend): epic 14 — Delete-Namespace Button + Confirmation (14-2 → 14-4)

### DIFF
--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -146,12 +146,45 @@ describe('NamespacePanelComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(apiSpy.exportNamespace).toHaveBeenCalledOnceWith('foo');
+    // Story 14.4 — exportNamespace now carries the admin "show all" flag
+    // ({ all: showAll }); default showAll=false ⇒ owner-scoped read.
+    expect(apiSpy.exportNamespace).toHaveBeenCalledOnceWith('foo', {
+      all: false,
+    });
     expect(component.serverYaml).toBe('key: value\n');
     expect(component.buffer).toBe('key: value\n');
     expect(component.mode).toBe('view');
     expect(component.lastValidation).toBeNull();
     expect(component.loading).toBe(false);
+  });
+
+  it('(14.4 AC8, AC17) admin foreign-open — showAll=true threads all:true into the entry read', async () => {
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('key: value\n'));
+
+    await buildFixture('foreign-ns');
+    fixture.componentRef.setInput('showAll', true);
+    fixture.detectChanges(); // triggers ngOnInit / loadNamespace
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(apiSpy.exportNamespace).toHaveBeenCalledOnceWith('foreign-ns', {
+      all: true,
+    });
+    expect(component.serverYaml).toBe('key: value\n');
+  });
+
+  it('(14.4 AC8) toggle off — showAll=false keeps the normal owner-scoped entry read', async () => {
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('key: value\n'));
+
+    await buildFixture('owned-ns');
+    fixture.componentRef.setInput('showAll', false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(apiSpy.exportNamespace).toHaveBeenCalledOnceWith('owned-ns', {
+      all: false,
+    });
   });
 
   it('(AC13) load flow (error) — leaves buffers empty, toasts, and renders empty state', async () => {
@@ -198,7 +231,10 @@ describe('NamespacePanelComponent', () => {
     fixture.detectChanges();
 
     expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
-    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual(['bar']);
+    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual([
+      'bar',
+      { all: false },
+    ]);
     expect(component.loading).toBe(true);
     expect(component.serverYaml).toBe('');
     expect(component.buffer).toBe('');
@@ -1435,7 +1471,10 @@ entries:
     // exportNamespace called twice: once on mount (cloneSrcYaml), once for
     // the re-load (exportedFresh).
     expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
-    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual(['dst']);
+    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual([
+      'dst',
+      { all: false },
+    ]);
     expect(component.namespace).toBe('dst');
     expect(component.mode).toBe('view');
     expect(component.cloneDialogVisible).toBeFalse();

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -22,6 +22,7 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { NamespaceValidationReport } from '../../../models/catalog.interface';
 import { ApiService } from '../../../services/api.service';
+import { AuthService } from '../../../services/auth.service';
 import { HttpError } from '../../../services/fetch.service';
 import { NamespacePanelComponent } from './namespace-panel.component';
 import { ValidationReportComponent } from './validation-report/validation-report.component';
@@ -69,6 +70,11 @@ describe('NamespacePanelComponent', () => {
   let apiSpy: jasmine.SpyObj<ApiService>;
   let messageSpy: jasmine.SpyObj<MessageService>;
   let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
+  // Minimal AuthService stub exposing only a settable `currentUserValue`
+  // (the sole surface the panel's advisory owner pre-check reads). Defaults
+  // to the anonymous user so pre-existing Save tests — whose buffers carry
+  // `user_id: null` (unresolvable owner → defer to server) — are unaffected.
+  let authStub: { currentUserValue: { user_id: string; roles?: string[] } };
 
   async function buildFixture(namespace: string) {
     fixture = TestBed.createComponent(NamespacePanelComponent);
@@ -91,12 +97,14 @@ describe('NamespacePanelComponent', () => {
     confirmationSpy =
       new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
     spyOn(confirmationSpy, 'confirm').and.callThrough();
+    authStub = { currentUserValue: { user_id: 'anonymous' } };
 
     await TestBed.configureTestingModule({
       imports: [NamespacePanelComponent, NoopAnimationsModule],
       providers: [
         { provide: ApiService, useValue: apiSpy },
         { provide: MessageService, useValue: messageSpy },
+        { provide: AuthService, useValue: authStub },
       ],
     })
       // Swap the real NuMonacoEditor for a lightweight stub that honours
@@ -550,6 +558,112 @@ describe('NamespacePanelComponent', () => {
     await component.onSaveClick();
 
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------
+  // Story 14.3 — Advisory owner-or-admin pre-flight guard on Edit-Save.
+  // The buffer's namespace MUST match the panel's (`foo`) so the existing
+  // namespace-change guard is a no-op and the ownership guard is reached.
+  // ---------------------------------------------------------------------
+
+  it('(14.3 AC2/AC10) owner can Save — import fires, no owner-block toast', async () => {
+    authStub.currentUserValue = { user_id: 'alice', roles: [] };
+    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    const ownerBlocked = messageSpy.add.calls
+      .allArgs()
+      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
+    expect(ownerBlocked).toBeFalse();
+  });
+
+  it('(14.3 AC1/AC4/AC11) non-owner non-admin is blocked — no import, sticky toast, stays edit', async () => {
+    authStub.currentUserValue = { user_id: 'bob', roles: [] };
+    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    const toast = messageSpy.add.calls.mostRecent().args[0];
+    expect(toast.severity).toBe('error');
+    expect(toast.sticky).toBeTrue();
+    expect(toast.summary).toBe('Cannot save changes to this namespace');
+    expect(component.mode).toBe('edit');
+    expect(component.saving).toBeFalse();
+  });
+
+  it('(14.3 AC3/AC12) admin can Save another user\'s namespace — import fires, no block', async () => {
+    authStub.currentUserValue = { user_id: 'bob', roles: ['admin'] };
+    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    const ownerBlocked = messageSpy.add.calls
+      .allArgs()
+      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
+    expect(ownerBlocked).toBeFalse();
+  });
+
+  it('(14.3 AC5/AC13) community anonymous can Save anonymous-owned namespace — no block', async () => {
+    authStub.currentUserValue = { user_id: 'anonymous' };
+    await loadedEditMode('namespace: foo\nuser_id: anonymous\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: foo\nuser_id: anonymous\nentries:\n  x: 1\n';
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    const ownerBlocked = messageSpy.add.calls
+      .allArgs()
+      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
+    expect(ownerBlocked).toBeFalse();
+  });
+
+  it('(14.3 AC7/AC14) unresolvable owner defers to server for non-admin — import fires', async () => {
+    authStub.currentUserValue = { user_id: 'bob', roles: [] };
+    // No root user_id → extractYamlUserId returns null → fall through.
+    await loadedEditMode('namespace: foo\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: foo\nentries:\n  x: 1\n';
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    const ownerBlocked = messageSpy.add.calls
+      .allArgs()
+      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
+    expect(ownerBlocked).toBeFalse();
+  });
+
+  it('(14.3 AC8/AC15) namespace-change guard still wins over ownership guard', async () => {
+    // Non-owner AND namespace changed — the namespace-change guard fires
+    // first with its own message; the ownership message is never reached.
+    authStub.currentUserValue = { user_id: 'bob', roles: [] };
+    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
+    await component.onEditClick();
+    component.buffer = 'namespace: bar\nuser_id: alice\nentries: {}\n';
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    const toast = messageSpy.add.calls.mostRecent().args[0];
+    expect(toast.summary).toBe('Cannot change namespace on Save');
+    expect(toast.severity).toBe('error');
+    expect(toast.sticky).toBeTrue();
   });
 
   // ---------------------------------------------------------------------

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
@@ -24,11 +24,13 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { NamespaceValidationReport } from '../../../models/catalog.interface';
 import { ApiService } from '../../../services/api.service';
+import { AuthService } from '../../../services/auth.service';
 import { HttpError } from '../../../services/fetch.service';
 import {
   CloneYamlError,
   extractYamlName,
   extractYamlNamespace,
+  extractYamlUserId,
   rewriteNamespaceInYaml,
   suggestDestName,
   suggestDestNamespace,
@@ -102,6 +104,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   private apiService: ApiService = inject(ApiService);
   private messageService: MessageService = inject(MessageService);
   private confirmationService: ConfirmationService = inject(ConfirmationService);
+  private authService: AuthService = inject(AuthService);
   private destroyRef: DestroyRef = inject(DestroyRef);
 
   // Internal state — initial values per AC 2.
@@ -572,6 +575,27 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
         severity: 'error',
         summary: 'Cannot change namespace on Save',
         detail: `The buffer's namespace is "${bufferNamespace}" but the panel is editing "${this.namespace}". Use Clone to save under a new namespace name.`,
+        sticky: true,
+      });
+      return;
+    }
+
+    // Advisory pre-flight (NOT the security boundary — the infra import gate
+    // is). Mirror the namespace-change guard above: block obviously-doomed
+    // Saves with a clear message instead of letting the server bounce a 403.
+    // This check lives in the browser and can be bypassed (devtools, direct
+    // API call), so it must NEVER be relied upon for enforcement — the
+    // server's owner-or-admin import gate is authoritative. Admin is checked
+    // first; an unresolvable owner (null) falls through to the server.
+    const me = this.authService.currentUserValue;
+    const namespaceOwner = extractYamlUserId(savedBuffer);
+    const isAdmin = me?.roles?.includes('admin') === true;
+    const isOwner = namespaceOwner !== null && namespaceOwner === me?.user_id;
+    if (!isAdmin && !isOwner && namespaceOwner !== null) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Cannot save changes to this namespace',
+        detail: 'You can only save changes to namespaces you own.',
         sticky: true,
       });
       return;

--- a/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/admin/catalog/namespace-panel/namespace-panel.component.ts
@@ -98,6 +98,17 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    * Collision-on-race).
    */
   @Input() existingNamespaces: string[] = [];
+  /**
+   * Story 14.4 — admin "show all" context, propagated from the home toggle
+   * (`showAllNamespaces`). When `true`, the panel's entry-read
+   * (`exportNamespace`) carries `?all=true` so an admin can open a
+   * foreign-owned namespace surfaced by the "show all" list. `all=true` is
+   * honoured server-side only for admins (the `/admin/catalog/*` mount
+   * unscopes admin GETs — see ADR-028 §Decision 9); for a non-admin (or when
+   * the host toggle is off) it is the normal owner-scoped read. Default
+   * `false` keeps every existing caller on the unchanged owner-scoped path.
+   */
+  @Input() showAll: boolean = false;
   @Output() closed = new EventEmitter<void>();
   @Output() saved = new EventEmitter<void>();
 
@@ -429,7 +440,12 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     }
     this.refreshingForEdit = true;
     try {
-      const latestYaml = await this.apiService.exportNamespace(this.namespace);
+      // Story 14.4 — the Edit drift-check re-read must also carry the admin
+      // "show all" flag, else an admin editing a foreign-owned namespace would
+      // hit an owner-scoped read here and fail the drift check.
+      const latestYaml = await this.apiService.exportNamespace(this.namespace, {
+        all: this.showAll,
+      });
       if (this.destroyed) {
         return;
       }
@@ -1195,7 +1211,12 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     this.serverYaml = '';
     this.buffer = '';
     try {
-      const yaml = await this.apiService.exportNamespace(namespace);
+      // Story 14.4 — carry the admin "show all" flag so an admin opening a
+      // foreign-owned namespace from the home "show all" list can read it
+      // (the export GET is unscoped server-side for admins when all=true).
+      const yaml = await this.apiService.exportNamespace(namespace, {
+        all: this.showAll,
+      });
       if (this.destroyed || seq !== this.loadSeq) {
         return;
       }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -17,6 +17,28 @@
       </ng-template>
     </p-select>
     &nbsp;
+    <!--
+      Story 14.4 — admin-only "show all namespaces" toggle (ADR-028 §Decision 9).
+      Admin-gated UX affordance only; NOT the security boundary (the infra
+      unscoping of admin reads is authoritative). `*ngIf="(isAdmin$ | async)"`
+      so non-admins (incl. anonymous, no roles) never see it — hidden, not
+      merely disabled. Default off (firehose is opt-in). Flips
+      `showAllNamespaces` via `onToggleShowAll`, which re-runs the single
+      `loadNamespaces()` path so `?all=true` flows through it.
+    -->
+    <span
+      *ngIf="(isAdmin$ | async)"
+      class="show-all-namespaces"
+    >
+      <p-toggleswitch
+        [ngModel]="showAllNamespaces"
+        (ngModelChange)="onToggleShowAll($event)"
+        data-test="show-all-namespaces-toggle"
+        inputId="show-all-namespaces-toggle"
+      ></p-toggleswitch>
+      <label for="show-all-namespaces-toggle">Show all namespaces</label>
+    </span>
+    &nbsp;
     <button
       pButton
       size="small"
@@ -243,6 +265,7 @@
     <app-namespace-panel
       [namespace]="((selectedNamespace$ | async)?.namespace) ?? ''"
       [existingNamespaces]="namespaceIdentifiers"
+      [showAll]="showAllNamespaces"
       (closed)="namespacePanelVisible = false"
       (saved)="onNamespaceSaved()"
     />

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -35,7 +35,13 @@ describe('HomeComponent', () => {
   let contextSpy: jasmine.SpyObj<ContextService> & {
     teams$: BehaviorSubject<TeamContext[]>;
   };
-  let authSpy: jasmine.SpyObj<AuthService>;
+  let authSpy: jasmine.SpyObj<AuthService> & {
+    currentUser$: BehaviorSubject<any>;
+    currentUserValue: any;
+  };
+  // Story 14.4 — settable auth subject so the reactive admin predicate
+  // (isAdmin$ derived from currentUser$) can be driven from tests.
+  let currentUser$: BehaviorSubject<any>;
   let routerSpy: jasmine.SpyObj<Router>;
   let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
 
@@ -69,7 +75,18 @@ describe('HomeComponent', () => {
     contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
     contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
 
-    authSpy = jasmine.createSpyObj('AuthService', ['checkAuth']);
+    // Story 14.4 — anonymous by default (no `roles`), so isAdmin$ resolves
+    // false and the toggle is hidden unless a test pushes an admin user.
+    currentUser$ = new BehaviorSubject<any>({ user_id: 'anonymous' });
+    authSpy = jasmine.createSpyObj('AuthService', ['checkAuth'], {
+      currentUser$,
+      get currentUserValue() {
+        return currentUser$.value;
+      },
+    }) as jasmine.SpyObj<AuthService> & {
+      currentUser$: BehaviorSubject<any>;
+      currentUserValue: any;
+    };
     authSpy.checkAuth.and.returnValue(of(true as any));
 
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
@@ -725,5 +742,159 @@ describe('HomeComponent', () => {
     }
     // Deterministic assertion: the getter itself is the contract.
     expect(component.namespaceIdentifiers).toEqual(['alpha', 'beta']);
+  });
+
+  // --- Story 14.4 — admin "show all namespaces" toggle -----------------
+
+  function toggleEl(): HTMLElement | null {
+    return fixture.nativeElement.querySelector(
+      '[data-test="show-all-namespaces-toggle"]',
+    ) as HTMLElement | null;
+  }
+
+  it('(14.4 AC1, AC11) toggle is hidden for a non-admin (roles: [])', async () => {
+    currentUser$.next({ user_id: 'alice', roles: [] });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(toggleEl()).toBeNull();
+  });
+
+  it('(14.4 AC1, AC11) toggle is hidden for the anonymous user (roles absent)', async () => {
+    currentUser$.next({ user_id: 'anonymous' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(toggleEl()).toBeNull();
+  });
+
+  it('(14.4 AC1, AC12) toggle is visible for an admin (roles: ["admin"])', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(toggleEl()).not.toBeNull();
+  });
+
+  it('(14.4 AC7, AC12) toggle appears reactively after a deferred admin /auth/me resolves', async () => {
+    // Starts anonymous (seeded in beforeEach) — toggle hidden.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(toggleEl()).toBeNull();
+
+    // The deferred /auth/me resolves an admin → toggle becomes visible
+    // WITHOUT a manual refresh (reactive predicate via currentUser$).
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(toggleEl()).not.toBeNull();
+  });
+
+  it('(14.4 AC2, AC15) default off on init — first getNamespaces call omits all=true', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    apiSpy.getNamespaces.calls.reset();
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([
+        { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd' },
+      ]),
+    );
+
+    await component.ngOnInit();
+
+    expect(component.showAllNamespaces).toBeFalse();
+    expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
+    expect(apiSpy.getNamespaces.calls.first().args[0]).toEqual({ all: false });
+  });
+
+  it('(14.4 AC3) toggling on re-fetches with all=true and surfaces a foreign namespace', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    const foreign = {
+      namespace: 'other-tenant-ns',
+      name: 'Other Tenant',
+      description: 'foreign-owned',
+    };
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve([foreign]));
+    apiSpy.getNamespaces.calls.reset();
+
+    await component.onToggleShowAll(true);
+
+    expect(component.showAllNamespaces).toBeTrue();
+    expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
+    expect(apiSpy.getNamespaces.calls.mostRecent().args[0]).toEqual({
+      all: true,
+    });
+    expect(
+      component.namespaces$.value.some(
+        (n) => n.namespace === 'other-tenant-ns',
+      ),
+    ).toBeTrue();
+  });
+
+  it('(14.4 AC4) toggling off re-fetches the normal owner+public list', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve([]));
+
+    await component.onToggleShowAll(true);
+    apiSpy.getNamespaces.calls.reset();
+
+    await component.onToggleShowAll(false);
+
+    expect(component.showAllNamespaces).toBeFalse();
+    expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
+    expect(apiSpy.getNamespaces.calls.mostRecent().args[0]).toEqual({
+      all: false,
+    });
+  });
+
+  it('(14.4 AC6, AC18) toggle re-fetch still runs the Story 14.2 selection reconciliation', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    // Seed a selection that the toggled-on list no longer contains — the
+    // reconciliation must drop it and advance to the first remaining ns.
+    component.selectedNamespace$.next({
+      namespace: 'stale-ns',
+      name: 'Stale',
+      description: 'gone',
+    });
+    const refreshed = [
+      { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
+      { namespace: 'rag-team-v1', name: 'RAG Team', description: 'd2' },
+    ];
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve(refreshed));
+
+    await component.onToggleShowAll(true);
+
+    // AC3: the call carried all=true.
+    expect(apiSpy.getNamespaces.calls.mostRecent().args[0]).toEqual({
+      all: true,
+    });
+    // AC18: stale selection dropped, advanced to first remaining (Story 14.2).
+    expect(component.selectedNamespace$.value?.namespace).toBe('agent-team-v1');
+  });
+
+  it('(14.4 AC6, AC18) toggle re-fetch preserves a still-present selection by identity', async () => {
+    currentUser$.next({ user_id: 'gpiroux', roles: ['admin'] });
+    const original = {
+      namespace: 'rag-team-v1',
+      name: 'RAG Team',
+      description: 'original',
+    };
+    component.selectedNamespace$.next(original);
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([
+        { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
+        { namespace: 'rag-team-v1', name: 'RAG Team', description: 'refreshed' },
+      ]),
+    );
+
+    await component.onToggleShowAll(true);
+
+    // Still-present selection left untouched (reference-equal) — Story 14.2.
+    expect(component.selectedNamespace$.value).toBe(original);
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -344,6 +344,12 @@ describe('HomeComponent', () => {
   });
 
   it('(AC14 11.2) "Edit namespace YAML" button is enabled when a namespace is selected', async () => {
+    // The refreshed list (driven by ngOnInit's loadNamespaces) must contain
+    // the seeded selection — otherwise the Story 14.2 reconciliation correctly
+    // drops a selection absent from the fetched list, clearing it to null.
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([{ namespace: 'foo', name: 'Foo', description: '' }]),
+    );
     component.selectedNamespace$.next({
       namespace: 'foo',
       name: 'Foo',
@@ -359,6 +365,11 @@ describe('HomeComponent', () => {
   });
 
   it('(AC14 11.2) clicking the button sets namespacePanelVisible = true', async () => {
+    // See note above: keep the seeded selection present in the fetched list so
+    // the Story 14.2 reconciliation does not drop it during ngOnInit.
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([{ namespace: 'foo', name: 'Foo', description: '' }]),
+    );
     component.selectedNamespace$.next({
       namespace: 'foo',
       name: 'Foo',
@@ -482,6 +493,112 @@ describe('HomeComponent', () => {
 
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
     expect(component.namespaces$.value).toEqual(updated);
+  });
+
+  // --- Story 14.2 — stale-selection drop on refresh --------------------
+
+  it('(14.2 AC8) stale selection (deleted ns) is dropped → advances to first remaining', async () => {
+    // Seed a selection that the refreshed list no longer contains.
+    component.selectedNamespace$.next({
+      namespace: 'agent-team-v1_copy',
+      name: 'Agent Team_copy',
+      description: 'clone',
+    });
+    const refreshed = [
+      { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
+      { namespace: 'rag-team-v1', name: 'RAG Team', description: 'd2' },
+    ];
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve(refreshed));
+
+    // Drive loadNamespaces via the public (saved) handler.
+    await component.onNamespaceSaved();
+
+    expect(component.selectedNamespace$.value?.namespace).toBe('agent-team-v1');
+  });
+
+  it('(14.2 AC9) still-present selection is preserved by `namespace` identity, untouched (no re-set)', async () => {
+    // Seed the ORIGINAL object instance.
+    const original = {
+      namespace: 'rag-team-v1',
+      name: 'RAG Team',
+      description: 'original',
+    };
+    component.selectedNamespace$.next(original);
+
+    // Refresh returns a DIFFERENT object instance with the SAME namespace —
+    // proves identity is compared on `namespace`, not object reference.
+    const refreshed = [
+      { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
+      { namespace: 'rag-team-v1', name: 'RAG Team', description: 'refreshed copy' },
+    ];
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve(refreshed));
+
+    await component.onNamespaceSaved();
+
+    // The subject must hold the EXACT original object (reference-equal) —
+    // confirming no `.next()` re-set fired for a still-valid selection.
+    expect(component.selectedNamespace$.value).toBe(original);
+  });
+
+  it('(14.2 AC10) deleting the last namespace → null selection + placeholder', async () => {
+    component.selectedNamespace$.next({
+      namespace: 'only-team-v1',
+      name: 'Only Team',
+      description: 'last one',
+    });
+    apiSpy.getNamespaces.and.returnValue(Promise.resolve([]));
+
+    await component.onNamespaceSaved();
+
+    expect(component.selectedNamespace$.value).toBeNull();
+
+    // Render the template on a null selection — must not throw, and the
+    // Create / Edit buttons must be disabled.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const createBtn = fixture.nativeElement.querySelector(
+      'button[label="Create"]',
+    ) as HTMLButtonElement | null;
+    const editBtn = fixture.nativeElement.querySelector(
+      'button[data-test="edit-namespace-yaml-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(editBtn).not.toBeNull();
+    expect(editBtn!.disabled).toBeTrue();
+    if (createBtn) {
+      expect(createBtn.disabled).toBeTrue();
+    }
+  });
+
+  it('(14.2 AC6) initial-load auto-select still works (null → first of non-empty list)', async () => {
+    // selectedNamespace$ starts null; loadNamespaces via ngOnInit selects first.
+    expect(component.selectedNamespace$.value).toBeNull();
+    apiSpy.getNamespaces.and.returnValue(
+      Promise.resolve([
+        { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
+        { namespace: 'rag-team-v1', name: 'RAG Team', description: 'd2' },
+      ]),
+    );
+
+    await component.ngOnInit();
+
+    expect(component.selectedNamespace$.value?.namespace).toBe('agent-team-v1');
+  });
+
+  it('(14.2 AC7) getNamespaces failure leaves namespaces$ unchanged and logs', async () => {
+    component.namespaces$.next([
+      { namespace: 'existing-v1', name: 'Existing', description: 'd' },
+    ]);
+    apiSpy.getNamespaces.and.returnValue(Promise.reject(new Error('boom')));
+    const consoleErrorSpy = spyOn(console, 'error');
+
+    await expectAsync(component.onNamespaceSaved()).toBeResolved();
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(component.namespaces$.value).toEqual([
+      { namespace: 'existing-v1', name: 'Existing', description: 'd' },
+    ]);
   });
 
   // --- Story 11.5 — namespaceIdentifiers getter + binding ---------------

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,7 +8,8 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { ApiService } from '../services/api.service';
 import { TeamContext, isRunning } from '../models/team.interface';
@@ -23,6 +24,7 @@ import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
 import { AuthService } from '../services/auth.service';
 import { ConfigService } from '../services/config.service';
@@ -47,6 +49,7 @@ import { NamespacePanelComponent } from '../admin/catalog/namespace-panel/namesp
     DialogModule,
     ConfirmDialogModule,
     InputTextModule,
+    ToggleSwitchModule,
     NamespacePanelComponent,
   ],
   // First PrimeNG ConfirmDialog in the HomeComponent — scoped locally for
@@ -79,6 +82,31 @@ export class HomeComponent {
   // component is mounted lazily via @defer in home.component.html so its
   // Monaco-editor dependency is NOT part of the initial home-page chunk.
   namespacePanelVisible: boolean = false;
+
+  // Story 14.4 — admin-only "show all namespaces" toggle (ADR-028 §Decision 9).
+  //
+  // This is an admin-gated UX affordance, NOT the security boundary. The
+  // authoritative "see all" enforcement is the infra unscoping of admin reads
+  // (`?all=true` honoured server-side only when the caller's roles include
+  // `admin`). A non-admin who forges the flag gets the normal owner+public
+  // list back, so the toggle must never be relied upon for enforcement.
+  //
+  // `showAllNamespaces` is the single source of truth read inside
+  // `loadNamespaces()` and forwarded to `getNamespaces`/the panel; it defaults
+  // OFF so even an admin starts on the owner+public list (opt-in, never an
+  // always-on firehose).
+  showAllNamespaces = false;
+
+  // Reactive admin predicate. Derived from `authService.currentUser$` (NOT a
+  // one-shot eager read) because `ngOnInit` fires `checkAuth()` which resolves
+  // `/auth/me` AFTER first render — reading `currentUserValue` once would miss
+  // the late admin resolution. `roles` is read off the verbatim `/auth/me`
+  // body (typed `any`); the optional chain yields `false` for the anonymous
+  // user (no `roles`). Consumed in the template via the `async` pipe so the
+  // toggle appears once the deferred admin user lands.
+  isAdmin$: Observable<boolean> = this.authService.currentUser$.pipe(
+    map((u) => u?.roles?.includes('admin') === true),
+  );
 
   @ViewChildren('descriptionInput') descriptionInputs!: QueryList<ElementRef>;
 
@@ -136,7 +164,14 @@ export class HomeComponent {
    */
   private async loadNamespaces(): Promise<void> {
     try {
-      const namespaces = await this.apiService.getNamespaces();
+      // Story 14.4 — forward the admin "show all" flag through the single
+      // load path so every caller (initial, save, clone, delete, refresh,
+      // toggle) stays consistent and the Story 14.2 reconciliation below still
+      // runs on every re-fetch. `all=true` is honoured server-side only for
+      // admins; for everyone else it is a no-op (normal owner+public list).
+      const namespaces = await this.apiService.getNamespaces({
+        all: this.showAllNamespaces,
+      });
       this.namespaces$.next(namespaces);
       const current = this.selectedNamespace$.value;
       const stillExists =
@@ -311,6 +346,20 @@ export class HomeComponent {
    * fetch logic in one place.
    */
   async onNamespaceSaved(): Promise<void> {
+    await this.loadNamespaces();
+  }
+
+  /**
+   * Story 14.4 — admin "show all namespaces" toggle handler. Flips the
+   * component flag and re-runs the single `loadNamespaces()` path so the
+   * `all` flag flows through it (the toggle never calls `getNamespaces`
+   * directly — that keeps every load path consistent and preserves the
+   * Story 14.2 stale-selection reconciliation on the re-fetch). Turning on
+   * requests `?all=true` (admin firehose); turning off restores the normal
+   * owner+public list.
+   */
+  async onToggleShowAll(value: boolean): Promise<void> {
+    this.showAllNamespaces = value;
     await this.loadNamespaces();
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -121,13 +121,28 @@ export class HomeComponent {
    * Load catalog namespaces for the dropdown. Extracted so the 2xx save
    * branch (Story 11.3 AC 6) can re-invoke the same code path without
    * duplicating the error handling.
+   *
+   * Story 14.2 — drop a stale selection / preserve a valid one. After
+   * refreshing the options, reconcile the current selection against the
+   * freshly-fetched list, comparing on the stable `namespace` identifier
+   * (NOT object reference — every fetch returns new objects — and NOT the
+   * display `name`, which two summaries may share). If the current
+   * selection is no longer present (e.g. it was just deleted), re-select
+   * the first remaining namespace, or `null` when the list is empty. If it
+   * is still present, leave the subject untouched to avoid a gratuitous
+   * dropdown flicker on an unrelated refresh. A `null` current selection
+   * is "not present", so a non-empty list still auto-selects `namespaces[0]`
+   * (preserves the Story 1.9 initial-load behavior).
    */
   private async loadNamespaces(): Promise<void> {
     try {
       const namespaces = await this.apiService.getNamespaces();
       this.namespaces$.next(namespaces);
-      if (namespaces.length > 0 && !this.selectedNamespace$.value) {
-        this.selectedNamespace$.next(namespaces[0]);
+      const current = this.selectedNamespace$.value;
+      const stillExists =
+        current != null && namespaces.some((n) => n.namespace === current.namespace);
+      if (!stillExists) {
+        this.selectedNamespace$.next(namespaces.length > 0 ? namespaces[0] : null);
       }
     } catch (error) {
       console.error('Failed to load namespaces:', error);

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -58,6 +58,31 @@ describe('ApiService', () => {
     });
   });
 
+  describe('getNamespaces ?all=true (Story 14.4 AC5, AC16)', () => {
+    it('appends ?all=true when opts.all is truthy', async () => {
+      await service.getNamespaces({ all: true });
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/admin\/catalog\/namespaces\?all=true$/);
+    });
+
+    it('issues the bare URL (no query) when opts.all is false', async () => {
+      await service.getNamespaces({ all: false });
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/admin\/catalog\/namespaces$/);
+      expect(callArgs.url).not.toContain('?all');
+    });
+
+    it('issues the bare URL (no query) when opts is omitted', async () => {
+      await service.getNamespaces();
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/admin\/catalog\/namespaces$/);
+      expect(callArgs.url).not.toContain('?all');
+    });
+  });
+
   describe('createTeam (Story 1.9)', () => {
     it('POSTs {catalog_namespace, params:{}} — not catalog_entry_id', async () => {
       fetchServiceSpy.fetch.and.returnValue(Promise.resolve({} as any));
@@ -85,6 +110,31 @@ describe('ApiService', () => {
       expect(callArgs.options?.method).toBeUndefined(); // defaults to GET
       expect(callArgs.responseType).toBe('text');
       expect(result).toBe(yamlText);
+    });
+
+    it('(Story 14.4 AC8) appends ?all=true for an admin foreign-open', async () => {
+      const yamlText = 'namespace: foo\n';
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(yamlText));
+
+      await service.exportNamespace('foo', { all: true });
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(
+        /\/admin\/catalog\/namespace\/foo\/export\?all=true$/,
+      );
+      expect(callArgs.responseType).toBe('text');
+    });
+
+    it('(Story 14.4 AC8) issues the bare export URL when all is false/omitted', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve('x'));
+
+      await service.exportNamespace('foo', { all: false });
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(
+        /\/admin\/catalog\/namespace\/foo\/export$/,
+      );
+      expect(callArgs.url).not.toContain('?all');
     });
   });
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -163,11 +163,20 @@ export class ApiService {
    * creation dropdown. Consumes catalog Story 16.6's `GET /catalog/namespaces`
    * endpoint, which returns `NamespaceSummary[]` directly (always a list,
    * even when empty).
+   *
+   * The optional `all` flag appends `?all=true`, the admin-only "see all"
+   * lever: it surfaces every tenant's namespaces (not just owner+public).
+   * `all=true` is honoured server-side ONLY for callers whose roles include
+   * `admin`; a non-admin (or anonymous) caller sending it is silently treated
+   * as the normal owner+public list (no error, no privilege grant). The flag
+   * is therefore a convenience surface, not the authorization boundary — the
+   * infra unscoping of admin reads is the boundary.
    */
-  async getNamespaces(): Promise<NamespaceSummary[]> {
-    return await this.fetchService.fetch({
-      url: `${this.apiUrl}/admin/catalog/namespaces`,
-    });
+  async getNamespaces(opts?: { all?: boolean }): Promise<NamespaceSummary[]> {
+    const url = opts?.all
+      ? `${this.apiUrl}/admin/catalog/namespaces?all=true`
+      : `${this.apiUrl}/admin/catalog/namespaces`;
+    return await this.fetchService.fetch({ url });
   }
 
   /**
@@ -175,10 +184,21 @@ export class ApiService {
    *
    * Hits `GET /admin/catalog/namespace/{namespace}/export` which returns
    * `application/yaml` — the response is consumed as text (not JSON).
+   *
+   * The optional `all` flag appends `?all=true` so an admin can open a
+   * foreign-owned namespace surfaced by the home "show all" list. As with
+   * `getNamespaces`, `all=true` is honoured server-side only for admins (the
+   * `/admin/catalog/*` mount unscopes admin GETs); a non-admin sending it gets
+   * the normal owner-scoped read. It widens reads only — never writes.
    */
-  async exportNamespace(namespace: string): Promise<string> {
+  async exportNamespace(
+    namespace: string,
+    opts?: { all?: boolean },
+  ): Promise<string> {
+    const base = `${this.apiUrl}/admin/catalog/namespace/${namespace}/export`;
+    const url = opts?.all ? `${base}?all=true` : base;
     return await this.fetchService.fetch({
-      url: `${this.apiUrl}/admin/catalog/namespace/${namespace}/export`,
+      url,
       responseType: 'text',
     });
   }

--- a/src/app/services/yaml-clone.helper.spec.ts
+++ b/src/app/services/yaml-clone.helper.spec.ts
@@ -4,6 +4,7 @@ import {
   CloneYamlError,
   extractYamlName,
   extractYamlNamespace,
+  extractYamlUserId,
   rewriteNamespaceInYaml,
   suggestDestName,
   suggestDestNamespace,
@@ -213,6 +214,34 @@ describe('extractYamlNamespace', () => {
 
   it('returns null when namespace is not a string (e.g. a number)', () => {
     expect(extractYamlNamespace('namespace: 42\nentries: {}\n')).toBeNull();
+  });
+});
+
+describe('extractYamlUserId', () => {
+  it('returns the top-level user_id string on a well-formed bundle', () => {
+    const input = 'namespace: foo\nuser_id: alice\nentries: {}\n';
+    expect(extractYamlUserId(input)).toBe('alice');
+  });
+
+  it('returns null on malformed YAML (defers to the server)', () => {
+    const malformed = 'namespace: foo\nentries: [\n  unclosed\n';
+    expect(extractYamlUserId(malformed)).toBeNull();
+  });
+
+  it('returns null when the root is not a mapping', () => {
+    expect(extractYamlUserId('- 1\n- 2\n')).toBeNull();
+  });
+
+  it('returns null when the mapping has no user_id key', () => {
+    expect(extractYamlUserId('namespace: foo\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null when user_id is null (unknown ownership)', () => {
+    expect(extractYamlUserId('namespace: foo\nuser_id: null\nentries: {}\n')).toBeNull();
+  });
+
+  it('returns null when user_id is not a string (e.g. a number)', () => {
+    expect(extractYamlUserId('namespace: foo\nuser_id: 42\nentries: {}\n')).toBeNull();
   });
 });
 

--- a/src/app/services/yaml-clone.helper.ts
+++ b/src/app/services/yaml-clone.helper.ts
@@ -154,6 +154,34 @@ export function extractYamlName(input: string): string | null {
   return typeof name === 'string' ? name : null;
 }
 
+/**
+ * Best-effort extraction of the top-level `user_id:` field (the namespace
+ * owner anchor) from a bundle YAML string. Returns `null` when the input
+ * cannot be parsed, the root is not a mapping, or the `user_id` key is
+ * missing / not a string.
+ *
+ * Powers the advisory owner-or-admin pre-check in
+ * `NamespacePanelComponent.onSaveClick`: the panel compares this owner
+ * against the current user to surface a friendly "you don't own this"
+ * message before the import fires. Returning `null` (unknown ownership)
+ * intentionally defers the decision to the server — the frontend guard is
+ * advisory only and the server's import gate is the real boundary, so a
+ * missing/`null` owner must NOT pre-block a legitimate first-save/create.
+ */
+export function extractYamlUserId(input: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(input);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const userId = (parsed as Record<string, unknown>)['user_id'];
+  return typeof userId === 'string' ? userId : null;
+}
+
 const RANDOM_SUFFIX_RE = /_[A-Za-z0-9]{5}$/;
 const RANDOM_SUFFIX_ALPHABET =
   'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';


### PR DESCRIPTION
# Epic 14 — Delete-Namespace Button + Confirmation (ADR-028)

Umbrella PR for Epic 14. Frontend-only work, stacked on a single shared branch (`feat/133-epic-14-delete-namespace-button`). Each story lands as its own commit; this PR tracks the whole epic.

## Stories

- [x] 14-2-home-dropdown-drops-deleted-namespace — home dropdown drops the deleted namespace from selection (stale-selection fix) (Relates to #133)
- [x] 14-3-edit-save-owner-or-admin-preflight-guard — advisory owner-or-admin pre-flight guard on Edit-Save (Relates to #135)
- [x] 14-4-admin-show-all-namespaces-toggle — admin-only "show all namespaces" toggle threading `?all=true` through the single load path + panel entry-read (Relates to #136)

## Review status

**14-2 — DONE.** Reviewed commit `ee25d83`.

- All 7 behavioral ACs implemented exactly per the story spec:
  - `loadNamespaces()` reconciles the current selection against the freshly-fetched list, comparing on the stable `namespace` identifier (not object reference, not display `name`).
  - Re-selects `namespaces[0]` (or `null` when empty) only when the current selection is absent; a still-valid selection is left untouched (no `.next()`, no flicker).
  - Initial-load auto-select (null current → first of non-empty list) preserved.
  - `getNamespaces()` failure still caught + logged, `namespaces$` unchanged.
  - Fix lives entirely in `loadNamespaces()` — no delete-special-casing in `onNamespaceSaved()`.
- Template (AC3): existing `home.component.html` guards already tolerate a `null` selection (placeholder, Create disabled on empty list, Edit disabled on no selection, null-coalesced dialog input). No template change.
- Tests: 5 new Karma cases (stale-drops-to-first, still-present-preserved by `namespace` identity with a different object instance, delete-last → null + placeholder, initial-load regression, failure-resilience regression). Two existing `(AC14 11.2)` tests had their `getNamespaces` stub aligned to the corrected reconciliation logic — legitimate and documented.
- No fixup commit required: no HIGH/MEDIUM findings. One LOW nit (a soft `if (createBtn)` guard in the AC10 test) left as-is; the hard `editBtn` assertion already proves null-selection renders cleanly.
- Golden Rule 8: no ADR-string assertions in tests.
- Full Karma suite: **692/692 SUCCESS** (local).

- 14-3 review: PASS. Reviewed commit `08b2de2`. No fixup commit required — no fix-worthy findings. The advisory owner-or-admin guard in `onSaveClick` is a faithful mirror of the existing namespace-change guard: placed after it / before `this.saving = true`, admin checked first, unresolvable owner (`null`) falls through to the server (AC 7). New `extractYamlUserId` helper copies `extractYamlNamespace` exactly. Type-safe (`unknown` parse + `string` narrowing, no casts), null-safe (`me?.` optional chaining), Golden-Rule-8 compliant (no ADR-string assertions). All 9 behavioral ACs + 6 helper cases covered, asserting both `importNamespace` call state and side effects (toast/`mode`/`saving`). Frontend-only scope (4 files under `src/`). Full Karma suite: **704/704 SUCCESS** (local).

- 14-4 review: PASS. Reviewed commit `0271839`. No fixup commit required — no fix-worthy findings. The admin-gated toggle is rendered via `*ngIf="(isAdmin$ | async)"` (hidden, not disabled) with `isAdmin$` derived reactively from `authService.currentUser$` (`u?.roles?.includes('admin') === true`), so it appears once the deferred `/auth/me` resolves an admin and stays hidden for anonymous (no `roles`) — AC1/AC7. `showAllNamespaces` defaults OFF (AC2); `onToggleShowAll` flips the flag and re-runs the single `loadNamespaces()` path (never calls `getNamespaces` directly), so the `?all=true` flag flows through one source and the Story 14.2 selection reconciliation runs on every toggle re-fetch (AC6/AC18). `getNamespaces({ all })` / `exportNamespace(ns, { all })` are backward-compatible optional-arg extensions that append `?all=true` only when truthy (AC5/AC16). The panel `@Input() showAll` is threaded into BOTH `exportNamespace` call sites (open-read and Edit drift-check) so an admin foreign-open carries `all=true` (AC8/AC17). Type-safe (`opts?: { all?: boolean }` — no `any` in production; `any` confined to spec auth stubs matching the existing pattern, no `auth.service.ts` change — AC10). Reads-only, no write-authz widening (AC9). Golden Rule 8: no ADR-string assertions (ADR refs only in comments/docstrings). Frontend-only scope: all 7 files under `src/`. Full Karma suite: **720/720 SUCCESS** (local).

## Epic 14 slice complete

All Epic 14 frontend stories have landed on this branch:

- **14-1 (delete-namespace button + confirmation)** — merged earlier in PR #130 (the original delete button + confirm dialog).
- **14-2** — home dropdown reconciles selection on delete/refresh, dropping a deleted/stale namespace and advancing to the first remaining (or `null`).
- **14-3** — Edit-Save advisory owner-or-admin pre-flight guard (client-side fail-fast; the infra import gate remains the authoritative boundary).
- **14-4** — admin-only "show all namespaces" toggle consuming infra Story 31.4's `?all=true` admin unscoping; threads the flag through the single `loadNamespaces()` load path and the panel entry-read so an admin can list and open foreign-owned namespaces. Admin-gated UX only — infra unscoping is the boundary (ADR-028 §Decision 9).

## Scope guard

All changes stay inside `packages/akgentic-frontend/`. 14-2 touched `src/app/home/home.component.ts` + spec; 14-3 touched `src/app/admin/catalog/namespace-panel/namespace-panel.component.{ts,spec.ts}` and `src/app/services/yaml-clone.helper.{ts,spec.ts}`; 14-4 touched `src/app/home/home.component.{ts,html,spec.ts}`, `src/app/services/api.service.{ts,spec.ts}`, and `src/app/admin/catalog/namespace-panel/namespace-panel.component.{ts,spec.ts}`. No other submodule modified (Golden Rule #4).
