### PR TITLE
feat(akgentic-frontend): epic 15 — slash-command mention (15-1)

### DIFF
--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -16,6 +16,7 @@ import { ChatMessage, classifyMessage } from '../models/chat-message.model';
 import { ApiService } from '../services/api.service';
 import { AkgentService } from '../services/akgent.service';
 import { GraphDataService } from '../services/graph-data.service';
+import { ActorMessageService } from '../services/message.service';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
   return {
@@ -113,6 +114,12 @@ describe('ChatPanelComponent', () => {
       nodes$: of([]),
     };
 
+    // Story 15-1 (ADR-013): the embedded <app-user-input> now injects
+    // ActorMessageService for its `commandsByAgent$` (the `/` mention store).
+    const messageService = {
+      commandsByAgent$: new BehaviorSubject<Record<string, any[]>>({}),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ChatPanelComponent, NoopAnimationsModule],
       providers: [
@@ -122,6 +129,7 @@ describe('ChatPanelComponent', () => {
         { provide: ApiService, useValue: apiService },
         { provide: AkgentService, useValue: akgentService },
         { provide: GraphDataService, useValue: graphDataService },
+        { provide: ActorMessageService, useValue: messageService },
       ],
     }).compileComponents();
 

--- a/src/app/models/message.types.ts
+++ b/src/app/models/message.types.ts
@@ -114,6 +114,49 @@ export interface WelcomeMessage extends BaseMessage {
   content: string;
 }
 
+/**
+ * One argument of a slash-command, mirroring akgentic-tool `CommandArg`
+ * (ADR-028 §Decision 3). Ordered position in `CommandDescriptor.args` drives
+ * both the backend positional parsing and the frontend args hint.
+ */
+export interface CommandArg {
+  name: string;
+  /** JSON-schema type name: "string", "integer", "boolean", … */
+  type: string;
+  required: boolean;
+  description?: string | null;
+}
+
+/**
+ * Metadata for one slash-command supported by an agent, mirroring
+ * akgentic-tool `CommandDescriptor` (ADR-028 §Decision 3). Sourced from
+ * `CommandsAnnouncedEvent` and rendered in the `/` mention dropdown.
+ */
+export interface CommandDescriptor {
+  /** Canonical command name, e.g. "hire_member". */
+  name: string;
+  /** Human-readable description (from the callable docstring). */
+  description: string;
+  /** Ordered argument list — drives the dropdown args hint. */
+  args: CommandArg[];
+  /** Provenance, e.g. "TeamTool". */
+  tool_card: string;
+}
+
+/**
+ * Inner event payload announcing the full command set for one agent
+ * (akgentic-tool `CommandsAnnouncedEvent`, ADR-028 §Decision 3). It rides the
+ * existing `EventMessage` passthrough; the frontend discriminates it by the
+ * inner `__model__` (ADR-013). A later event for the same agent replaces the
+ * previous set.
+ */
+export interface CommandsAnnouncedEvent {
+  __model__: string; // contains 'CommandsAnnouncedEvent'
+  /** The agent that executes these commands. */
+  agent: ActorAddress;
+  commands: CommandDescriptor[];
+}
+
 // Union type for all possible messages
 export type AkgenticMessage =
   | SentMessage
@@ -177,6 +220,20 @@ export function isResultMessage(msg: BaseMessage): msg is ResultMessage {
  */
 export function isWelcomeMessage(msg: BaseMessage): msg is WelcomeMessage {
   return msg.__model__.includes('WelcomeMessage');
+}
+
+/**
+ * Inner-event check (ADR-013): true when the inner event carried by an
+ * `EventMessage` is a `CommandsAnnouncedEvent`. Matches on the inner
+ * `__model__`, the same discrimination already used for `LlmMessageEvent` /
+ * `ToolCallEvent` / `ToolStateEvent`. `event` is the `EventMessage.event`
+ * payload (loosely typed on the wire); the guard narrows it to
+ * `CommandsAnnouncedEvent`.
+ */
+export function isCommandsAnnouncedEvent(
+  event: { __model__?: string } | null | undefined,
+): event is CommandsAnnouncedEvent {
+  return !!event?.__model__?.includes('CommandsAnnouncedEvent');
 }
 
 /**

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -78,9 +78,23 @@
           cols="50"
           [(ngModel)]="userInput"
           (click)="scroll()"
+          [mentionConfig]="mentionConfig"
+          [mentionListTemplate]="mentionItemTemplate"
         ></textarea>
         <label for="on_label">Chat input</label>
       </div>
+      <!--
+        ADR-013: `/` command mention item template — renders the command name
+        prominently, an optional args hint (`<role> [name]`), and the
+        description as secondary text.
+      -->
+      <ng-template #mentionItemTemplate let-item="item">
+        <span class="mention-item-name">{{ item.name }}</span>
+        <span *ngIf="item.args?.length" class="mention-item-args">
+          {{ commandArgsHint(item.args) }}
+        </span>
+        <span *ngIf="item.description" class="mention-item-desc">{{ item.description }}</span>
+      </ng-template>
       <div class="input-row-buttons">
         <button
           pButton

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+
+import { AkgentChatComponent } from './akgent-chat.component';
+import { ApiService } from '../../../services/api.service';
+import { UtilService } from '../../../services/utils.service';
+import { ContextService } from '../../../services/context.service';
+import { ActorMessageService } from '../../../services/message.service';
+import { CommandDescriptor } from '../../../models/message.types';
+
+/**
+ * Story 15-1 (ADR-013) — member-chat `/` slash-command mention. The member
+ * chat targets exactly one agent (its own `agentName`), so the `/` list is
+ * unconditionally that agent's commands.
+ */
+describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
+  let component: AkgentChatComponent;
+  let commandsByAgentSubject: BehaviorSubject<
+    Record<string, CommandDescriptor[]>
+  >;
+
+  const HIRE: CommandDescriptor = {
+    name: 'hire_member',
+    description: 'Hire a new team member',
+    args: [
+      { name: 'role', type: 'string', required: true },
+      { name: 'name', type: 'string', required: false },
+    ],
+    tool_card: 'TeamTool',
+  };
+  const ROSTER: CommandDescriptor = {
+    name: 'roster',
+    description: 'List the current team roster',
+    args: [],
+    tool_card: 'TeamTool',
+  };
+
+  beforeEach(() => {
+    commandsByAgentSubject = new BehaviorSubject<
+      Record<string, CommandDescriptor[]>
+    >({});
+
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        { provide: ApiService, useValue: { sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined) } },
+        { provide: UtilService, useValue: {} },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        {
+          provide: ActorMessageService,
+          useValue: { commandsByAgent$: commandsByAgentSubject },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = 'a-mgr';
+    component.agentName = '@Manager';
+    fixture.detectChanges();
+  });
+
+  it('AC-2: commandItems are the panel agent\'s commands', () => {
+    commandsByAgentSubject.next({ '@Manager': [HIRE, ROSTER] });
+    expect(component.commandItems.map((c) => c.name)).toEqual([
+      'hire_member',
+      'roster',
+    ]);
+  });
+
+  it('AC-6: empty / list until a CommandsAnnouncedEvent arrives for this agent', () => {
+    expect(component.commandItems).toEqual([]);
+    commandsByAgentSubject.next({ '@Other': [HIRE] });
+    expect(component.commandItems).toEqual([]);
+  });
+
+  it('AC-2: selectCommand inserts `/${name} ` (leading slash, trailing space)', () => {
+    expect(component.selectCommand({ name: 'roster' })).toBe('/roster ');
+  });
+
+  it('mentionConfig exposes a single `/` trigger', () => {
+    const triggers = component.mentionConfig.mentions.map((m) => m.triggerChar);
+    expect(triggers).toEqual(['/']);
+  });
+
+  it('commandArgsHint renders required in <> and optional in []', () => {
+    expect(component.commandArgsHint(HIRE.args)).toBe('<role> [name]');
+    expect(component.commandArgsHint(ROSTER.args)).toBe('');
+  });
+});

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -10,6 +10,7 @@ import { FloatLabelModule } from 'primeng/floatlabel';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { Table, TableModule } from 'primeng/table';
 import { TextareaModule } from 'primeng/textarea';
+import { MentionModule } from 'angular-mentions';
 
 import { BehaviorSubject } from 'rxjs';
 
@@ -18,6 +19,7 @@ import { ApiService } from '../../../services/api.service';
 import { UtilService } from '../../../services/utils.service';
 import { ContextService } from '../../../services/context.service';
 import { ActorMessageService } from '../../../services/message.service';
+import { CommandDescriptor } from '../../../models/message.types';
 
 import { CopyButtonComponent } from '../../copy-button/copy-button.component';
 
@@ -37,6 +39,7 @@ import { CopyButtonComponent } from '../../copy-button/copy-button.component';
     FloatLabelModule,
     ButtonModule,
     ProgressSpinnerModule,
+    MentionModule,
     CapitalizePipe,
     CopyButtonComponent,
   ],
@@ -59,6 +62,14 @@ export class AkgentChatComponent {
 
   context: any[] = [];
 
+  /**
+   * ADR-013: latest per-agent slash-command store (keyed by raw actor
+   * `name`). Snapshot of `ActorMessageService.commandsByAgent$`; read by
+   * `commandItems` to build this panel's `/` mention list. Empty until a
+   * `CommandsAnnouncedEvent` arrives for this agent (AC-6).
+   */
+  commandsByAgent: Record<string, CommandDescriptor[]> = {};
+
   ngOnInit(): void {
     // Subscribe to context$ for the selected agent
     this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((ctx) => {
@@ -68,6 +79,72 @@ export class AkgentChatComponent {
       this.isLoading = false;
       this.updateContext(ctx);
     });
+
+    // ADR-013: keep a live snapshot of the per-agent slash-command store so
+    // this panel's `/` mention reflects the latest CommandsAnnouncedEvent.
+    this.messageService.commandsByAgent$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((byAgent) => {
+        this.commandsByAgent = byAgent;
+      });
+  }
+
+  /**
+   * ADR-013 §3 — member chat target is unambiguous: this panel's own agent
+   * (`agentName`). The `/` list is that agent's command descriptors, mapped to
+   * dropdown items. Empty until a CommandsAnnouncedEvent arrives (AC-6).
+   */
+  get commandItems(): {
+    name: string;
+    description: string;
+    args: CommandDescriptor['args'];
+  }[] {
+    const descriptors = this.commandsByAgent[this.agentName] ?? [];
+    return descriptors.map((d) => ({
+      name: d.name,
+      description: d.description,
+      args: d.args,
+    }));
+  }
+
+  /**
+   * ADR-013 §2 — single `/` mention trigger for the member chat. Inserts
+   * `/${name} ` via `selectCommand`; `allowSpace: false` closes the dropdown
+   * after the command name so the user types args freely. The send path is
+   * unchanged — text is sent verbatim (AC-5).
+   */
+  get mentionConfig() {
+    return {
+      mentions: [
+        {
+          triggerChar: '/',
+          labelKey: 'name',
+          allowSpace: false,
+          mentionSelect: this.selectCommand,
+          dropUp: true,
+          maxItems: 10,
+          items: this.commandItems,
+        },
+      ],
+    };
+  }
+
+  /**
+   * ADR-013 §2 — insert `/${name} ` (leading slash + trailing space); does NOT
+   * send. The literal text is sent verbatim on submit (AC-5).
+   */
+  selectCommand = (item: { name: string }) => {
+    return `/${item.name} `;
+  };
+
+  /**
+   * ADR-013 §2 — args hint for a command row, e.g. `<role> [name]`: required
+   * in angle brackets, optional in square brackets, declared order.
+   */
+  commandArgsHint(args: CommandDescriptor['args']): string {
+    return args
+      .map((a) => (a.required ? `<${a.name}>` : `[${a.name}]`))
+      .join(' ');
   }
 
   updateContext(context: any[]) {

--- a/src/app/process/user-input/user-input.component.html
+++ b/src/app/process/user-input/user-input.component.html
@@ -15,20 +15,26 @@
         (keydown.enter)="userInputEnterKeySubmit ? sendMessage() : null"
         (keydown.meta.enter)="sendMessage()"
         (keydown.control.enter)="sendMessage()"
-        [mention]="mentionItems"
-        [mentionConfig]="{
-          triggerChar: '@',
-          labelKey: 'name',
-          returnTrigger: true,
-          allowSpace: true,
-          mentionSelect: selectAgent,
-          dropUp: true,
-          maxItems: 10
-        }"
+        [mentionConfig]="mentionConfig"
+        [mentionListTemplate]="mentionItemTemplate"
       ></textarea>
       <label for="on_label">Process input</label>
     </div>
   </p-floatlabel>
+
+  <!--
+    ADR-013: shared mention-list item template. `@` items carry only `name`
+    (description/args absent → those rows simply do not render); `/` command
+    items render `name` prominently plus `description` and an optional args
+    hint (e.g. `<role> [name]`).
+  -->
+  <ng-template #mentionItemTemplate let-item="item">
+    <span class="mention-item-name">{{ item.name }}</span>
+    <span *ngIf="item.args?.length" class="mention-item-args">
+      {{ commandArgsHint(item.args) }}
+    </span>
+    <span *ngIf="item.description" class="mention-item-desc">{{ item.description }}</span>
+  </ng-template>
 
   <div class="button-group">
     @if (humanAgents.length > 1) {

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -7,7 +7,8 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { ContextService } from '../../services/context.service';
 import { GraphDataService } from '../../services/graph-data.service';
-import { ActorAddress } from '../../models/message.types';
+import { ActorMessageService } from '../../services/message.service';
+import { ActorAddress, CommandDescriptor } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
 import { makeAgentNameUserFriendly } from '../../lib/util';
 
@@ -44,6 +45,7 @@ describe('ProcessUserInputComponent', () => {
   let chatServiceMock: any;
   let contextServiceStub: { currentTeamRunning$: BehaviorSubject<boolean> };
   let nodesSubject: BehaviorSubject<NodeInterface[]>;
+  let commandsByAgentSubject: BehaviorSubject<Record<string, CommandDescriptor[]>>;
 
   beforeEach(async () => {
     apiServiceSpy = jasmine.createSpyObj('ApiService', ['sendMessage', 'sendMessageFromTo']);
@@ -67,6 +69,13 @@ describe('ProcessUserInputComponent', () => {
       nodes$: nodesSubject,
     };
 
+    commandsByAgentSubject = new BehaviorSubject<
+      Record<string, CommandDescriptor[]>
+    >({});
+    const messageServiceStub = {
+      commandsByAgent$: commandsByAgentSubject,
+    };
+
     await TestBed.configureTestingModule({
       imports: [FormsModule, ProcessUserInputComponent],
       providers: [
@@ -74,6 +83,7 @@ describe('ProcessUserInputComponent', () => {
         { provide: ChatService, useValue: chatServiceMock },
         { provide: ContextService, useValue: contextServiceStub },
         { provide: GraphDataService, useValue: graphDataService },
+        { provide: ActorMessageService, useValue: messageServiceStub },
       ],
     }).compileComponents();
 
@@ -701,6 +711,136 @@ describe('ProcessUserInputComponent', () => {
       expect(
         style.justifyContent === 'flex-end' || style.marginLeft === 'auto',
       ).toBeTrue();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Story 15-1 (ADR-013) — `/` slash-command mention
+  // -------------------------------------------------------------------------
+
+  function mkDescriptor(
+    name: string,
+    overrides: Partial<CommandDescriptor> = {},
+  ): CommandDescriptor {
+    return {
+      name,
+      description: `${name} description`,
+      args: [],
+      tool_card: 'TeamTool',
+      ...overrides,
+    };
+  }
+
+  describe('slash-command mention (Story 15-1)', () => {
+    const HIRE = mkDescriptor('hire_member', {
+      description: 'Hire a new team member',
+      args: [
+        { name: 'role', type: 'string', required: true },
+        { name: 'name', type: 'string', required: false },
+      ],
+    });
+    const ROSTER = mkDescriptor('roster', {
+      description: 'List the current team roster',
+    });
+
+    it('AC-3: with exactly one Send-to recipient, commandItems are that agent\'s commands', () => {
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
+      ]);
+      commandsByAgentSubject.next({ '@Manager': [HIRE, ROSTER] });
+      component.selectedAgents = ['@Manager'];
+
+      expect(component.commandItems.map((c) => c.name)).toEqual([
+        'hire_member',
+        'roster',
+      ]);
+    });
+
+    it('AC-3: with zero recipients, defaults to the supervisor (child of @Human entry point)', () => {
+      nodesSubject.next([
+        makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
+        makeNode({
+          name: 'mgr-1',
+          actorName: '@Manager',
+          role: 'Worker',
+          parentId: 'human-1',
+        }),
+        makeNode({
+          name: 'dev-1',
+          actorName: '@Developer',
+          role: 'Worker',
+          parentId: 'mgr-1',
+        }),
+      ]);
+      commandsByAgentSubject.next({
+        '@Manager': [HIRE],
+        '@Developer': [ROSTER],
+      });
+      component.selectedAgents = [];
+
+      // Supervisor = the agent whose parent is @Human → @Manager.
+      expect(component.commandItems.map((c) => c.name)).toEqual(['hire_member']);
+    });
+
+    it('AC-4: with multiple Send-to recipients, the / list is empty', () => {
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
+      ]);
+      commandsByAgentSubject.next({ '@Manager': [HIRE], '@Developer': [ROSTER] });
+      component.selectedAgents = ['@Manager', '@Developer'];
+
+      expect(component.commandItems).toEqual([]);
+    });
+
+    it('AC-6: no CommandsAnnouncedEvent for the target → empty / list', () => {
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+      ]);
+      // commandsByAgent$ stays {} (no event arrived yet).
+      component.selectedAgents = ['@Manager'];
+
+      expect(component.commandItems).toEqual([]);
+    });
+
+    it('selectCommand inserts `/${name} ` (leading slash, trailing space, no send)', () => {
+      const text = component.selectCommand({ name: 'hire_member' });
+      expect(text).toBe('/hire_member ');
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('AC-5: `/command args` text is sent verbatim via the existing send path', async () => {
+      component.selectedAgents = ['@Manager'];
+      component.userInput = '/hire_member Developer "Alice"';
+
+      await component.sendMessage();
+
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id',
+        '/hire_member Developer "Alice"',
+        '@Manager',
+      );
+    });
+
+    it('commandArgsHint renders required in <> and optional in [] in order', () => {
+      expect(component.commandArgsHint(HIRE.args)).toBe('<role> [name]');
+      expect(component.commandArgsHint(ROSTER.args)).toBe('');
+    });
+
+    it('AC-7: mentionConfig still exposes the unchanged @ trigger alongside /', () => {
+      const triggers = component.mentionConfig.mentions.map((m) => m.triggerChar);
+      expect(triggers).toContain('@');
+      expect(triggers).toContain('/');
+      const at = component.mentionConfig.mentions.find((m) => m.triggerChar === '@');
+      expect(at!.mentionSelect).toBe(component.selectAgent);
+      expect(at!.allowSpace).toBeTrue();
+    });
+
+    it('AC-7: selectAgent behavior is unchanged (inserts friendly name + space)', () => {
+      expect(component.selectAgent({ name: 'Manager [Manager]' })).toBe(
+        'Manager [Manager] ',
+      );
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -17,8 +17,10 @@ import { ApiService } from '../../services/api.service';
 import { ChatService } from '../../services/chat.service';
 import { ContextService } from '../../services/context.service';
 import { GraphDataService, HUMAN_ROLE } from '../../services/graph-data.service';
+import { ActorMessageService } from '../../services/message.service';
 
 import { ENTRY_POINT_NAME } from '../../models/chat-message.model';
+import { CommandDescriptor } from '../../models/message.types';
 import { NodeInterface } from '../../models/types';
 
 @Component({
@@ -43,12 +45,27 @@ export class ProcessUserInputComponent implements OnInit {
   chatService: ChatService = inject(ChatService);
   contextService: ContextService = inject(ContextService);
   graphDataService: GraphDataService = inject(GraphDataService);
+  messageService: ActorMessageService = inject(ActorMessageService);
   private config = inject(ConfigService);
   userInput: string = '';
   userInputEnterKeySubmit: boolean = this.config.userInputEnterKeySubmit;
 
   // Mention configuration
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];
+
+  /**
+   * ADR-013: latest per-agent slash-command store (keyed by raw actor
+   * `name`, e.g. `@Manager-…`). Snapshot of `ActorMessageService
+   * .commandsByAgent$`; read by the targeted-agent selector to build the `/`
+   * mention list. Empty until a `CommandsAnnouncedEvent` arrives (AC-6).
+   */
+  commandsByAgent: Record<string, CommandDescriptor[]> = {};
+
+  /**
+   * ADR-013: live snapshot of the graph nodes — used to derive the
+   * supervisor / entry-point default target for the main chat (Task 2.1).
+   */
+  private nodes: NodeInterface[] = [];
   // Dropdown configuration
   dropdownAgents: { label: string; value: string }[] = [];
   selectedAgents: string[] = [];
@@ -59,10 +76,20 @@ export class ProcessUserInputComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
+    // ADR-013: keep a live snapshot of the per-agent slash-command store so
+    // the `/` mention list (built by the targeted-agent selector) reflects the
+    // latest CommandsAnnouncedEvent. Component-scoped (NFR1).
+    this.messageService.commandsByAgent$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((byAgent) => {
+        this.commandsByAgent = byAgent;
+      });
+
     // Subscribe to nodes to populate mention items and dropdown agents
     this.graphDataService.nodes$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((nodes) => {
+        this.nodes = nodes;
         const agents = nodes.filter(
           (n) => n.actorName.startsWith('@') && n.actorName !== ENTRY_POINT_NAME,
         );
@@ -168,4 +195,112 @@ export class ProcessUserInputComponent implements OnInit {
   selectAgent = (item: any) => {
     return `${item.name} `;
   };
+
+  /**
+   * ADR-013 §3 — resolve the SINGLE agent the `/` command list targets in the
+   * MAIN chat, by raw actor `name` (the `commandsByAgent$` / Send-to key):
+   *   - exactly one "Send to" recipient   → that recipient;
+   *   - zero recipients                   → supervisor / entry-point default;
+   *   - multiple recipients (broadcast)   → null (no single target, AC-4).
+   * Returns null when no single target resolves (the `/` list is then empty).
+   */
+  private resolveTargetedAgent(): string | null {
+    if (this.selectedAgents.length > 1) return null;
+    if (this.selectedAgents.length === 1) return this.selectedAgents[0];
+    return this.defaultSupervisorTarget();
+  }
+
+  /**
+   * ADR-013 §3 — supervisor / entry-point default for the main chat when no
+   * "Send to" recipient is selected. Derived from existing graph state (no new
+   * backend field): the agent whose parent is the `@Human` entry-point node.
+   * Falls back to the first non-human agent when the parent link is absent,
+   * and to null when no candidate agent exists.
+   */
+  private defaultSupervisorTarget(): string | null {
+    const candidates = this.nodes.filter(
+      (n) => n.actorName.startsWith('@') && n.actorName !== ENTRY_POINT_NAME,
+    );
+    if (candidates.length === 0) return null;
+    const entry = this.nodes.find((n) => n.actorName === ENTRY_POINT_NAME);
+    if (entry) {
+      const child = candidates.find((n) => n.parentId === entry.name);
+      if (child) return child.actorName;
+    }
+    return candidates[0].actorName;
+  }
+
+  /**
+   * ADR-013 — the `/` mention candidate list: the resolved targeted agent's
+   * command descriptors, mapped to dropdown items (`name` + `description` +
+   * ordered `args`). Empty when no single target resolves (none/ambiguous,
+   * AC-4) or no CommandsAnnouncedEvent has arrived yet for it (AC-6).
+   */
+  get commandItems(): {
+    name: string;
+    description: string;
+    args: CommandDescriptor['args'];
+  }[] {
+    const target = this.resolveTargetedAgent();
+    if (!target) return [];
+    const descriptors = this.commandsByAgent[target] ?? [];
+    return descriptors.map((d) => ({
+      name: d.name,
+      description: d.description,
+      args: d.args,
+    }));
+  }
+
+  /**
+   * ADR-013 §2 — multi-trigger `angular-mentions` config. The `@` entry is
+   * unchanged (AC-7); the `/` entry lists the targeted agent's commands and
+   * inserts `/${name} ` via `selectCommand`. `allowSpace: false` closes the
+   * dropdown at the first space (after the command name) so the user types
+   * args freely; `maxItems`/`dropUp` mirror the `@` list.
+   */
+  get mentionConfig() {
+    return {
+      mentions: [
+        {
+          triggerChar: '@',
+          labelKey: 'name',
+          returnTrigger: true,
+          allowSpace: true,
+          mentionSelect: this.selectAgent,
+          dropUp: true,
+          maxItems: 10,
+          items: this.mentionItems,
+        },
+        {
+          triggerChar: '/',
+          labelKey: 'name',
+          allowSpace: false,
+          mentionSelect: this.selectCommand,
+          dropUp: true,
+          maxItems: 10,
+          items: this.commandItems,
+        },
+      ],
+    };
+  }
+
+  /**
+   * ADR-013 §2 — insert `/${name} ` (leading slash + trailing space) for the
+   * chosen command so the user keeps typing arguments. Does NOT send; the
+   * literal text is sent verbatim on the existing Enter path (AC-5).
+   */
+  selectCommand = (item: { name: string }) => {
+    return `/${item.name} `;
+  };
+
+  /**
+   * ADR-013 §2 — render an args hint for a command dropdown row, e.g.
+   * `<role> [name]`: required args in angle brackets, optional in square
+   * brackets, in declared order. Empty string when the command takes no args.
+   */
+  commandArgsHint(args: CommandDescriptor['args']): string {
+    return args
+      .map((a) => (a.required ? `<${a.name}>` : `[${a.name}]`))
+      .join(' ');
+  }
 }

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -543,12 +543,195 @@ describe('ActorMessageService — Story 6.1 (frame-batched log ingestion)', () =
 });
 
 // ---------------------------------------------------------------------------
-// Story 6.4 (AC5) — two-exceptions invariant (NFR9)
+// Epic 15 / Story 15-1 (ADR-013) — commandsByAgent$ from CommandsAnnouncedEvent
+// ---------------------------------------------------------------------------
+
+describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () => {
+  let service: ActorMessageService;
+  let chatService: ChatService;
+  let fakeSocket: Subject<any>;
+
+  function mkCommandsEvent(
+    agentName: string,
+    commands: any[],
+    id = 'cmd-evt',
+  ): any {
+    return {
+      id,
+      parent_id: null,
+      team_id: 'team-X',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: makeAddress({ name: agentName, agent_id: 'a-' + agentName }),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      event: {
+        __model__: 'akgentic.tool.commands.CommandsAnnouncedEvent',
+        agent: makeAddress({ name: agentName, agent_id: 'a-' + agentName }),
+        commands,
+      },
+    };
+  }
+
+  const HIRE = {
+    name: 'hire_member',
+    description: 'Hire a new team member',
+    args: [
+      { name: 'role', type: 'string', required: true },
+      { name: 'name', type: 'string', required: false },
+    ],
+    tool_card: 'TeamTool',
+  };
+  const ROSTER = {
+    name: 'roster',
+    description: 'List the current team roster',
+    args: [],
+    tool_card: 'TeamTool',
+  };
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+
+    fakeSocket = new Subject<any>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MessageLogService,
+        ActorMessageService,
+        ChatService,
+        {
+          provide: ApiService,
+          useValue: {
+            getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+          },
+        },
+        { provide: MessageService, useValue: { add: jasmine.createSpy('add'), clear: jasmine.createSpy('clear') } },
+      ],
+    });
+    service = TestBed.inject(ActorMessageService);
+    chatService = TestBed.inject(ChatService);
+
+    spyOn<any>(service, 'createWebSocket').and.returnValue(
+      fakeSocket as unknown as WebSocketSubject<any>,
+    );
+  });
+
+  afterEach(() => {
+    try {
+      fakeSocket.complete();
+    } catch {
+      /* already closed */
+    }
+    jasmine.clock().uninstall();
+  });
+
+  it('AC-1: a CommandsAnnouncedEvent accumulates the agent\'s descriptors under its name', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE, ROSTER]));
+    jasmine.clock().tick(17);
+
+    const byAgent = service.commandsByAgent$.getValue();
+    expect(byAgent['@Manager']).toBeDefined();
+    expect(byAgent['@Manager'].map((c) => c.name)).toEqual([
+      'hire_member',
+      'roster',
+    ]);
+  });
+
+  it('AC-1: a later event for the same agent REPLACES that entry', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE, ROSTER], 'e1'));
+    jasmine.clock().tick(17);
+    expect(service.commandsByAgent$.getValue()['@Manager'].length).toBe(2);
+
+    // Re-announce with a shorter list — must replace, not merge.
+    fakeSocket.next(mkCommandsEvent('@Manager', [ROSTER], 'e2'));
+    jasmine.clock().tick(17);
+
+    const byAgent = service.commandsByAgent$.getValue();
+    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['roster']);
+  });
+
+  it('AC-1: events for different agents are kept under distinct keys', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE], 'e1'));
+    fakeSocket.next(mkCommandsEvent('@Developer', [ROSTER], 'e2'));
+    jasmine.clock().tick(17);
+
+    const byAgent = service.commandsByAgent$.getValue();
+    expect(Object.keys(byAgent).sort()).toEqual(['@Developer', '@Manager']);
+    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['hire_member']);
+    expect(byAgent['@Developer'].map((c) => c.name)).toEqual(['roster']);
+  });
+
+  it('Task 1.3: init() resets commandsByAgent$ to {}', async () => {
+    await service.init('proc-A', true);
+    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE]));
+    jasmine.clock().tick(17);
+    expect(Object.keys(service.commandsByAgent$.getValue()).length).toBe(1);
+
+    // Re-init (team switch) — store must be cleared synchronously.
+    const socketB = new Subject<any>();
+    (service as any).createWebSocket = jasmine
+      .createSpy('createWebSocket')
+      .and.returnValue(socketB as unknown as WebSocketSubject<any>);
+    await service.init('proc-B', true);
+
+    expect(service.commandsByAgent$.getValue()).toEqual({});
+    socketB.complete();
+  });
+
+  it('AC-1: a CommandsAnnouncedEvent without an agent name is ignored (no partial populate)', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next({
+      id: 'bad',
+      parent_id: null,
+      team_id: 'team-X',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: makeAddress(),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      event: {
+        __model__: 'akgentic.tool.commands.CommandsAnnouncedEvent',
+        commands: [HIRE],
+      },
+    });
+    jasmine.clock().tick(17);
+
+    expect(service.commandsByAgent$.getValue()).toEqual({});
+  });
+
+  it('Replay: stopped-team getEvents() rebuilds commandsByAgent$', async () => {
+    const apiService = TestBed.inject(ApiService) as any;
+    apiService.getEvents.and.resolveTo([
+      { event: mkCommandsEvent('@Manager', [HIRE, ROSTER], 'r1') },
+      // Later replay event for @Manager replaces the earlier one.
+      { event: mkCommandsEvent('@Manager', [ROSTER], 'r2') },
+      { event: mkCommandsEvent('@Developer', [HIRE], 'r3') },
+    ]);
+
+    await service.init('proc-stopped', false);
+
+    const byAgent = service.commandsByAgent$.getValue();
+    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['roster']);
+    expect(byAgent['@Developer'].map((c) => c.name)).toEqual(['hire_member']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 6.4 (AC5) — sanctioned-exceptions invariant (NFR9)
 //
-// ADR-005 §Decision 5: stateDict$ and contextDict$ are the ONLY imperative
+// ADR-005 §Decision 5: stateDict$ and contextDict$ were the ONLY imperative
 // state containers on ActorMessageService after the Story 6.4 refactor.
-// "Adding a third exception requires a new ADR. This test is the automated
-// guard."
+// "Adding an exception requires a new ADR. This test is the automated guard."
+// ADR-013 adds a third sanctioned exception, commandsByAgent$ (the per-agent
+// slash-command store driven by CommandsAnnouncedEvent).
 // ---------------------------------------------------------------------------
 
 /**
@@ -575,7 +758,7 @@ function probeStateContainers(service: object): string[] {
   });
 }
 
-describe('ActorMessageService — two-exceptions invariant (Story 6.4, NFR9)', () => {
+describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NFR9; ADR-013)', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -593,26 +776,28 @@ describe('ActorMessageService — two-exceptions invariant (Story 6.4, NFR9)', (
     });
   });
 
-  it('public data surface is exactly {stateDict$, contextDict$}', () => {
+  it('public data surface is exactly {stateDict$, contextDict$, commandsByAgent$}', () => {
     const service = TestBed.inject(ActorMessageService);
     // AC5 spec: the probe MUST NOT rely on a name allow-list — it walks
     // `Object.getOwnPropertyNames` with a runtime `instanceof` check so that
     // any new `BehaviorSubject` field (regardless of name) forces this test
-    // to fail. Per ADR-005 §Decision 5, adding a third exception requires a
-    // new ADR.
+    // to fail. Per ADR-005 §Decision 5, adding an exception requires a new
+    // ADR — ADR-013 sanctioned commandsByAgent$ (the third exception).
     const containers = probeStateContainers(service);
-    expect(new Set(containers)).toEqual(new Set(['stateDict$', 'contextDict$']));
+    expect(new Set(containers)).toEqual(
+      new Set(['stateDict$', 'contextDict$', 'commandsByAgent$']),
+    );
   });
 
-  it('negative probe: adding a third exception fails the invariant', () => {
+  it('negative probe: adding a fourth exception fails the invariant', () => {
     const service = TestBed.inject(ActorMessageService);
     // Simulate the "someone added a new BehaviorSubject" diff.
     (service as any).extraDict$ = { agent: new BehaviorSubject<any>(null) };
     const containers = probeStateContainers(service);
     // The probe MUST detect the addition (set is no longer the documented
-    // pair). Without this guard, the invariant test would silently pass.
+    // trio). Without this guard, the invariant test would silently pass.
     expect(new Set(containers)).not.toEqual(
-      new Set(['stateDict$', 'contextDict$']),
+      new Set(['stateDict$', 'contextDict$', 'commandsByAgent$']),
     );
     expect(containers).toContain('extraDict$');
   });

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -4,7 +4,11 @@ import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 import { bufferTime, filter, take } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { ConfigService } from './config.service';
-import { AkgenticMessage } from '../models/message.types';
+import {
+  AkgenticMessage,
+  CommandDescriptor,
+  isCommandsAnnouncedEvent,
+} from '../models/message.types';
 import { EventResponse } from '../models/team.interface';
 
 import { ApiService } from '../services/api.service';
@@ -27,11 +31,14 @@ const SPINNER_MIN_VISIBLE_MS = 500;
  *   - WS `bufferTime(16)` ingestion appends to the log + per-agent dicts.
  *   - Spinner floor (`loadingProcess$` on `ChatService`, AC7) — UX concern.
  *
- * Two documented exceptions (NFR9 / ADR-005 §Decision 5):
- *   - `stateDict$`  — driven by `StateChangedMessage`
- *   - `contextDict$` — driven by `LlmMessageEvent`
+ * Three documented exceptions (NFR9 / ADR-005 §Decision 5; ADR-013):
+ *   - `stateDict$`       — driven by `StateChangedMessage`
+ *   - `contextDict$`     — driven by `LlmMessageEvent`
+ *   - `commandsByAgent$` — driven by `CommandsAnnouncedEvent` (ADR-013); the
+ *     per-agent slash-command store consumed by the `/` mention. ADR-005
+ *     §Decision 5 requires a new ADR to add an exception — ADR-013 is that ADR.
  *
- * Adding a third exception requires a new ADR.
+ * Adding a fourth exception requires a new ADR.
  * `message.service.spec.ts` enforces this invariant by test (Story 6.4 AC5).
  */
 @Injectable()
@@ -54,6 +61,18 @@ export class ActorMessageService {
 
   contextDict$: { [key: string]: BehaviorSubject<any[]> } = {};
   stateDict$: { [key: string]: BehaviorSubject<any> } = {};
+
+  /**
+   * ADR-013 (third NFR9 exception): per-agent slash-command store, keyed by
+   * agent friendly name (the `@`-prefixed actor `name`, e.g. `@Manager`).
+   * Driven by `CommandsAnnouncedEvent` riding the existing `EventMessage`
+   * passthrough; a later event for an agent REPLACES that agent's entry (the
+   * backend re-emits the full list on change). Consumed by the `/` mention's
+   * targeted-agent selector. Reset on every `init()` alongside the other
+   * per-team dicts.
+   */
+  commandsByAgent$: BehaviorSubject<Record<string, CommandDescriptor[]>> =
+    new BehaviorSubject<Record<string, CommandDescriptor[]>>({});
 
   processId: string = '';
 
@@ -113,6 +132,9 @@ export class ActorMessageService {
     this.log.reset();
     this.stateDict$ = {};
     this.contextDict$ = {};
+    // ADR-013: clear the per-agent slash-command store so process-A's
+    // announced commands cannot leak into process-B.
+    this.commandsByAgent$.next({});
 
     // Story 8-2: clear any stale toasts from a prior init() cycle
     // so process-A's warnings do not persist into process-B.
@@ -151,6 +173,11 @@ export class ActorMessageService {
       // - LlmMessageEvent: messages appended in chronological order (ordered context)
       const latestStates: { [agentId: string]: any } = {};
       const contextArrays: { [agentId: string]: any[] } = {};
+      // ADR-013: rebuild the per-agent slash-command store from persisted
+      // events too, so a stopped-team reopen still shows the `/` list. Keyed
+      // by agent friendly name; a later replay event REPLACES the entry
+      // (consistent with the live replace-on-reannounce semantics).
+      const commandsByAgent: Record<string, CommandDescriptor[]> = {};
 
       for (const er of eventResponses) {
         const evt = er.event;
@@ -169,11 +196,18 @@ export class ActorMessageService {
               if (!contextArrays[agentId]) contextArrays[agentId] = [];
               contextArrays[agentId].push(inner.message);
             }
+          } else if (isCommandsAnnouncedEvent(inner)) {
+            const agentName = inner.agent?.name;
+            if (agentName) commandsByAgent[agentName] = inner.commands ?? [];
           }
           // Story 6.2 (ADR-005 §Decision 4): `ToolStateEvent` is now folded
           // into `knowledgeGraph$` via `kgFold` over `log$` (seeded above by
           // `log.appendAll`). No explicit reducer drive required.
         }
+      }
+
+      if (Object.keys(commandsByAgent).length > 0) {
+        this.commandsByAgent$.next(commandsByAgent);
       }
 
       for (const [agentId, state] of Object.entries(latestStates)) {
@@ -393,10 +427,32 @@ export class ActorMessageService {
         const current = this.contextDict$[agentId].getValue();
         this.contextDict$[agentId].next([...current, inner.message]);
       }
+    } else if (isCommandsAnnouncedEvent(inner)) {
+      this.applyCommandsAnnounced(inner);
     }
     // Story 6.2 (ADR-005 §Decision 4): `ToolStateEvent` is now covered
     // entirely by `KGStateReducer.knowledgeGraph$` (pure selector over
     // `log$`). The batched subscriber no longer drives the reducer.
+  }
+
+  /**
+   * ADR-013: fold a `CommandsAnnouncedEvent` into `commandsByAgent$`. Keyed by
+   * the announcing agent's friendly `name` (the `@`-prefixed actor name, which
+   * the `/`-mention selector matches against the Send-to / panel agent). A
+   * later event for the same agent REPLACES that agent's entry. Ignored when
+   * the event carries no agent name (defensive — never partially populate).
+   */
+  private applyCommandsAnnounced(inner: {
+    agent?: { name?: string };
+    commands?: CommandDescriptor[];
+  }): void {
+    const agentName = inner.agent?.name;
+    if (!agentName) return;
+    const current = this.commandsByAgent$.getValue();
+    this.commandsByAgent$.next({
+      ...current,
+      [agentName]: inner.commands ?? [],
+    });
   }
 
   /**
@@ -493,6 +549,9 @@ export class ActorMessageService {
     this.bufferSub?.unsubscribe();
     this.spinnerSub?.unsubscribe();
     this._wsInbound$.complete();
+    // ADR-013: complete the slash-command store on teardown so no leaked
+    // subscriber survives the component.
+    this.commandsByAgent$.complete();
     if (this.spinnerFlipTimer !== null) {
       clearTimeout(this.spinnerFlipTimer);
       this.spinnerFlipTimer = null;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -137,6 +137,28 @@ chat-wrapper {
   transform: translateY(calc(-100% - 2.5rem));
 }
 
+// ADR-013: slash-command mention dropdown rows. The `angular-mentions`
+// `mention-list` component is created via ViewContainerRef, so its rows live
+// outside the input component's scoped styles — these rules are global.
+// `@` rows carry only `.mention-item-name`; `/` command rows add an args hint
+// and a secondary description line.
+.mention-item-name {
+  font-weight: 600;
+}
+
+.mention-item-args {
+  margin-left: 0.4rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  font-family: monospace;
+}
+
+.mention-item-desc {
+  display: block;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
 // markdown styles
 markdown {
 


### PR DESCRIPTION
## Epic 15 — Slash-command mention

Adds a second `angular-mentions` trigger (`/`) to the chat input that lists the
currently-targeted agent's available commands (with descriptions) and inserts
`/${name} ` text, mirroring the existing `@` mention. The candidate list is
sourced from `CommandsAnnouncedEvent` riding the existing `EventMessage`
passthrough — no infra change, no new WS envelope.

### Stories

- [x] 15-1 — slash-command mention (Relates to #137)

## Review status

**Verdict: APPROVED — done.** No HIGH or CRITICAL findings. The diff faithfully
implements ADR-013 and all seven acceptance criteria:

- AC-1: `commandsByAgent$` accumulates per-agent descriptors discriminated by the
  inner `__model__` (`CommandsAnnouncedEvent`), replace-on-reannounce, distinct
  keys, rebuilt on stopped-team replay.
- AC-2: member chat `/` lists the panel agent's commands; `selectCommand` inserts
  `/${name} ` (leading slash, trailing space) without sending.
- AC-3: main chat resolves a single target — one Send-to recipient, else the
  supervisor/entry-point default (agent whose parent is the `@Human` node).
- AC-4: zero or multiple Send-to recipients → empty `/` list.
- AC-5: literal `/command args` text sent verbatim via the existing send path
  (no client-side parsing; `sendMessage()` untouched).
- AC-6: no `CommandsAnnouncedEvent` yet → empty `/` list, text sent as ordinary.
- AC-7: `@` mention, Send-to/Send-as dropdowns, and routing unchanged
  (verified: `@` trigger retains `mentionSelect: selectAgent`, `allowSpace: true`).

Key-consistency verified end-to-end: the store key (`agent.name`), the main-chat
lookup key (`node.actorName` = `sender.name`), and the member-chat key
(`agentName` = `Akgent.name` = `actorName`) are all the same `@`-prefixed actor
name. No `any`-soup — typed `CommandArg` / `CommandDescriptor` / `CommandsAnnouncedEvent`
interfaces and a typed `isCommandsAnnouncedEvent` guard.

**Test gate:** Karma `TOTAL: 781 SUCCESS`, 0 failing. `ng build` green
(only the pre-existing lodash CommonJS warning, unrelated).

## CI status

`akgentic-frontend` has **no GitHub Actions pipeline** (no `.github/workflows`).
The authoritative gate is the local Karma suite + `ng build`, both run and green
(781 passing, build successful).

## ADR-005 invariant

Amelia updated the NFR9 "sanctioned-exceptions" Karma invariant to admit a third
component-scoped `BehaviorSubject` (`commandsByAgent$` on `ActorMessageService`),
relaxing the previous `{stateDict$, contextDict$}` pair to the trio
`{stateDict$, contextDict$, commandsByAgent$}`; the negative probe now guards
against a *fourth*. **This change is legitimate.** ADR-005 §Decision 5 / AC6
state the two exceptions are the only imperative state and "Adding a third
exception requires a new ADR." ADR-013 §1 is exactly that ADR — it explicitly
introduces `commandsByAgent$` as a new component-scoped state container driven by
`CommandsAnnouncedEvent`. The invariant test still walks `getOwnPropertyNames`
with a runtime `instanceof` check (no name allow-list), so any *fourth*
BehaviorSubject still fails the guard. Approved.

## Scope guard

All changes in `9dfaf49` are confined to `packages/akgentic-frontend/` (models,
`ActorMessageService`, both chat-input surfaces, styles, and their specs). No
cross-submodule edits. No review fixup commit was required.

## Epic 15 complete

Single-story epic; 15-1 is `done`. Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
