### PR TITLE
feat(akgentic-frontend): epic 16 — System Prompt Trace — Head Rendering from LlmSystemPromptEvent (16-1-latest-system-prompt-selector-over-log → 16-2-render-head-system-block-remove-inline-system-rendering)

### DIFF
--- a/src/app/models/message.types.ts
+++ b/src/app/models/message.types.ts
@@ -157,6 +157,36 @@ export interface CommandsAnnouncedEvent {
   commands: CommandDescriptor[];
 }
 
+/**
+ * Immutable snapshot of one rendered system-prompt part, mirroring the
+ * akgentic-llm `SystemPromptPartSnapshot` frozen dataclass (ADR-004 §Decision 1).
+ * `dynamic_ref` is the pydantic-ai dynamic-prompt function name (e.g.
+ * `current_date`) or `null` for static parts; `content` is the rendered text
+ * actually sent to the model. `__model__` is the serializer-injected tag
+ * (`akgentic.llm.event.SystemPromptPartSnapshot`) and is optional on read.
+ */
+export interface SystemPromptPartSnapshot {
+  __model__?: string;
+  dynamic_ref: string | null;
+  content: string;
+}
+
+/**
+ * Inner event payload announcing the effective system-prompt rendering for one
+ * run, mirroring the akgentic-llm `LlmSystemPromptEvent` frozen dataclass
+ * (ADR-004 §Decision 1). It rides the standard `EventMessage` envelope (outer
+ * `sender.agent_id` identifies the agent) and is discriminated frontend-side by
+ * the inner `__model__` — exactly like `LlmMessageEvent` / `ToolStateEvent` /
+ * `CommandsAnnouncedEvent`. A later event for the same agent supersedes the
+ * previous rendering (latest-wins). See ADR-004 §5a for the wire JSON.
+ */
+export interface LlmSystemPromptEvent {
+  __model__: string; // contains 'LlmSystemPromptEvent'
+  run_id: string;
+  content_hash: string;
+  parts: SystemPromptPartSnapshot[];
+}
+
 // Union type for all possible messages
 export type AkgenticMessage =
   | SentMessage
@@ -234,6 +264,19 @@ export function isCommandsAnnouncedEvent(
   event: { __model__?: string } | null | undefined,
 ): event is CommandsAnnouncedEvent {
   return !!event?.__model__?.includes('CommandsAnnouncedEvent');
+}
+
+/**
+ * Inner-event check (ADR-004 §5a): true when the inner event carried by an
+ * `EventMessage` is a `LlmSystemPromptEvent`. Matches on the inner `__model__`,
+ * the same discrimination used for `LlmMessageEvent` / `ToolStateEvent` /
+ * `CommandsAnnouncedEvent`. `event` is the `EventMessage.event` payload (loosely
+ * typed on the wire); the guard narrows it to `LlmSystemPromptEvent`.
+ */
+export function isLlmSystemPromptEvent(
+  event: { __model__?: string } | null | undefined,
+): event is LlmSystemPromptEvent {
+  return !!event?.__model__?.includes('LlmSystemPromptEvent');
 }
 
 /**

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -1,3 +1,29 @@
+<!--
+  ADR-004 §5b step 2 — head system block. Rendered ABOVE the conversation table
+  and independently of `context.length`, sourced ONCE from `systemPrompt$`
+  (SystemPromptSelector, Story 16-1). Latest-wins: shows the most recent
+  rendering across runs. `*ngIf ... as rows` + `rows.length` guard renders
+  nothing when there are no system rows (AC8). Reuses the existing system-block
+  fieldset markup so it is visually identical to how system blocks rendered
+  before. `async` keeps it OnPush-safe and self-unsubscribing.
+-->
+<div
+  class="head-system-container"
+  *ngIf="systemPrompt$ | async as rows"
+>
+  <ng-container *ngIf="rows.length">
+    <div class="card-container" *ngFor="let row of rows">
+      <div class="card-header">{{ row.type | capitalize }} : {{ row.name }}</div>
+      <div class="fieldset-body">
+        <p-fieldset legend="Content" [toggleable]="false">
+          <app-copy-button (click)="utilService.copyToClipboard(row.content)" />
+          <div class="text-container" [innerHTML]="row.content"></div>
+        </p-fieldset>
+      </div>
+    </div>
+  </ng-container>
+</div>
+
 <!-- Collapsible Arrow and Button -->
 <div class="collapsible-container" *ngIf="context.length">
   <div class="collapsible">

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
 
 import { AkgentChatComponent } from './akgent-chat.component';
@@ -6,7 +7,12 @@ import { ApiService } from '../../../services/api.service';
 import { UtilService } from '../../../services/utils.service';
 import { ContextService } from '../../../services/context.service';
 import { ActorMessageService } from '../../../services/message.service';
-import { CommandDescriptor } from '../../../models/message.types';
+import { MessageLogService } from '../../../services/message-log.service';
+import { SystemPromptSelector } from '../../../services/system-prompt.selector';
+import {
+  AkgenticMessage,
+  CommandDescriptor,
+} from '../../../models/message.types';
 
 /**
  * Story 15-1 (ADR-013) — member-chat `/` slash-command mention. The member
@@ -56,6 +62,10 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
           provide: ActorMessageService,
           useValue: { commandsByAgent$: commandsByAgentSubject },
         },
+        // Story 16-2: AkgentChatComponent now injects the component-scoped
+        // SystemPromptSelector (over MessageLogService). Provide the real pair.
+        MessageLogService,
+        SystemPromptSelector,
       ],
     });
 
@@ -93,5 +103,343 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
   it('commandArgsHint renders required in <> and optional in []', () => {
     expect(component.commandArgsHint(HIRE.args)).toBe('<role> [name]');
     expect(component.commandArgsHint(ROSTER.args)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 16-2 (ADR-004 §5b) — head system block rendered ONCE from
+// `latestSystemPrompt$`, inline `system-prompt` branch removed from
+// `updateContext()`. Driven through the real MessageLogService →
+// SystemPromptSelector → component pipeline (log → selector → head render).
+//
+// Fixtures mirror the ADR-004 §5a wire JSON. The backend emitter (akgentic-llm)
+// need NOT be merged/released — the event contract is frozen, so fixtures are an
+// authoritative source. (Full live e2e is deferred per the story Open Questions.)
+// ---------------------------------------------------------------------------
+
+interface PartSnapshot {
+  dynamic_ref: string | null;
+  content: string;
+}
+
+function spSender(agentId: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name: '@' + agentId,
+    role: 'Agent',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+let spCounter = 0;
+
+/** EventMessage envelope carrying a LlmSystemPromptEvent (primary path). */
+function systemPromptEnvelope(
+  agentId: string,
+  parts: PartSnapshot[],
+  contentHash = 'h-' + spCounter
+): AkgenticMessage {
+  return {
+    id: 'sp-' + agentId + '-' + spCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: spSender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmSystemPromptEvent',
+      run_id: 'run-' + contentHash,
+      content_hash: contentHash,
+      parts: parts.map((p) => ({
+        __model__: 'akgentic.llm.event.SystemPromptPartSnapshot',
+        ...p,
+      })),
+    },
+  } as unknown as AkgenticMessage;
+}
+
+/**
+ * EventMessage envelope carrying a LlmMessageEvent whose inner ModelRequest
+ * `message.parts` include `part_kind === 'system-prompt'` parts (fallback path,
+ * pre-event teams).
+ */
+function llmMessageEnvelope(
+  agentId: string,
+  systemParts: PartSnapshot[]
+): AkgenticMessage {
+  return {
+    id: 'llm-' + agentId + '-' + spCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: spSender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmMessageEvent',
+      message: {
+        parts: [
+          ...systemParts.map((p) => ({ part_kind: 'system-prompt', ...p })),
+          { part_kind: 'user-prompt', content: 'hi' },
+        ],
+      },
+    },
+  } as unknown as AkgenticMessage;
+}
+
+/**
+ * A raw context message (as fed via `context$`) whose `parts` carry both a
+ * `system-prompt` and a `user-prompt` part — the run-1 double-carry. After
+ * Story 16-2, `updateContext()` must drop the `system-prompt` arm and keep the
+ * `user-prompt` arm.
+ */
+function doubleCarryContextMessage(): any {
+  return {
+    kind: 'request',
+    parts: [
+      {
+        part_kind: 'system-prompt',
+        dynamic_ref: 'team.roster',
+        content: 'inline roster v1',
+      },
+      { part_kind: 'user-prompt', content: 'hello team' },
+    ],
+  };
+}
+
+describe('AkgentChatComponent — head system block (Story 16-2)', () => {
+  const AGENT = 'a-mgr';
+
+  function setup(): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    component: AkgentChatComponent;
+    log: MessageLogService;
+  } {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine
+              .createSpy('sendMessage')
+              .and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        {
+          provide: ActorMessageService,
+          useValue: {
+            commandsByAgent$: new BehaviorSubject<
+              Record<string, CommandDescriptor[]>
+            >({}),
+          },
+        },
+        MessageLogService,
+        SystemPromptSelector,
+        // PrimeNG p-fieldset registers a synthetic animation listener.
+        provideNoopAnimations(),
+      ],
+    });
+
+    const log = TestBed.inject(MessageLogService);
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, component, log };
+  }
+
+  /** All rendered head-block card headers, e.g. "System : roster". */
+  function headHeaders(
+    fixture: ComponentFixture<AkgentChatComponent>
+  ): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.head-system-container .card-header')
+    ).map((n) => (n.textContent ?? '').trim());
+  }
+
+  /** Rendered head-block content bodies, in order. */
+  function headBodies(
+    fixture: ComponentFixture<AkgentChatComponent>
+  ): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.head-system-container .text-container')
+    ).map((n) => (n.textContent ?? '').trim());
+  }
+
+  it('AC1 latest-wins: head fieldset shows the LAST event\'s rows', () => {
+    const { fixture, component, log } = setup();
+    log.appendAll([
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+      ]),
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster v2' },
+        { dynamic_ref: null, content: 'backstory' },
+      ]),
+    ]);
+    fixture.detectChanges();
+
+    expect(headHeaders(fixture)).toEqual([
+      'System : roster',
+      'System : System',
+    ]);
+    expect(headBodies(fixture)).toEqual(['roster v2', 'backstory']);
+    // No system row leaked into the conversation table.
+    expect(component.context.some((m) => m.type === 'system')).toBeFalse();
+  });
+
+  it('AC2 single source: updateContext() emits NO system row from a system-prompt part', () => {
+    const { component } = setup();
+    component.updateContext([doubleCarryContextMessage()]);
+    // The user-prompt arm still produces a human row...
+    expect(component.context.some((m) => m.type === 'human')).toBeTrue();
+    // ...but the system-prompt arm is gone — no system row from updateContext.
+    expect(component.context.some((m) => m.type === 'system')).toBeFalse();
+  });
+
+  it('AC2 untouched arms: tool-call / tool-return / text parts still render', () => {
+    const { component } = setup();
+    component.updateContext([
+      {
+        parts: [
+          {
+            part_kind: 'tool-call',
+            tool_name: 'search',
+            args: '{"q":"x"}',
+            tool_call_id: 't1',
+          },
+          {
+            part_kind: 'tool-return',
+            content: 'result-x',
+            tool_call_id: 't1',
+          },
+          { part_kind: 'text', content: 'final answer' },
+        ],
+      },
+    ]);
+    const types = component.context.map((m) => m.type);
+    expect(types).toContain('tool_call');
+    expect(types).toContain('ai');
+    // tool_call result merged from the tool-return.
+    const toolCall = component.context.find((m) => m.type === 'tool_call');
+    expect(toolCall.result).toBe('result-x');
+  });
+
+  it('AC3 no duplicate: run-1 double-carry renders the system block exactly once (at the head)', () => {
+    const { fixture, component, log } = setup();
+    // Same rendering carried in BOTH the first LlmMessageEvent (→ context$)
+    // AND a LlmSystemPromptEvent (→ selector).
+    log.appendAll([
+      llmMessageEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster' },
+      ]),
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster' },
+      ]),
+    ]);
+    component.context$.next([doubleCarryContextMessage()]);
+    fixture.detectChanges();
+
+    // Head block renders once.
+    expect(headHeaders(fixture)).toEqual(['System : roster']);
+    // And there is no second system block inside the conversation rows.
+    const el: HTMLElement = fixture.nativeElement;
+    const allSystemHeaders = Array.from(
+      el.querySelectorAll('.card-header')
+    ).filter((n) => (n.textContent ?? '').includes('System :'));
+    expect(allSystemHeaders.length).toBe(1);
+  });
+
+  it('AC5 old-team fallback: no LlmSystemPromptEvent → head block from first LlmMessageEvent system parts', () => {
+    const { fixture, component, log } = setup();
+    log.appendAll([
+      llmMessageEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'legacy roster' },
+      ]),
+    ]);
+    // The same first message also seeds the conversation context (double-carry).
+    component.context$.next([doubleCarryContextMessage()]);
+    fixture.detectChanges();
+
+    expect(headHeaders(fixture)).toEqual(['System : roster']);
+    expect(headBodies(fixture)).toEqual(['legacy roster']);
+    // Still no inline duplicate.
+    expect(component.context.some((m) => m.type === 'system')).toBeFalse();
+  });
+
+  it('AC7 REST/WS parity: batch appendAll and per-message append render identical head rows', () => {
+    const fixtureEvents = (): AkgenticMessage[] => [
+      llmMessageEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'legacy' },
+      ]),
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+        { dynamic_ref: 'current_date', content: 'day 1' },
+      ]),
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster v2' },
+        { dynamic_ref: 'current_date', content: 'day 2' },
+      ]),
+    ];
+
+    // REST: single batch.
+    const rest = setup();
+    rest.log.appendAll(fixtureEvents());
+    rest.fixture.detectChanges();
+    const restHead = headHeaders(rest.fixture).concat(headBodies(rest.fixture));
+
+    // WS: per-message.
+    const ws = setup();
+    for (const ev of fixtureEvents()) ws.log.append(ev);
+    ws.fixture.detectChanges();
+    const wsHead = headHeaders(ws.fixture).concat(headBodies(ws.fixture));
+
+    expect(restHead).toEqual(wsHead);
+    // Latest-wins: roster v2 / day 2.
+    expect(headBodies(rest.fixture)).toEqual(['roster v2', 'day 2']);
+  });
+
+  it('AC8 empty/absent: no system parts → no head fieldset, no throw', () => {
+    const { fixture, component, log } = setup();
+    // A log with only an unrelated event — no system parts for the agent.
+    log.append({
+      id: 'u1',
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: new Date().toISOString(),
+      sender: spSender(AGENT),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      event: { __model__: 'akgentic.llm.event.ToolStateEvent' },
+    } as unknown as AkgenticMessage);
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelectorAll('.head-system-container .card-header').length).toBe(
+      0
+    );
+    expect(component.context.some((m) => m.type === 'system')).toBeFalse();
   });
 });

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -12,13 +12,17 @@ import { Table, TableModule } from 'primeng/table';
 import { TextareaModule } from 'primeng/textarea';
 import { MentionModule } from 'angular-mentions';
 
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 import { CapitalizePipe } from '../../../pipes/capitalise.pipe';
 import { ApiService } from '../../../services/api.service';
 import { UtilService } from '../../../services/utils.service';
 import { ContextService } from '../../../services/context.service';
 import { ActorMessageService } from '../../../services/message.service';
+import {
+  SystemPromptRow,
+  SystemPromptSelector,
+} from '../../../services/system-prompt.selector';
 import { CommandDescriptor } from '../../../models/message.types';
 
 import { CopyButtonComponent } from '../../copy-button/copy-button.component';
@@ -56,11 +60,27 @@ export class AkgentChatComponent {
   utilService: UtilService = inject(UtilService);
   contextService: ContextService = inject(ContextService);
   messageService: ActorMessageService = inject(ActorMessageService);
+  // ADR-004 §5b: component-scoped selector provided on ProcessComponent.providers
+  // (Story 16-1) — resolves the same MessageLogService instance as this subtree.
+  private systemPromptSelector: SystemPromptSelector = inject(
+    SystemPromptSelector
+  );
   private destroyRef = inject(DestroyRef);
 
   collapsedMessages$ = new BehaviorSubject<boolean>(true);
 
   context: any[] = [];
+
+  /**
+   * ADR-004 §5b step 2 — the head system block, derived once from the unified
+   * log by `SystemPromptSelector.latestSystemPrompt$`. Bound in the template via
+   * the `async` pipe (OnPush-safe; self-unsubscribes). Latest-wins MVP: the
+   * trace is a flat list, so this shows the most recent rendering. The selector
+   * already does latest-wins, the FR2 fallback for pre-event teams, and the
+   * `dynamic_ref → name` labelling — the component consumes `row.name` /
+   * `row.content` directly and renders nothing for an empty array.
+   */
+  systemPrompt$!: Observable<SystemPromptRow[]>;
 
   /**
    * ADR-013: latest per-agent slash-command store (keyed by raw actor
@@ -71,6 +91,12 @@ export class AkgentChatComponent {
   commandsByAgent: Record<string, CommandDescriptor[]> = {};
 
   ngOnInit(): void {
+    // ADR-004 §5b step 2 — head system block for this panel's agent. Rendered
+    // in the template via `async`, above the conversation table.
+    this.systemPrompt$ = this.systemPromptSelector.latestSystemPrompt$(
+      this.agentId
+    );
+
     // Subscribe to context$ for the selected agent
     this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((ctx) => {
       if (this.isLoading) {
@@ -160,18 +186,14 @@ export class AkgentChatComponent {
       // Handle new parts-based protocol
       if (message.parts && Array.isArray(message.parts)) {
         message.parts.forEach((part: any) => {
-          if (
-            part.part_kind === 'system-prompt' ||
-            part.part_kind === 'user-prompt'
-          ) {
+          // ADR-004 §5b step 3 — the `system-prompt` arm is intentionally gone:
+          // the head system block is the SINGLE source (via systemPrompt$), so
+          // the run-1 double-carry renders once. Only `user-prompt` is handled
+          // here now; the system label/`dynamic_ref` logic moved to the selector.
+          if (part.part_kind === 'user-prompt') {
             msg.push({
-              type: part.part_kind === 'system-prompt' ? 'system' : 'human',
-              name:
-                part.part_kind === 'system-prompt'
-                  ? part.dynamic_ref
-                    ? part.dynamic_ref.split('.').pop()
-                    : 'System'
-                  : 'User',
+              type: 'human',
+              name: 'User',
               content: part.content,
               timestamp: part.timestamp,
             });

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -8,6 +8,7 @@ import { ContextService } from '../services/context.service';
 import { KGStateReducer } from '../services/kg-state.reducer';
 import { MessageLogService } from '../services/message-log.service';
 import { ActorMessageService } from '../services/message.service';
+import { SystemPromptSelector } from '../services/system-prompt.selector';
 import { ToolPresenceService } from '../services/tool-presence.service';
 
 import { AgentTabsComponent } from './agent-tabs/agent-tabs.component';
@@ -55,6 +56,7 @@ interface VisualizationOption {
     MessageLogService,
     ToolPresenceService,
     KGStateReducer,
+    SystemPromptSelector,
     ActorMessageService,
     GraphDataService,
     ChatService,

--- a/src/app/services/system-prompt.selector.spec.ts
+++ b/src/app/services/system-prompt.selector.spec.ts
@@ -1,0 +1,395 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AkgenticMessage } from '../models/message.types';
+import { MessageLogService } from './message-log.service';
+import {
+  latestSystemPromptFold,
+  SystemPromptRow,
+  SystemPromptSelector,
+  systemPromptLabel,
+} from './system-prompt.selector';
+
+// ---------------------------------------------------------------------
+// Fixtures
+//
+// These mirror the ADR-004 §5a wire JSON for `EventMessage(LlmSystemPromptEvent)`
+// and the existing `EventMessage(LlmMessageEvent)` envelope (the fallback path).
+// The backend emitter (akgentic-llm) need NOT be merged/released: the event
+// contract is frozen, so fixtures are a sufficient and authoritative source.
+// ---------------------------------------------------------------------
+
+interface PartSnapshot {
+  __model__?: string;
+  dynamic_ref: string | null;
+  content: string;
+}
+
+function sender(agentId: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name: '@' + agentId,
+    role: 'Agent',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+let envCounter = 0;
+
+/** EventMessage envelope carrying a LlmSystemPromptEvent (primary path). */
+function makeSystemPromptEnvelope(
+  agentId: string,
+  parts: PartSnapshot[],
+  content_hash = 'h-' + envCounter,
+): AkgenticMessage {
+  return {
+    id: 'sp-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmSystemPromptEvent',
+      run_id: 'run-' + content_hash,
+      content_hash,
+      // `parts` may be deliberately undefined (malformed-event fixture, AC6) —
+      // guard the eager map so the malformation reaches the fold, not the builder.
+      parts: parts?.map((p) => ({
+        __model__: 'akgentic.llm.event.SystemPromptPartSnapshot',
+        ...p,
+      })),
+    },
+  } as unknown as AkgenticMessage;
+}
+
+/**
+ * EventMessage envelope carrying a LlmMessageEvent whose inner ModelRequest
+ * `message.parts` include `part_kind === 'system-prompt'` parts (fallback path).
+ */
+function makeLlmMessageEnvelope(
+  agentId: string,
+  systemParts: Array<{ dynamic_ref: string | null; content: string }>,
+): AkgenticMessage {
+  return {
+    id: 'llm-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmMessageEvent',
+      message: {
+        parts: [
+          ...systemParts.map((p) => ({ part_kind: 'system-prompt', ...p })),
+          { part_kind: 'user-prompt', content: 'hi' },
+        ],
+      },
+    },
+  } as unknown as AkgenticMessage;
+}
+
+function makeUnknownEnvelope(id: string): AkgenticMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender('whoever'),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: { __model__: 'akgentic.llm.event.ToolStateEvent' },
+  } as unknown as AkgenticMessage;
+}
+
+// ---------------------------------------------------------------------
+// Tests — pure fold export
+// ---------------------------------------------------------------------
+
+describe('latestSystemPromptFold (pure function)', () => {
+  it('AC1 latest-wins: last LlmSystemPromptEvent for the agent yields its parts as rows', () => {
+    const log: AkgenticMessage[] = [
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+      ]),
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'roster v2' },
+        { dynamic_ref: null, content: 'backstory' },
+      ]),
+    ];
+    const rows = latestSystemPromptFold(log, 'A');
+    expect(rows).toEqual([
+      { type: 'system', name: 'roster', content: 'roster v2' },
+      { type: 'system', name: 'System', content: 'backstory' },
+    ]);
+  });
+
+  it('AC1 label: dynamic_ref takes its trailing segment, null → "System"', () => {
+    const rows = latestSystemPromptFold(
+      [
+        makeSystemPromptEnvelope('A', [
+          { dynamic_ref: 'current_date', content: 'today' },
+          { dynamic_ref: 'a.b.c', content: 'deep' },
+          { dynamic_ref: null, content: 'static' },
+        ]),
+      ],
+      'A',
+    );
+    expect(rows.map((r) => r.name)).toEqual(['current_date', 'c', 'System']);
+  });
+
+  it('AC2 per-agent isolation: A reflects only A, B only B', () => {
+    const log: AkgenticMessage[] = [
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'A-prompt' }]),
+      makeSystemPromptEnvelope('B', [{ dynamic_ref: null, content: 'B-prompt' }]),
+    ];
+    expect(latestSystemPromptFold(log, 'A')).toEqual([
+      { type: 'system', name: 'System', content: 'A-prompt' },
+    ]);
+    expect(latestSystemPromptFold(log, 'B')).toEqual([
+      { type: 'system', name: 'System', content: 'B-prompt' },
+    ]);
+  });
+
+  it('AC3 fallback: no LlmSystemPromptEvent → first LlmMessageEvent system parts', () => {
+    const log: AkgenticMessage[] = [
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'legacy roster' },
+      ]),
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'second message roster' },
+      ]),
+    ];
+    // First such message wins for the fallback.
+    expect(latestSystemPromptFold(log, 'A')).toEqual([
+      { type: 'system', name: 'roster', content: 'legacy roster' },
+    ]);
+  });
+
+  it('AC4 precedence: LlmSystemPromptEvent wins over LlmMessageEvent fallback', () => {
+    const log: AkgenticMessage[] = [
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'legacy roster' },
+      ]),
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'event roster' },
+      ]),
+    ];
+    expect(latestSystemPromptFold(log, 'A')).toEqual([
+      { type: 'system', name: 'roster', content: 'event roster' },
+    ]);
+  });
+
+  it('AC6 passthrough: malformed/empty latest event yields [] (latest-wins still applies)', () => {
+    // Missing parts entirely.
+    expect(
+      latestSystemPromptFold(
+        [makeSystemPromptEnvelope('A', undefined as unknown as PartSnapshot[])],
+        'A',
+      ),
+    ).toEqual([]);
+    // Empty parts array.
+    expect(
+      latestSystemPromptFold([makeSystemPromptEnvelope('A', [])], 'A'),
+    ).toEqual([]);
+    // A malformed LATEST event above an earlier well-formed one → [] (latest-wins).
+    const log: AkgenticMessage[] = [
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'good' }]),
+      makeSystemPromptEnvelope('A', []),
+    ];
+    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
+  });
+
+  it('AC6 passthrough: a part missing content maps to empty string, no throw', () => {
+    const rows = latestSystemPromptFold(
+      [
+        makeSystemPromptEnvelope('A', [
+          { dynamic_ref: 'current_date' } as unknown as PartSnapshot,
+        ]),
+      ],
+      'A',
+    );
+    expect(rows).toEqual([
+      { type: 'system', name: 'current_date', content: '' },
+    ]);
+  });
+
+  it('AC6 passthrough: a log of only unrelated __model__s yields []', () => {
+    const log: AkgenticMessage[] = [
+      makeUnknownEnvelope('u1'),
+      makeUnknownEnvelope('u2'),
+    ];
+    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
+  });
+
+  it('AC7 absent agent: empty log and no-match log both yield []', () => {
+    expect(latestSystemPromptFold([], 'A')).toEqual([]);
+    const log: AkgenticMessage[] = [
+      makeSystemPromptEnvelope('B', [{ dynamic_ref: null, content: 'B' }]),
+    ];
+    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
+  });
+
+  it('AC9 fresh reference + no input mutation: two folds give distinct arrays, log untouched', () => {
+    const log: AkgenticMessage[] = [
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'same' }]),
+    ];
+    const snapshot = JSON.stringify(log);
+    const r1 = latestSystemPromptFold(log, 'A');
+    const r2 = latestSystemPromptFold(log, 'A');
+    expect(r1).toEqual(r2);
+    expect(r1).not.toBe(r2);
+    expect(JSON.stringify(log)).toBe(snapshot); // input not mutated
+  });
+});
+
+describe('systemPromptLabel (pure helper)', () => {
+  it('returns trailing segment for dotted refs, the ref itself when undotted', () => {
+    expect(systemPromptLabel('team.roster')).toBe('roster');
+    expect(systemPromptLabel('current_date')).toBe('current_date');
+  });
+
+  it('returns "System" for null/undefined/empty', () => {
+    expect(systemPromptLabel(null)).toBe('System');
+    expect(systemPromptLabel(undefined)).toBe('System');
+    expect(systemPromptLabel('')).toBe('System');
+  });
+});
+
+// ---------------------------------------------------------------------
+// Tests — Observable-level (SystemPromptSelector over MessageLogService.log$)
+// ---------------------------------------------------------------------
+
+describe('SystemPromptSelector (log-driven selector)', () => {
+  let log: MessageLogService;
+  let selector: SystemPromptSelector;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MessageLogService, SystemPromptSelector],
+    });
+    log = TestBed.inject(MessageLogService);
+    selector = TestBed.inject(SystemPromptSelector);
+  });
+
+  it('AC8 late-subscriber: shareReplay(1) delivers the current block synchronously', () => {
+    log.appendAll([
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v1' }]),
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v2' }]),
+    ]);
+
+    let received: SystemPromptRow[] | undefined;
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => (received = r));
+    expect(received).toEqual([{ type: 'system', name: 'System', content: 'v2' }]);
+    sub.unsubscribe();
+  });
+
+  it('AC9 distinctUntilChanged: identical head block across a no-op log tick does not re-emit', () => {
+    const emissions: SystemPromptRow[][] = [];
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => emissions.push(r));
+
+    log.append(
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v1' }]),
+    );
+    // A log tick that does NOT change A's head block (an unrelated message).
+    log.append(makeUnknownEnvelope('u1'));
+
+    // Initial [] + the v1 block. The unrelated tick yields the same [] -> no.
+    // Actually: subscribe emits [] (empty log), then v1 block. The unknown
+    // envelope leaves the v1 block identical, so it must NOT re-emit.
+    expect(emissions.length).toBe(2);
+    expect(emissions[0]).toEqual([]);
+    expect(emissions[1]).toEqual([
+      { type: 'system', name: 'System', content: 'v1' },
+    ]);
+    sub.unsubscribe();
+  });
+
+  it('AC9 fresh reference on real change: distinct array objects across changes', () => {
+    const emissions: SystemPromptRow[][] = [];
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => emissions.push(r));
+
+    log.append(
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v1' }]),
+    );
+    log.append(
+      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v2' }]),
+    );
+
+    expect(emissions.length).toBe(3); // [], v1, v2
+    expect(emissions[1]).not.toBe(emissions[2]);
+    sub.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// Tests — REST/WS parity (AC5)
+// ---------------------------------------------------------------------
+
+describe('SystemPromptSelector parity — REST batch vs WS per-message (AC5)', () => {
+  function buildFixture(): AkgenticMessage[] {
+    return [
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'legacy' },
+      ]),
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+        { dynamic_ref: 'current_date', content: 'day 1' },
+      ]),
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'roster v2' },
+        { dynamic_ref: 'current_date', content: 'day 2' },
+      ]),
+    ];
+  }
+
+  function head(mode: 'rest' | 'ws'): SystemPromptRow[] {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [MessageLogService, SystemPromptSelector],
+    });
+    const log = TestBed.inject(MessageLogService);
+    const selector = TestBed.inject(SystemPromptSelector);
+
+    const emissions: SystemPromptRow[][] = [];
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => emissions.push(r));
+
+    // Distinct envelopes per run so REST dedupe-by-id and WS yield same set.
+    const fixture = buildFixture();
+    if (mode === 'rest') {
+      log.appendAll(fixture);
+    } else {
+      for (const msg of fixture) log.append(msg);
+    }
+
+    const result = emissions[emissions.length - 1];
+    sub.unsubscribe();
+    return result;
+  }
+
+  it('REST batch and WS sequence produce identical head blocks (AC5)', () => {
+    const rest = head('rest');
+    const ws = head('ws');
+    expect(JSON.stringify(rest)).toBe(JSON.stringify(ws));
+    // Latest-wins: roster v2 / day 2.
+    expect(rest).toEqual([
+      { type: 'system', name: 'roster', content: 'roster v2' },
+      { type: 'system', name: 'current_date', content: 'day 2' },
+    ]);
+  });
+});

--- a/src/app/services/system-prompt.selector.ts
+++ b/src/app/services/system-prompt.selector.ts
@@ -1,0 +1,164 @@
+import { inject, Injectable } from '@angular/core';
+import { distinctUntilChanged, map, Observable, shareReplay } from 'rxjs';
+
+import {
+  AkgenticMessage,
+  isEventMessage,
+  isLlmSystemPromptEvent,
+  SystemPromptPartSnapshot,
+} from '../models/message.types';
+import { MessageLogService } from './message-log.service';
+
+/**
+ * One rendered row of the trace head system block. Mirrors the shape the
+ * `AkgentChatComponent` already produces for `part_kind === 'system-prompt'`
+ * parts (`akgent-chat.component.ts` label/mapping) so Story 16-2 can render it
+ * with no shape change: `name` is the human label, `content` the rendered text.
+ */
+export interface SystemPromptRow {
+  type: 'system';
+  name: string;
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope pure helpers (ADR-005 §Decision 4; ADR-004 §5b).
+// The fold allocates a fresh result array per call; it never mutates `log`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Label for a system-prompt block — reuses the exact logic from
+ * `akgent-chat.component.ts`: the trailing segment of the pydantic-ai
+ * `dynamic_ref` (e.g. `team.roster` → `roster`), or `'System'` for static parts
+ * (`dynamic_ref` null/empty). Defensive: never throws on null/undefined.
+ */
+export function systemPromptLabel(
+  dynamic_ref: string | null | undefined,
+): string {
+  return dynamic_ref ? (dynamic_ref.split('.').pop() ?? 'System') : 'System';
+}
+
+/**
+ * Map a list of rendered parts (either `SystemPromptPartSnapshot` from a
+ * `LlmSystemPromptEvent`, or pydantic-ai `SystemPromptPart`s from a
+ * `LlmMessageEvent` fallback — both expose `dynamic_ref` + `content`) to render
+ * rows. Defensive reads only: a missing/empty `parts` yields `[]`, a part with
+ * no `content` contributes an empty string rather than throwing. Always returns
+ * a freshly-allocated array (OnPush safety, AC9).
+ */
+function mapPartsToRows(
+  parts: ReadonlyArray<{ dynamic_ref?: string | null; content?: string }>
+    | null
+    | undefined,
+): SystemPromptRow[] {
+  return (parts ?? []).map((p) => ({
+    type: 'system' as const,
+    name: systemPromptLabel(p?.dynamic_ref),
+    content: p?.content ?? '',
+  }));
+}
+
+/**
+ * Primary path (FR1, latest-wins): the `parts` of the LAST
+ * `EventMessage(LlmSystemPromptEvent)` for `agentId`, in log order. Returns
+ * `undefined` when the agent has no such event (so the caller can fall back).
+ * The log is append-only and ordered — latest-wins is "last by position", not
+ * a sort on `run_id`.
+ */
+function latestSystemPromptParts(
+  log: AkgenticMessage[],
+  agentId: string,
+): SystemPromptPartSnapshot[] | undefined {
+  let latest: SystemPromptPartSnapshot[] | undefined;
+  for (const msg of log) {
+    if (!isEventMessage(msg)) continue;
+    const inner = (msg as { event?: unknown }).event as
+      | { __model__?: string; parts?: SystemPromptPartSnapshot[] }
+      | undefined;
+    if (!isLlmSystemPromptEvent(inner)) continue;
+    if (msg.sender?.agent_id !== agentId) continue;
+    latest = inner.parts;
+  }
+  return latest;
+}
+
+/**
+ * Fallback path (FR2): the `system-prompt` parts of the FIRST
+ * `EventMessage(LlmMessageEvent)` for `agentId` (pre-event teams whose logs
+ * predate `LlmSystemPromptEvent`). Mirrors the `contextDict$` seeding read in
+ * `message.service.ts` (inner is the `ModelRequest`, whose `.parts` carry
+ * `part_kind`). Returns `undefined` when no such message exists for the agent.
+ */
+function fallbackSystemPromptParts(
+  log: AkgenticMessage[],
+  agentId: string,
+): Array<{ dynamic_ref?: string | null; content?: string }> | undefined {
+  for (const msg of log) {
+    if (!isEventMessage(msg)) continue;
+    const inner = (msg as { event?: unknown }).event as
+      | { __model__?: string; message?: { parts?: unknown[] } }
+      | undefined;
+    if (!inner?.__model__?.includes('LlmMessageEvent')) continue;
+    if (msg.sender?.agent_id !== agentId) continue;
+    const parts = (inner.message?.parts ?? []) as Array<{
+      part_kind?: string;
+      dynamic_ref?: string | null;
+      content?: string;
+    }>;
+    const systemParts = parts.filter((p) => p?.part_kind === 'system-prompt');
+    if (systemParts.length > 0) return systemParts;
+  }
+  return undefined;
+}
+
+/**
+ * Pure fold over the message log producing the current head system block for
+ * one agent (ADR-004 §5b step 1). Primary source: the LAST
+ * `LlmSystemPromptEvent` for the agent (latest-wins, FR1). Fallback (FR2, only
+ * when the agent has ZERO `LlmSystemPromptEvent`s): the system-prompt parts of
+ * the FIRST `LlmMessageEvent` for the agent. Unknown/unrelated `__model__`s
+ * pass through silently; never throws; allocates a fresh array per call.
+ *
+ * Exported so tests can import it directly (no TestBed required).
+ */
+export function latestSystemPromptFold(
+  log: AkgenticMessage[],
+  agentId: string,
+): SystemPromptRow[] {
+  const primary = latestSystemPromptParts(log, agentId);
+  if (primary !== undefined) return mapPartsToRows(primary);
+  return mapPartsToRows(fallbackSystemPromptParts(log, agentId));
+}
+
+/** Structural comparator so identical head blocks across no-op `log$` ticks do
+ *  not re-emit (OnPush), while a real change emits a fresh reference (AC9). */
+function rowsEqual(a: SystemPromptRow[], b: SystemPromptRow[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * SystemPromptSelector — Story 16-1 (ADR-004 §5b step 1).
+ *
+ * Exposes `latestSystemPrompt$(agentId)` as a pure selector over
+ * `MessageLogService.log$`, mirroring `KGStateReducer.knowledgeGraph$`. NO new
+ * imperative per-agent dict / `BehaviorSubject` — the head block is derived by
+ * folding the unified log, preserving frontend ADR-005's two-exception
+ * invariant (NFR1). `shareReplay(1)` gives late subscribers the current block
+ * synchronously (AC8); the structural `distinctUntilChanged` suppresses no-op
+ * re-emissions while still emitting a fresh array on real change (AC9).
+ *
+ * Scope: component-scoped (NOT `providedIn: 'root'`) — it injects the
+ * component-scoped `MessageLogService` from `ProcessComponent.providers`.
+ */
+@Injectable()
+export class SystemPromptSelector {
+  private readonly log: MessageLogService = inject(MessageLogService);
+
+  latestSystemPrompt$(agentId: string): Observable<SystemPromptRow[]> {
+    return this.log.log$.pipe(
+      map((log) => latestSystemPromptFold(log, agentId)),
+      distinctUntilChanged(rowsEqual),
+      shareReplay(1),
+    );
+  }
+}


### PR DESCRIPTION
## Epic 16 — System Prompt Trace: Head Rendering from LlmSystemPromptEvent

Umbrella PR for Epic 16. Renders the agent trace's system block from the authoritative `LlmSystemPromptEvent` (akgentic-llm ADR-004), with replay/live parity and a fallback for pre-event teams. Branch: `feat/139-epic-16-system-prompt-trace-head-rendering`.

### Stories

- [x] **16-1-latest-system-prompt-selector-over-log** — `latestSystemPrompt$` selector over `log$` (pure, dark) (Relates to #139)
- [x] **16-2-render-head-system-block-remove-inline-system-rendering** — render the head system block + remove inline `part_kind === 'system-prompt'` rendering (Relates to #141)

### Story 16-1 — what landed

A pure, dark selector — no user-visible change, no new imperative per-agent dict:

- `message.types.ts`: `SystemPromptPartSnapshot` + `LlmSystemPromptEvent` wire types and the `isLlmSystemPromptEvent` inner-event guard (ADR-004 frozen shape).
- `system-prompt.selector.ts`: module-scope `latestSystemPromptFold` — latest-wins primary path over `LlmSystemPromptEvent`, first-`LlmMessageEvent` `system-prompt` fallback (mutually exclusive with the primary path) — plus a component-scoped `SystemPromptSelector` exposing `latestSystemPrompt$` over `log$` (`shareReplay(1)`, structural `distinctUntilChanged`), mirroring `KGStateReducer`.
- `process.component.ts`: `SystemPromptSelector` registered component-scoped.
- `system-prompt.selector.spec.ts`: fixture-based unit tests for latest-wins (AC1), per-agent isolation (AC2), fallback + precedence (AC3/AC4), REST/WS parity (AC5), malformed/empty passthrough (AC6), absent agent (AC7), late-subscriber replay (AC8), fresh-reference-per-emission + no input mutation (AC9).

### Story 16-2 — what landed

The user-visible fix — consume the dark 16-1 selector and render the system block once, at the head:

- `akgent-chat.component.ts`: inject the component-scoped `SystemPromptSelector`, expose `systemPrompt$ = latestSystemPrompt$(this.agentId)` in `ngOnInit`. Remove the `part_kind === 'system-prompt'` arm (and its `dynamic_ref.split('.').pop()` label) from `updateContext()` — only `user-prompt` now produces a row; `tool-call` / `tool-return` / `retry-prompt` / `text` / `response` / legacy branches untouched. Single source of `system` rows → the run-1 double-carry renders once.
- `akgent-chat.component.html`: render the head system fieldset ABOVE the conversation `p-table`, independently of `context.length`, `async`-bound (OnPush-safe), guarded by `*ngIf ... as rows` + `rows.length` so an empty array renders nothing (AC8). Reuses the existing system-block markup so it is visually identical.
- `akgent-chat.component.spec.ts`: head-block suite over the real `MessageLogService` + `SystemPromptSelector` (log → selector → head render): latest-wins head (AC1), single-source + untouched arms (AC2), no-duplicate double-carry (AC3), old-team fallback (AC5), REST/WS parity (AC7), empty/no-head (AC8). Fixtures mirror the frozen ADR-004 §5a wire shape.

## Review status

**Story 16-1: APPROVED (done).** Reviewer: Rex.

- All 9 behavioral ACs verified against the implementation. The selector is **pure over `log$`** — no new `BehaviorSubject`/per-agent dict, so the ADR-005 two/three-exception invariant enforced by `message.service.spec.ts` is preserved (the selector lives on a separate `SystemPromptSelector` service; `message.service.{ts,spec.ts}` are untouched).
- Latest-wins + fallback correctness confirmed: primary keeps the LAST `LlmSystemPromptEvent` by log order (not a `run_id` sort); fallback fires only when the agent has zero such events, taking the FIRST `LlmMessageEvent`'s `system-prompt` parts.
- Snapshot→row mapping reuses the exact `akgent-chat.component.ts` label logic (`dynamic_ref.split('.').pop() ?? 'System'`) and reads `content` defensively.
- REST (`appendAll`) vs WS (per-message `append`) parity asserted; malformed/empty/unrelated payloads pass through to `[]` without throwing.
- No ADR-string assertions in tests (Golden Rule 8 clean). No fixup commit required.

- 16-2 review: **PASS.** Reviewer: Rex. All 10 ACs verified against the diff. The `part_kind === 'system-prompt'` arm is fully removed from `updateContext()` (single source); `user-prompt` / `tool-call` / `tool-return` / `retry-prompt` / `text` rendering untouched. Head fieldset renders from the 16-1 `latestSystemPrompt$` selector, above the conversation table, `async`-bound (OnPush-safe), empty-guarded (AC8). Old/no-event teams still show the system block via the FR2 fallback (no regression) — confirmed the selector (16-1) is unchanged and not re-provided. Scope clean: only `akgent-chat.{ts,html,spec.ts}` touched, all inside `packages/akgentic-frontend/`. No ADR-string assertions (Golden Rule 8 clean). No fixup commit required.

## Epic 16 slice complete

Both stories landed:

- **16-1** — the pure, dark `latestSystemPrompt$` selector folds the unified `log$` (latest-wins primary over `LlmSystemPromptEvent`, FR2 fallback over the first `LlmMessageEvent`'s `system-prompt` parts), component-scoped on `ProcessComponent.providers`.
- **16-2** — `AkgentChatComponent` consumes that selector and renders the head system block once, with the inline `system-prompt` rendering removed so there is a single source.

The user-visible fix ships now with **no regression** via the FR2 fallback (pre-event teams render their system block from existing `LlmMessageEvent` data, exactly as today, just relocated to the head and de-duplicated). The **full latest-wins behaviour** (roster/date changes visible across runs instead of the stale run-1 prompt) **activates once akgentic-llm Epic 6 / `LlmSystemPromptEvent` is merged and released** and the connected backend runs that version. Per-run segmentation is explicitly deferred (latest-wins MVP); the event already carries `run_id` + `dynamic_ref`, so no schema change is needed later.

## Scope guard

All changes are inside `packages/akgentic-frontend/` — no edits to any other submodule.

- 16-1 (4 files): `message.types.ts`, `system-prompt.selector.ts` (new), `system-prompt.selector.spec.ts` (new), `process.component.ts`.
- 16-2 (3 files): `akgent-chat.component.ts`, `akgent-chat.component.html`, `akgent-chat.component.spec.ts`. The 16-1 selector / `message.types.ts` / `process.component.ts` were NOT re-touched.

## Prerequisite

Full end-to-end behaviour depends on **akgentic-llm Epic 6** (the backend emitting `LlmSystemPromptEvent` across runs) being merged and released. This epic does **not** require it: the selector and head render are fixture-tested against the frozen ADR-004 §5b contract. The FR2 fallback (first `LlmMessageEvent` `system-prompt` parts) means there is **no regression** when this ships ahead of the backend — pre-event teams render their system block from the existing `LlmMessageEvent` data exactly as today.

## Quality gate (no GitHub Actions CI on this submodule — local gate authoritative)

- Karma headless: **TOTAL: 804 SUCCESS** (full suite, includes the 16-2 head-block tests).
- `npm run build`: **Application bundle generation complete** (only the pre-existing `lodash`-not-ESM optimization warning; zero errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
