### PR TITLE
fix(akgentic-frontend): 16-3 single trace-scroll region keeps chat input reachable

### DIFF
--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -1,40 +1,44 @@
 <!--
-  ADR-004 §5b step 2 — head system block. Rendered ABOVE the conversation table
-  and independently of `context.length`, sourced ONCE from `systemPrompt$`
-  (SystemPromptSelector, Story 16-1). Latest-wins: shows the most recent
-  rendering across runs. `*ngIf ... as rows` + `rows.length` guard renders
-  nothing when there are no system rows (AC8). Reuses the existing system-block
-  fieldset markup so it is visually identical to how system blocks rendered
-  before. `async` keeps it OnPush-safe and self-unsubscribing.
+  Single scroll region for the whole trace. The head system block (Epic 16)
+  scrolls TOGETHER with the conversation, exactly as it did before Epic 16 when
+  the system block was the first row inside the scrollable table — only now it
+  stays pinned at the head. `.trace-scroll` owns the scroll so neither the head
+  block nor a long conversation can overflow the clipped tab container and push
+  the chat input out of reach.
 -->
-<div
-  class="head-system-container"
-  *ngIf="systemPrompt$ | async as rows"
->
-  <ng-container *ngIf="rows.length">
-    <div class="card-container" *ngFor="let row of rows">
-      <div class="card-header">{{ row.type | capitalize }} : {{ row.name }}</div>
-      <div class="fieldset-body">
-        <p-fieldset legend="Content" [toggleable]="false">
-          <app-copy-button (click)="utilService.copyToClipboard(row.content)" />
-          <div class="text-container" [innerHTML]="row.content"></div>
-        </p-fieldset>
+<div class="trace-scroll" #traceScroll>
+  <!--
+    Head system block — sourced ONCE from `systemPrompt$` (SystemPromptSelector,
+    Story 16-1), independently of `context.length`. Latest-wins. `*ngIf ... as
+    rows` + `rows.length` guard renders nothing when there are no system rows
+    (AC8). `async` keeps it OnPush-safe and self-unsubscribing.
+  -->
+  <div
+    class="head-system-container"
+    *ngIf="systemPrompt$ | async as rows"
+  >
+    <ng-container *ngIf="rows.length">
+      <div class="card-container" *ngFor="let row of rows">
+        <div class="card-header">{{ row.type | capitalize }} : {{ row.name }}</div>
+        <div class="fieldset-body">
+          <p-fieldset legend="Content" [toggleable]="false">
+            <app-copy-button (click)="utilService.copyToClipboard(row.content)" />
+            <div class="text-container" [innerHTML]="row.content"></div>
+          </p-fieldset>
+        </div>
       </div>
-    </div>
-  </ng-container>
-</div>
+    </ng-container>
+  </div>
 
-<!-- Collapsible Arrow and Button -->
-<div class="collapsible-container" *ngIf="context.length">
-  <div class="collapsible">
-    <p-table
-      #dataTable
-      [value]="context"
-      [scrollable]="true"
-      scrollHeight="calc(100vh - 370px)"
-      (mouseenter)="isMouseOverTable = true"
-      (mouseleave)="isMouseOverTable = false"
-    >
+  <!-- Conversation. Not independently scrollable: `.trace-scroll` is the single
+       scroll region (hover-pauses auto-scroll via the table's mouse events). -->
+  <div class="collapsible-container" *ngIf="context.length">
+    <div class="collapsible">
+      <p-table
+        [value]="context"
+        (mouseenter)="isMouseOverTable = true"
+        (mouseleave)="isMouseOverTable = false"
+      >
       <ng-template #body let-message>
         <div class="card-container">
           <div class="card-header">
@@ -91,6 +95,7 @@
         </div>
       </ng-template>
     </p-table>
+  </div>
   </div>
 </div>
 

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.scss
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.scss
@@ -38,6 +38,18 @@
     }
 }
 
+// Single scroll region for the whole trace: the Epic 16 head system block and
+// the conversation scroll together, keeping the chat input pinned below and
+// always reachable. Viewport-relative (not flex:1) because the PrimeNG tab
+// chain above this component does not propagate a usable height. The 370px
+// reserves the tab header, the input row, and surrounding chrome — the same
+// budget the conversation table used before this single region replaced its
+// per-table `scrollHeight`.
+.trace-scroll {
+  height: calc(100vh - 370px);
+  overflow-y: auto;
+}
+
 .card-container {
   margin: 1rem 0;
 }

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -1,4 +1,11 @@
-import { Component, inject, Input, ViewChild, DestroyRef } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  inject,
+  Input,
+  ViewChild,
+  DestroyRef,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -8,7 +15,7 @@ import { CardModule } from 'primeng/card';
 import { FieldsetModule } from 'primeng/fieldset';
 import { FloatLabelModule } from 'primeng/floatlabel';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
-import { Table, TableModule } from 'primeng/table';
+import { TableModule } from 'primeng/table';
 import { TextareaModule } from 'primeng/textarea';
 import { MentionModule } from 'angular-mentions';
 
@@ -51,7 +58,9 @@ import { CopyButtonComponent } from '../../copy-button/copy-button.component';
   styleUrl: './akgent-chat.component.scss',
 })
 export class AkgentChatComponent {
-  @ViewChild('dataTable') dataTable!: Table;
+  // The single trace scroll region (head system block + conversation). Auto
+  // scroll-to-bottom targets this element so new messages stay in view.
+  @ViewChild('traceScroll') traceScroll?: ElementRef<HTMLElement>;
   @Input() context$!: BehaviorSubject<any[]>;
   @Input() agentId!: string;
   @Input() agentName!: string;
@@ -350,16 +359,10 @@ export class AkgentChatComponent {
 
   initialLoad = true;
   isMouseOverTable: boolean = false; // Track mouse hover state
-  scroll(behavior: string = 'smooth') {
-    if (!this.isMouseOverTable && this.dataTable && !this.initialLoad) {
-      const body =
-        this.dataTable.containerViewChild?.nativeElement.getElementsByClassName(
-          'p-datatable-table-container'
-        )[0];
-      body.scrollTo({
-        top: body.scrollHeight,
-        behavior: behavior,
-      });
+  scroll(behavior: ScrollBehavior = 'smooth') {
+    const el = this.traceScroll?.nativeElement;
+    if (el && !this.isMouseOverTable && !this.initialLoad) {
+      el.scrollTo({ top: el.scrollHeight, behavior });
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the Epic 16 regression on the per-agent LLM trace ("Chat with @Agent" Member tab).

Story 16-2 moved the system-prompt block out of the scrollable conversation table into a head block rendered above it, with no scroll containment. Both the head block and the conversation live inside `.visualization-container`, which is `overflow: hidden` with a fixed height. When a real (long, ~470px) system prompt renders, the combined height overflows and is clipped with no scrollbar, pushing the bottom of the conversation and the chat input out of reach. The bug is intermittent because an empty system prompt produces an empty head block.

## Fix

Wrap the head system block and the conversation in a single `.trace-scroll` region that owns the vertical scroll, restoring the pre-16-2 "scroll together" model:

- **`akgent-chat.component.html`** — one `<div class="trace-scroll" #traceScroll>` wraps `.head-system-container` + `.collapsible-container`; the per-table `[scrollable]`/`scrollHeight` and the `#dataTable` ref are removed; the `.input-container` stays a sibling outside the region (pinned, reachable).
- **`akgent-chat.component.scss`** — `.trace-scroll { height: calc(100vh - 370px); overflow-y: auto; }` (the same budget the table used before the head split it).
- **`akgent-chat.component.ts`** — `scroll()` retargets the `@ViewChild('traceScroll')` ElementRef (`el.scrollTo({ top: el.scrollHeight })`); the now-unused PrimeNG `Table` ViewChild and import are removed; hover-pause (`isMouseOverTable`) and `initialLoad` guards preserved.

The Epic 16 head-block feature (`systemPrompt$` / `SystemPromptSelector` wiring, empty-array guard, markup) is fully preserved — this is a layout-only change. `process.component.scss` `.visualization-container` is intentionally untouched (the fix works within it).

## Files changed

3 files, all under `src/app/process/agent-tabs/akgent-chat/`.

## Review

Adversarial code review (Rex): all 10 ACs verified PASS. The `scroll()` rewrite is a net improvement (proper ElementRef null-check, `ScrollBehavior`-typed param). No dead `Table` references remain (grep-confirmed). All changes confined to `akgentic-frontend`. No fixup commit required.

Local quality gate: full headless Karma suite **804/804 SUCCESS**.

Relates to #142
Closes #142
