### PR TITLE
feat(akgentic-frontend): 15-3 command dropdown polish — filter, readability, ordering

### DIFF
--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -85,6 +85,21 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
     ]);
   });
 
+  it('hides internal `_`-prefixed commands from the / list', () => {
+    const INTERNAL: CommandDescriptor = {
+      name: '_expand_media_refs',
+      description: 'Expand glob tokens into binary image content',
+      args: [{ name: 'prompt', type: 'string', required: true }],
+      tool_card: 'MediaTool',
+    };
+    commandsByAgentSubject.next({ '@Manager': [INTERNAL, HIRE, ROSTER] });
+    // `_expand_media_refs` is internal — only user commands remain.
+    expect(component.commandItems.map((c) => c.name)).toEqual([
+      'hire_member',
+      'roster',
+    ]);
+  });
+
   it('AC-6: empty / list until a CommandsAnnouncedEvent arrives for this agent', () => {
     expect(component.commandItems).toEqual([]);
     commandsByAgentSubject.next({ '@Other': [HIRE] });
@@ -103,6 +118,47 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
   it('commandArgsHint renders required in <> and optional in []', () => {
     expect(component.commandArgsHint(HIRE.args)).toBe('<role> [name]');
     expect(component.commandArgsHint(ROSTER.args)).toBe('');
+  });
+
+  // Story 15-3 (AC-4) — tool-family ordering: the member chat's commandItems
+  // order by `tool_card` then `name` (families contiguous, alphabetical
+  // within), and the single `/` mentionConfig entry sets `disableSort: true`
+  // so angular-mentions' label sort does not clobber that order.
+  it('AC-4: orders commandItems by tool_card then name (tool families contiguous)', () => {
+    const PLAN_BREAKDOWN: CommandDescriptor = {
+      name: 'breakdown',
+      description: 'Break a goal into tasks',
+      args: [],
+      tool_card: 'PlanningTool',
+    };
+    const PLAN_AUDIT: CommandDescriptor = {
+      name: 'audit',
+      description: 'Audit the current plan',
+      args: [],
+      tool_card: 'PlanningTool',
+    };
+    // Stored order: TeamTool first, PlanningTool names reversed — neither
+    // tool-grouped nor globally alphabetical, so a naive sort can't fake it.
+    commandsByAgentSubject.next({
+      '@Manager': [ROSTER, PLAN_BREAKDOWN, HIRE, PLAN_AUDIT],
+    });
+
+    // PlanningTool family (audit, breakdown) before TeamTool family
+    // (hire_member, roster); alphabetical within each family.
+    expect(component.commandItems.map((c) => c.name)).toEqual([
+      'audit',
+      'breakdown',
+      'hire_member',
+      'roster',
+    ]);
+  });
+
+  it('AC-4: the `/` mentionConfig entry sets disableSort === true', () => {
+    const slash = component.mentionConfig.mentions.find(
+      (m) => m.triggerChar === '/',
+    );
+    expect(slash).toBeTruthy();
+    expect((slash as any).disableSort).toBeTrue();
   });
 });
 

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -135,11 +135,23 @@ export class AkgentChatComponent {
     args: CommandDescriptor['args'];
   }[] {
     const descriptors = this.commandsByAgent[this.agentName] ?? [];
-    return descriptors.map((d) => ({
-      name: d.name,
-      description: d.description,
-      args: d.args,
-    }));
+    return descriptors
+      // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
+      // user-invocable — keep them out of the `/` dropdown.
+      .filter((d) => !d.name.startsWith('_'))
+      // `angular-mentions` renders a single flat list with no group headers, so
+      // the best we can do is keep tool families adjacent: order by provenance
+      // (`tool_card`) then command name. `.filter()` above returns a fresh
+      // array, so sorting in place does not mutate the stored descriptors.
+      .sort(
+        (a, b) =>
+          a.tool_card.localeCompare(b.tool_card) || a.name.localeCompare(b.name),
+      )
+      .map((d) => ({
+        name: d.name,
+        description: d.description,
+        args: d.args,
+      }));
   }
 
   /**
@@ -158,6 +170,11 @@ export class AkgentChatComponent {
           mentionSelect: this.selectCommand,
           dropUp: true,
           maxItems: 10,
+          // `angular-mentions` re-sorts every list by `labelKey` (here `name`)
+          // unless told not to — that would clobber the tool-family ordering
+          // `commandItems` builds. Opt out so our `tool_card`-then-name order
+          // survives to the dropdown.
+          disableSort: true,
           items: this.commandItems,
         },
       ],

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -757,6 +757,24 @@ describe('ProcessUserInputComponent', () => {
       ]);
     });
 
+    it('hides internal `_`-prefixed commands from the / list', () => {
+      const INTERNAL = mkDescriptor('_expand_media_refs', {
+        description: 'Expand glob tokens into binary image content',
+        args: [{ name: 'prompt', type: 'string', required: true }],
+      });
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+      ]);
+      commandsByAgentSubject.next({ '@Manager': [INTERNAL, HIRE, ROSTER] });
+      component.selectedAgents = ['@Manager'];
+
+      // `_expand_media_refs` is internal — only user commands remain.
+      expect(component.commandItems.map((c) => c.name)).toEqual([
+        'hire_member',
+        'roster',
+      ]);
+    });
+
     it('AC-3: with zero recipients, defaults to the supervisor (child of @Human entry point)', () => {
       nodesSubject.next([
         makeNode({ name: 'human-1', actorName: '@Human', role: 'Human' }),
@@ -841,6 +859,48 @@ describe('ProcessUserInputComponent', () => {
       expect(component.selectAgent({ name: 'Manager [Manager]' })).toBe(
         'Manager [Manager] ',
       );
+    });
+
+    // Story 15-3 (AC-4) — tool-family ordering: commands order by `tool_card`
+    // then `name`, so each tool family is contiguous and alphabetical within
+    // it, and the `/` mentionConfig entry opts out of angular-mentions' own
+    // label sort (`disableSort: true`) so the selector's order survives.
+    it('AC-4: orders commandItems by tool_card then name (tool families contiguous)', () => {
+      // Deliberately interleave two tool families AND list them out of order so
+      // a naive global-name sort would NOT reproduce the grouped result.
+      const PLAN_BREAKDOWN = mkDescriptor('breakdown', {
+        tool_card: 'PlanningTool',
+      });
+      const PLAN_AUDIT = mkDescriptor('audit', { tool_card: 'PlanningTool' });
+      const TEAM_HIRE = mkDescriptor('hire_member', { tool_card: 'TeamTool' });
+      const TEAM_ROSTER = mkDescriptor('roster', { tool_card: 'TeamTool' });
+
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+      ]);
+      // Stored order: TeamTool first, PlanningTool names reversed — neither
+      // tool-grouped nor globally alphabetical.
+      commandsByAgentSubject.next({
+        '@Manager': [TEAM_ROSTER, PLAN_BREAKDOWN, TEAM_HIRE, PLAN_AUDIT],
+      });
+      component.selectedAgents = ['@Manager'];
+
+      // PlanningTool family (audit, breakdown) before TeamTool family
+      // (hire_member, roster); alphabetical within each family.
+      expect(component.commandItems.map((c) => c.name)).toEqual([
+        'audit',
+        'breakdown',
+        'hire_member',
+        'roster',
+      ]);
+    });
+
+    it('AC-4: the `/` mentionConfig entry sets disableSort === true', () => {
+      const slash = component.mentionConfig.mentions.find(
+        (m) => m.triggerChar === '/',
+      );
+      expect(slash).toBeTruthy();
+      expect((slash as any).disableSort).toBeTrue();
     });
   });
 });

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -244,11 +244,23 @@ export class ProcessUserInputComponent implements OnInit {
     const target = this.resolveTargetedAgent();
     if (!target) return [];
     const descriptors = this.commandsByAgent[target] ?? [];
-    return descriptors.map((d) => ({
-      name: d.name,
-      description: d.description,
-      args: d.args,
-    }));
+    return descriptors
+      // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
+      // user-invocable — keep them out of the `/` dropdown.
+      .filter((d) => !d.name.startsWith('_'))
+      // `angular-mentions` renders a single flat list with no group headers, so
+      // the best we can do is keep tool families adjacent: order by provenance
+      // (`tool_card`) then command name. `.filter()` above returns a fresh
+      // array, so sorting in place does not mutate the stored descriptors.
+      .sort(
+        (a, b) =>
+          a.tool_card.localeCompare(b.tool_card) || a.name.localeCompare(b.name),
+      )
+      .map((d) => ({
+        name: d.name,
+        description: d.description,
+        args: d.args,
+      }));
   }
 
   /**
@@ -278,6 +290,11 @@ export class ProcessUserInputComponent implements OnInit {
           mentionSelect: this.selectCommand,
           dropUp: true,
           maxItems: 10,
+          // `angular-mentions` re-sorts every list by `labelKey` (here `name`)
+          // unless told not to — that would clobber the tool-family ordering
+          // `commandItems` builds. Opt out so our `tool_card`-then-name order
+          // survives to the dropdown.
+          disableSort: true,
           items: this.commandItems,
         },
       ],

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -154,9 +154,32 @@ chat-wrapper {
 }
 
 .mention-item-desc {
-  display: block;
+  // Keep the whole row on a single line. `angular-mentions` ships its rows as
+  // `.mention-item { white-space: nowrap }` and its arrow-key scroll math
+  // (`offsetTop + rect.height - clientHeight`) assumes uniform single-line
+  // rows — a block-level (two-line) description breaks that geometry and makes
+  // the dropdown jump on navigation. Stay inline and ellipsize instead of
+  // wrapping so a long description can't widen the nowrap dropdown unbounded.
+  display: inline-block;
+  vertical-align: bottom;
+  max-width: 22rem;
+  margin-left: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 0.8rem;
   color: #64748b;
+}
+
+// On the selected (active) row, `angular-mentions` paints the row's `<a>` white
+// on a blue background (`.mention-active>a { color:#fff }`). Our explicit grey
+// on the args hint and description overrides that inherited white and becomes
+// unreadable on the blue fill — restore a readable light tone for the secondary
+// text on the active row only (the bold name already inherits white).
+.mention-active > a {
+  .mention-item-args,
+  .mention-item-desc {
+    color: #e2e8f0;
+  }
 }
 
 // markdown styles


### PR DESCRIPTION
## Summary

Epic 15 / Story 15-3 — polish for the `/` slash-command mention dropdown (follow-up to the Story 15-1 `/` mention). All changes are frontend-only and additive: no change to the data layer (`commandsByAgent$`), the send path, or the `@` mention.

Four usability fixes, mirrored across the two chat surfaces (main chat `ProcessUserInputComponent` and member chat `AkgentChatComponent`) plus the shared global `.mention-item-*` styles:

- **AC-1 — Internal-command filter.** Both `commandItems` selectors now drop `_`-prefixed descriptors (e.g. `_expand_media_refs`), which are internal and not user-invocable.
- **AC-2 — Active-row readability.** Added a scoped `.mention-active > a { .mention-item-args, .mention-item-desc { color: #e2e8f0 } }` rule in `styles.scss` so the args hint and description stay readable on the blue active fill (angular-mentions paints the active `<a>` white); the bold command name still inherits white.
- **AC-3 — Single-line rows / scroll fix.** `.mention-item-desc` switches from `display: block` to `inline-block` with a bounded `max-width`, `overflow: hidden`, and `text-overflow: ellipsis`, restoring the single-line-row geometry angular-mentions' arrow-key scroll math assumes (no node_modules patch).
- **AC-4 — Tool-family ordering.** `commandItems` is sorted by `tool_card` then `name` (on the fresh post-filter array), and `disableSort: true` is set on the `/` `mentionConfig` entry so angular-mentions' built-in `labelKey` sort does not clobber the grouped order.

AC-5 (the `@` mention, Send-to/Send-as behavior, and the verbatim send path) is unchanged.

## Tests

Added the AC-4 tool-family-ordering / `disableSort` regression specs to both `user-input.component.spec.ts` and `akgent-chat.component.spec.ts` (plus the `_`-filter specs). Full Karma suite green: **810/810 SUCCESS** (`ChromeHeadlessNoSandbox`, `--karma-config=karma.conf.js`, `--watch=false`).

No GitHub Actions CI is configured for this submodule — the local Karma run is the gate, and it is green.

## Scope

All changes are contained within `packages/akgentic-frontend/`.

Relates to #144
