### PR TITLE
feat(akgentic-frontend): epic 17 — Generic Per-Agent Store (17-1-per-agent-store-foundation → 17-4-system-prompt-instance-facade-and-retire-exceptions-invariant)

### DIFF
--- a/src/app/chat/chat-panel.component.spec.ts
+++ b/src/app/chat/chat-panel.component.spec.ts
@@ -114,10 +114,14 @@ describe('ChatPanelComponent', () => {
       nodes$: of([]),
     };
 
-    // Story 15-1 (ADR-013): the embedded <app-user-input> now injects
-    // ActorMessageService for its `commandsByAgent$` (the `/` mention store).
+    // Story 15-1 (ADR-013) / Epic 17 (ADR-014): the embedded <app-user-input>
+    // injects ActorMessageService for its `commands` PerAgentStore (the `/`
+    // mention store). Story 17-3 removed the bespoke `commandsByAgent$`; this
+    // stub mirrors the current surface — a `commands`-shaped object exposing
+    // `snapshot(id)` (returns `[]` here: the empty-selection scenarios in this
+    // spec short-circuit before any command lookup).
     const messageService = {
-      commandsByAgent$: new BehaviorSubject<Record<string, any[]>>({}),
+      commands: { snapshot: (_id: string) => [] as any[] },
     };
 
     await TestBed.configureTestingModule({

--- a/src/app/process/agent-tabs/agent-tabs.component.spec.ts
+++ b/src/app/process/agent-tabs/agent-tabs.component.spec.ts
@@ -1,0 +1,190 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { WebSocketSubject } from 'rxjs/webSocket';
+
+import { AgentTabsComponent } from './agent-tabs.component';
+import { Akgent, AkgentService } from '../../services/akgent.service';
+import { GraphDataService } from '../../services/graph-data.service';
+import { ActorMessageService } from '../../services/message.service';
+import { MessageLogService } from '../../services/message-log.service';
+import { PerAgentStoreRegistry } from '../../services/per-agent-store';
+import { ChatService } from '../../services/chat.service';
+import { ApiService } from '../../services/api.service';
+
+/**
+ * Story 17-2 (ADR-014) — the agent-state panel and agent-chat context view are
+ * now sourced from `messageService.state.forAgent(id)` /
+ * `messageService.context.forAgent(id)` (PerAgentStore instances) instead of the
+ * deleted `stateDict$` / `contextDict$`. These specs verify the host wiring:
+ * the local `state$` / `context$` bridge subjects reflect the store values, with
+ * `undefined` mapped to the existing defaults (`null` / `[]`) so the template
+ * guards behave identically. Drives the real log fold (no store mocking).
+ */
+describe('AgentTabsComponent — store-backed state/context wiring (Story 17-2)', () => {
+  let component: AgentTabsComponent;
+  let log: MessageLogService;
+  let messageService: ActorMessageService;
+  let selectedAkgent$: BehaviorSubject<Akgent | null>;
+  let nodes$: BehaviorSubject<any[]>;
+  let categories$: BehaviorSubject<any[]>;
+  let fakeSocket: Subject<any>;
+
+  function addr(agentId: string) {
+    return {
+      __actor_address__: true,
+      name: '@' + agentId,
+      role: 'Worker',
+      agent_id: agentId,
+      team_id: 'team-1',
+      squad_id: 's1',
+      user_message: false,
+    };
+  }
+
+  function mkStateChanged(agentId: string, state: any, id: string): any {
+    return {
+      id,
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: addr(agentId),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.StateChangedMessage',
+      state,
+    };
+  }
+
+  function mkLlmEvent(agentId: string, message: any, id: string): any {
+    return {
+      id,
+      parent_id: null,
+      team_id: 'team-1',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: addr(agentId),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      event: {
+        __model__: 'akgentic.llm.event.LlmMessageEvent',
+        message,
+      },
+    };
+  }
+
+  beforeEach(async () => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+
+    selectedAkgent$ = new BehaviorSubject<Akgent | null>(null);
+    nodes$ = new BehaviorSubject<any[]>([]);
+    categories$ = new BehaviorSubject<any[]>([]);
+    fakeSocket = new Subject<any>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MessageLogService,
+        PerAgentStoreRegistry,
+        ActorMessageService,
+        ChatService,
+        {
+          provide: ApiService,
+          useValue: {
+            getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+          },
+        },
+        {
+          provide: MessageService,
+          useValue: { add: jasmine.createSpy('add'), clear: jasmine.createSpy('clear') },
+        },
+        {
+          provide: AkgentService,
+          useValue: { selectedAkgent$, select: jasmine.createSpy('select') },
+        },
+        {
+          provide: GraphDataService,
+          useValue: { nodes$, categories$ },
+        },
+      ],
+    });
+
+    messageService = TestBed.inject(ActorMessageService);
+    log = TestBed.inject(MessageLogService);
+    spyOn<any>(messageService, 'createWebSocket').and.returnValue(
+      fakeSocket as unknown as WebSocketSubject<any>,
+    );
+    // Wire the WS pipeline so the registry's log$ subscription is live.
+    await messageService.init('proc-1', true);
+
+    component = TestBed.createComponent(AgentTabsComponent).componentInstance;
+    component.ngOnInit();
+  });
+
+  afterEach(() => {
+    try {
+      fakeSocket.complete();
+    } catch {
+      /* already closed */
+    }
+    jasmine.clock().uninstall();
+  });
+
+  it('AC2/AC3: selecting an agent feeds context$/state$ from the store', () => {
+    log.appendAll([
+      mkStateChanged('agent-A', { phase: 'busy' }, 's1'),
+      mkLlmEvent('agent-A', { role: 'user', content: 'hi' }, 'e1'),
+    ]);
+
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    expect(component.state$.value).toEqual({ schema: {}, state: { phase: 'busy' } });
+    expect(component.context$.value).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('AC2/AC3: an agent with no store value maps undefined → null (state) / [] (context)', () => {
+    selectedAkgent$.next({ name: '@unknown', agentId: 'unknown' });
+
+    // Template guards (`state$ | async`, `(context$ | async)?.length`) depend
+    // on these exact defaults — undefined must never reach the template.
+    expect(component.state$.value).toBeNull();
+    expect(component.context$.value).toEqual([]);
+  });
+
+  it('AC2/AC3: switching agents swaps the source (no cross-agent leak)', () => {
+    log.appendAll([
+      mkStateChanged('agent-A', { who: 'A' }, 's1'),
+      mkStateChanged('agent-B', { who: 'B' }, 's2'),
+    ]);
+
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+    expect(component.state$.value).toEqual({ schema: {}, state: { who: 'A' } });
+
+    selectedAkgent$.next({ name: '@agent-B', agentId: 'agent-B' });
+    expect(component.state$.value).toEqual({ schema: {}, state: { who: 'B' } });
+  });
+
+  it('AC3: a later context message for the selected agent updates context$ live', () => {
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+    expect(component.context$.value).toEqual([]);
+
+    log.append(mkLlmEvent('agent-A', { role: 'user', content: 'm1' }, 'e1'));
+    expect(component.context$.value).toEqual([{ role: 'user', content: 'm1' }]);
+
+    log.append(mkLlmEvent('agent-A', { role: 'assistant', content: 'm2' }, 'e2'));
+    expect(component.context$.value).toEqual([
+      { role: 'user', content: 'm1' },
+      { role: 'assistant', content: 'm2' },
+    ]);
+  });
+
+  it('deselecting clears context$/state$ to defaults', () => {
+    log.append(mkStateChanged('agent-A', { phase: 'busy' }, 's1'));
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+    expect(component.state$.value).toEqual({ schema: {}, state: { phase: 'busy' } });
+
+    selectedAkgent$.next(null);
+    expect(component.state$.value).toBeNull();
+    expect(component.context$.value).toEqual([]);
+  });
+});

--- a/src/app/process/agent-tabs/agent-tabs.component.ts
+++ b/src/app/process/agent-tabs/agent-tabs.component.ts
@@ -8,7 +8,6 @@ import { map, takeUntil } from 'rxjs/operators';
 
 import { TabsModule } from 'primeng/tabs';
 import { DropdownModule } from 'primeng/dropdown';
-import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
 import { AkgentService } from '../../services/akgent.service';
 import {
@@ -29,7 +28,6 @@ import { AkgentStateComponent } from './akgent-state/akgent-state.component';
     FormsModule,
     TabsModule,
     DropdownModule,
-    ProgressSpinnerModule,
     AkgentChatComponent,
     AkgentStateComponent,
   ],
@@ -46,7 +44,6 @@ export class AgentTabsComponent implements OnInit {
   akgentName: string = '';
   agentsByCategory: any[] = [];
   selectedAgent: any = null;
-  isLoading: boolean = false;
 
   context$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
   state$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
@@ -162,7 +159,6 @@ export class AgentTabsComponent implements OnInit {
   }
 
   onAgentSelect(event: any): void {
-    this.isLoading = true;
     const agent = event.value;
     if (agent && agent.agent) {
       this.akgentService.select(agent.agent.name, agent.agent.actorName);

--- a/src/app/process/agent-tabs/agent-tabs.component.ts
+++ b/src/app/process/agent-tabs/agent-tabs.component.ts
@@ -3,8 +3,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { BehaviorSubject, combineLatest, Subject, Subscription } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
+import { map, takeUntil } from 'rxjs/operators';
 
 import { TabsModule } from 'primeng/tabs';
 import { DropdownModule } from 'primeng/dropdown';
@@ -64,27 +64,31 @@ export class AgentTabsComponent implements OnInit {
         this.akgentId = akgent?.agentId || '';
         this.akgentName = akgent?.name || '';
         if (akgent) {
-          this.initDict(this.messageService.contextDict$, akgent.agentId, []);
-          this.initDict(this.messageService.stateDict$, akgent.agentId, null);
-          // Subscribe to context observable for the selected agent
-          // Use takeUntil to properly clean up when agent changes
-          this.messageService.contextDict$[akgent.agentId]
-            .pipe(takeUntil(this.agentSubscriptions$))
+          // Epic 17 (ADR-014): source `context` / `state` from the
+          // PerAgentStore instances instead of the deleted dicts. `forAgent`'s
+          // `shareReplay(1)` delivers the current value on subscribe, so the
+          // explicit immediate `.value` push is no longer needed. Map
+          // `undefined` → the existing defaults (`[]` / `null`) so the template
+          // guards (`(context$ | async)?.length`, `state$ | async`) behave
+          // identically.
+          this.messageService.context
+            .forAgent(akgent.agentId)
+            .pipe(
+              map((context) => context ?? []),
+              takeUntil(this.agentSubscriptions$),
+            )
             .subscribe((context) => {
               this.context$.next(context);
             });
-          this.messageService.stateDict$[akgent.agentId]
-            .pipe(takeUntil(this.agentSubscriptions$))
+          this.messageService.state
+            .forAgent(akgent.agentId)
+            .pipe(
+              map((state) => state ?? null),
+              takeUntil(this.agentSubscriptions$),
+            )
             .subscribe((state) => {
               this.state$.next(state);
             });
-          // Immediately update with the latest context value
-          this.context$.next(
-            this.messageService.contextDict$[akgent.agentId].value
-          );
-          this.state$.next(
-            this.messageService.stateDict$[akgent.agentId].value
-          );
           // Select the agent in the dropdown
           this.set_dropdown_selected_agent(akgent.agentId);
         } else {
@@ -155,15 +159,6 @@ export class AgentTabsComponent implements OnInit {
     const dropdownItems = this.agentsByCategory.flatMap((g: any) => g.items);
     this.selectedAgent =
       dropdownItems.find((item: any) => item.value === agent_id) || null;
-  }
-
-  initDict(
-    dict: { [key: string]: BehaviorSubject<any[]> },
-    key: string,
-    defaultValue: any
-  ) {
-    if (dict[key]) return;
-    dict[key] = new BehaviorSubject<any>(defaultValue);
   }
 
   onAgentSelect(event: any): void {

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1,3 +1,4 @@
+import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
@@ -398,6 +399,26 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
     expect(headBodies(fixture)).toEqual(['roster v2', 'backstory']);
     // No system row leaked into the conversation table.
     expect(component.context.some((m) => m.type === 'system')).toBeFalse();
+  });
+
+  it('regression: switching agentId (component reused) rebinds the head block to the new agent', () => {
+    const { fixture, component, log } = setup();
+    const OTHER = 'b-other';
+    log.appendAll([
+      systemPromptEnvelope(AGENT, [{ dynamic_ref: null, content: 'A backstory' }]),
+      systemPromptEnvelope(OTHER, [{ dynamic_ref: null, content: 'B backstory' }]),
+    ]);
+    fixture.detectChanges();
+    expect(headBodies(fixture)).toEqual(['A backstory']);
+
+    // The agent-tabs dropdown REUSES this component when switching members, so
+    // ngOnInit does not re-run — ngOnChanges must re-point systemPrompt$ at the
+    // new agent. Without the fix the head block stays pinned to 'A backstory'.
+    component.agentId = OTHER;
+    component.ngOnChanges({ agentId: new SimpleChange(AGENT, OTHER, false) });
+    fixture.detectChanges();
+
+    expect(headBodies(fixture)).toEqual(['B backstory']);
   });
 
   it('AC2 single source: updateContext() emits NO system row from a system-prompt part', () => {

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -19,11 +19,11 @@ import {
  * chat targets exactly one agent (its own `agentName`), so the `/` list is
  * unconditionally that agent's commands.
  */
-describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
+describe('AkgentChatComponent — slash-command mention (Story 15-1 / 17-3)', () => {
   let component: AkgentChatComponent;
-  let commandsByAgentSubject: BehaviorSubject<
-    Record<string, CommandDescriptor[]>
-  >;
+  // Story 17-3: the member chat reads `commands.snapshot(this.agentId)` keyed by
+  // agent_id. The stub holds an agent_id → descriptors map + a `snapshot(id)`.
+  let commandsById: Record<string, CommandDescriptor[]>;
 
   const HIRE: CommandDescriptor = {
     name: 'hire_member',
@@ -42,9 +42,7 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
   };
 
   beforeEach(() => {
-    commandsByAgentSubject = new BehaviorSubject<
-      Record<string, CommandDescriptor[]>
-    >({});
+    commandsById = {};
 
     TestBed.configureTestingModule({
       imports: [AkgentChatComponent],
@@ -60,7 +58,12 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
         },
         {
           provide: ActorMessageService,
-          useValue: { commandsByAgent$: commandsByAgentSubject },
+          useValue: {
+            commands: {
+              snapshot: (id: string): CommandDescriptor[] | undefined =>
+                commandsById[id],
+            },
+          },
         },
         // Story 16-2: AkgentChatComponent now injects the component-scoped
         // SystemPromptSelector (over MessageLogService). Provide the real pair.
@@ -77,8 +80,9 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
     fixture.detectChanges();
   });
 
-  it('AC-2: commandItems are the panel agent\'s commands', () => {
-    commandsByAgentSubject.next({ '@Manager': [HIRE, ROSTER] });
+  it('AC-4: commandItems are the panel agent\'s commands (keyed by agent_id)', () => {
+    // Seed under the panel's agent_id (`component.agentId`), not the friendly name.
+    commandsById['a-mgr'] = [HIRE, ROSTER];
     expect(component.commandItems.map((c) => c.name)).toEqual([
       'hire_member',
       'roster',
@@ -92,7 +96,7 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
       args: [{ name: 'prompt', type: 'string', required: true }],
       tool_card: 'MediaTool',
     };
-    commandsByAgentSubject.next({ '@Manager': [INTERNAL, HIRE, ROSTER] });
+    commandsById['a-mgr'] = [INTERNAL, HIRE, ROSTER];
     // `_expand_media_refs` is internal — only user commands remain.
     expect(component.commandItems.map((c) => c.name)).toEqual([
       'hire_member',
@@ -102,7 +106,8 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
 
   it('AC-6: empty / list until a CommandsAnnouncedEvent arrives for this agent', () => {
     expect(component.commandItems).toEqual([]);
-    commandsByAgentSubject.next({ '@Other': [HIRE] });
+    // A different agent_id's commands must not bleed into this panel.
+    commandsById['a-other'] = [HIRE];
     expect(component.commandItems).toEqual([]);
   });
 
@@ -139,9 +144,8 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1)', () => {
     };
     // Stored order: TeamTool first, PlanningTool names reversed — neither
     // tool-grouped nor globally alphabetical, so a naive sort can't fake it.
-    commandsByAgentSubject.next({
-      '@Manager': [ROSTER, PLAN_BREAKDOWN, HIRE, PLAN_AUDIT],
-    });
+    // Seeded under the panel's agent_id (a-mgr).
+    commandsById['a-mgr'] = [ROSTER, PLAN_BREAKDOWN, HIRE, PLAN_AUDIT];
 
     // PlanningTool family (audit, breakdown) before TeamTool family
     // (hire_member, roster); alphabetical within each family.
@@ -302,9 +306,11 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
         {
           provide: ActorMessageService,
           useValue: {
-            commandsByAgent$: new BehaviorSubject<
-              Record<string, CommandDescriptor[]>
-            >({}),
+            // Story 17-3: member chat reads `commands.snapshot(agentId)`.
+            commands: {
+              snapshot: (_id: string): CommandDescriptor[] | undefined =>
+                undefined,
+            },
           },
         },
         MessageLogService,

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -8,7 +8,13 @@ import { UtilService } from '../../../services/utils.service';
 import { ContextService } from '../../../services/context.service';
 import { ActorMessageService } from '../../../services/message.service';
 import { MessageLogService } from '../../../services/message-log.service';
-import { SystemPromptSelector } from '../../../services/system-prompt.selector';
+import { PerAgentStoreRegistry } from '../../../services/per-agent-store';
+import {
+  SystemPromptSelector,
+  SystemPromptValue,
+  systemPromptMatch,
+  systemPromptReduce,
+} from '../../../services/system-prompt.selector';
 import {
   AkgenticMessage,
   CommandDescriptor,
@@ -56,18 +62,29 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1 / 17-3)', ()
             currentProcessId$: new BehaviorSubject<string>('proc-1'),
           },
         },
+        // Story 16-2 / Epic 17 (17-4): AkgentChatComponent injects
+        // SystemPromptSelector, now a thin façade over
+        // `ActorMessageService.systemPrompt`. Provide a stub service exposing the
+        // `commands` snapshot the `/` mention reads PLUS a REAL `systemPrompt`
+        // PerAgentStore (registered on a real registry over the same
+        // MessageLogService) so the façade resolves against a live store.
+        MessageLogService,
+        PerAgentStoreRegistry,
         {
           provide: ActorMessageService,
-          useValue: {
+          useFactory: (registry: PerAgentStoreRegistry) => ({
             commands: {
               snapshot: (id: string): CommandDescriptor[] | undefined =>
                 commandsById[id],
             },
-          },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
         },
-        // Story 16-2: AkgentChatComponent now injects the component-scoped
-        // SystemPromptSelector (over MessageLogService). Provide the real pair.
-        MessageLogService,
         SystemPromptSelector,
       ],
     });
@@ -303,17 +320,29 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
             currentProcessId$: new BehaviorSubject<string>('proc-1'),
           },
         },
+        // Story 17-3 / Epic 17 (17-4): member chat reads
+        // `commands.snapshot(agentId)`; the head block reads the
+        // SystemPromptSelector façade over `ActorMessageService.systemPrompt`.
+        // The stub exposes `commands` PLUS a REAL `systemPrompt` PerAgentStore
+        // (registered on a real registry over the same MessageLogService) so the
+        // head block renders from the actual log-driven fold.
+        MessageLogService,
+        PerAgentStoreRegistry,
         {
           provide: ActorMessageService,
-          useValue: {
-            // Story 17-3: member chat reads `commands.snapshot(agentId)`.
+          useFactory: (registry: PerAgentStoreRegistry) => ({
             commands: {
               snapshot: (_id: string): CommandDescriptor[] | undefined =>
                 undefined,
             },
-          },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
         },
-        MessageLogService,
         SystemPromptSelector,
         // PrimeNG p-fieldset registers a synthetic animation listener.
         provideNoopAnimations(),

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -91,14 +91,6 @@ export class AkgentChatComponent {
    */
   systemPrompt$!: Observable<SystemPromptRow[]>;
 
-  /**
-   * ADR-013: latest per-agent slash-command store (keyed by raw actor
-   * `name`). Snapshot of `ActorMessageService.commandsByAgent$`; read by
-   * `commandItems` to build this panel's `/` mention list. Empty until a
-   * `CommandsAnnouncedEvent` arrives for this agent (AC-6).
-   */
-  commandsByAgent: Record<string, CommandDescriptor[]> = {};
-
   ngOnInit(): void {
     // ADR-004 §5b step 2 — head system block for this panel's agent. Rendered
     // in the template via `async`, above the conversation table.
@@ -114,27 +106,22 @@ export class AkgentChatComponent {
       this.isLoading = false;
       this.updateContext(ctx);
     });
-
-    // ADR-013: keep a live snapshot of the per-agent slash-command store so
-    // this panel's `/` mention reflects the latest CommandsAnnouncedEvent.
-    this.messageService.commandsByAgent$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((byAgent) => {
-        this.commandsByAgent = byAgent;
-      });
   }
 
   /**
-   * ADR-013 §3 — member chat target is unambiguous: this panel's own agent
-   * (`agentName`). The `/` list is that agent's command descriptors, mapped to
-   * dropdown items. Empty until a CommandsAnnouncedEvent arrives (AC-6).
+   * ADR-013 §3 / Epic 17 (ADR-014) — member chat target is unambiguous: this
+   * panel's own agent. The `/` list is that agent's command descriptors, read
+   * from `store.commands` by the panel's `agent_id` (`@Input() agentId`) and
+   * mapped to dropdown items. Keying by `agent_id` (not the friendly name) is
+   * the ADR-013 keying fix. Empty until a CommandsAnnouncedEvent arrives (AC-6).
    */
   get commandItems(): {
     name: string;
     description: string;
     args: CommandDescriptor['args'];
   }[] {
-    const descriptors = this.commandsByAgent[this.agentName] ?? [];
+    const descriptors =
+      this.messageService.commands.snapshot(this.agentId) ?? [];
     return descriptors
       // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
       // user-invocable — keep them out of the `/` dropdown.

--- a/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/process/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -3,6 +3,9 @@ import {
   ElementRef,
   inject,
   Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
   ViewChild,
   DestroyRef,
 } from '@angular/core';
@@ -57,7 +60,7 @@ import { CopyButtonComponent } from '../../copy-button/copy-button.component';
   templateUrl: './akgent-chat.component.html',
   styleUrl: './akgent-chat.component.scss',
 })
-export class AkgentChatComponent {
+export class AkgentChatComponent implements OnInit, OnChanges {
   // The single trace scroll region (head system block + conversation). Auto
   // scroll-to-bottom targets this element so new messages stay in view.
   @ViewChild('traceScroll') traceScroll?: ElementRef<HTMLElement>;
@@ -76,8 +79,6 @@ export class AkgentChatComponent {
   );
   private destroyRef = inject(DestroyRef);
 
-  collapsedMessages$ = new BehaviorSubject<boolean>(true);
-
   context: any[] = [];
 
   /**
@@ -91,14 +92,27 @@ export class AkgentChatComponent {
    */
   systemPrompt$!: Observable<SystemPromptRow[]>;
 
-  ngOnInit(): void {
-    // ADR-004 §5b step 2 — head system block for this panel's agent. Rendered
-    // in the template via `async`, above the conversation table.
-    this.systemPrompt$ = this.systemPromptSelector.latestSystemPrompt$(
-      this.agentId
-    );
+  /**
+   * The agent-tabs dropdown REUSES this component across member selections (it
+   * lives under `*ngIf="context$.length"`, which stays truthy when switching
+   * between agents that both have context), so `ngOnInit` does NOT re-run on a
+   * switch. Re-bind the head system block to the newly-selected agent here, or
+   * it stays pinned to the first-opened agent. The initial bind is done in
+   * `ngOnInit` (which also covers unit tests that set `agentId` directly), so
+   * skip the first change to avoid binding twice.
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agentId'] && !changes['agentId'].firstChange) {
+      this.bindSystemPrompt();
+    }
+  }
 
-    // Subscribe to context$ for the selected agent
+  ngOnInit(): void {
+    // Initial head system block for this panel's agent (ADR-004 §5b step 2).
+    // Subsequent agent switches re-bind it in ngOnChanges — see above.
+    this.bindSystemPrompt();
+
+    // Subscribe to context$ for the selected agent.
     this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((ctx) => {
       if (this.isLoading) {
         setTimeout(() => this.scroll(), 10);
@@ -106,6 +120,14 @@ export class AkgentChatComponent {
       this.isLoading = false;
       this.updateContext(ctx);
     });
+  }
+
+  /** Point `systemPrompt$` at the current `agentId`'s head system block. The
+   *  async pipe in the template resubscribes to the new stream on reassignment. */
+  private bindSystemPrompt(): void {
+    this.systemPrompt$ = this.systemPromptSelector.latestSystemPrompt$(
+      this.agentId
+    );
   }
 
   /**
@@ -368,9 +390,5 @@ export class AkgentChatComponent {
     if (el && !this.isMouseOverTable && !this.initialLoad) {
       el.scrollTo({ top: el.scrollHeight, behavior });
     }
-  }
-
-  toggleCollapse() {
-    this.collapsedMessages$.next(!this.collapsedMessages$.value);
   }
 }

--- a/src/app/process/process.component.ts
+++ b/src/app/process/process.component.ts
@@ -8,6 +8,7 @@ import { ContextService } from '../services/context.service';
 import { KGStateReducer } from '../services/kg-state.reducer';
 import { MessageLogService } from '../services/message-log.service';
 import { ActorMessageService } from '../services/message.service';
+import { PerAgentStoreRegistry } from '../services/per-agent-store';
 import { SystemPromptSelector } from '../services/system-prompt.selector';
 import { ToolPresenceService } from '../services/tool-presence.service';
 
@@ -57,6 +58,12 @@ interface VisualizationOption {
     ToolPresenceService,
     KGStateReducer,
     SystemPromptSelector,
+    // Epic 17 (ADR-014): component-scoped registry that derives per-agent
+    // `state` / `context` from `log$`. Must be provided BEFORE
+    // ActorMessageService (which injects it). Never `providedIn: 'root'` —
+    // a team switch destroys this component, destroying the registry and its
+    // single `log$` subscription (same lifecycle guarantee as MessageLogService).
+    PerAgentStoreRegistry,
     ActorMessageService,
     GraphDataService,
     ChatService,

--- a/src/app/process/user-input/user-input.component.spec.ts
+++ b/src/app/process/user-input/user-input.component.spec.ts
@@ -45,7 +45,10 @@ describe('ProcessUserInputComponent', () => {
   let chatServiceMock: any;
   let contextServiceStub: { currentTeamRunning$: BehaviorSubject<boolean> };
   let nodesSubject: BehaviorSubject<NodeInterface[]>;
-  let commandsByAgentSubject: BehaviorSubject<Record<string, CommandDescriptor[]>>;
+  // Story 17-3: the service now exposes a `commands` PerAgentStore keyed by
+  // agent_id. The stub holds a plain agent_id → descriptors map and a
+  // `snapshot(id)` reader matching the real store's synchronous getter shape.
+  let commandsById: Record<string, CommandDescriptor[]>;
 
   beforeEach(async () => {
     apiServiceSpy = jasmine.createSpyObj('ApiService', ['sendMessage', 'sendMessageFromTo']);
@@ -69,11 +72,12 @@ describe('ProcessUserInputComponent', () => {
       nodes$: nodesSubject,
     };
 
-    commandsByAgentSubject = new BehaviorSubject<
-      Record<string, CommandDescriptor[]>
-    >({});
+    commandsById = {};
     const messageServiceStub = {
-      commandsByAgent$: commandsByAgentSubject,
+      commands: {
+        snapshot: (id: string): CommandDescriptor[] | undefined =>
+          commandsById[id],
+      },
     };
 
     await TestBed.configureTestingModule({
@@ -743,12 +747,13 @@ describe('ProcessUserInputComponent', () => {
       description: 'List the current team roster',
     });
 
-    it('AC-3: with exactly one Send-to recipient, commandItems are that agent\'s commands', () => {
+    it('AC-3: with exactly one Send-to recipient, commandItems are that agent\'s commands (keyed by agent_id)', () => {
       nodesSubject.next([
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
         makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
       ]);
-      commandsByAgentSubject.next({ '@Manager': [HIRE, ROSTER] });
+      // Seed under the node's agent_id (`name`), NOT the friendly actor name.
+      commandsById['mgr-1'] = [HIRE, ROSTER];
       component.selectedAgents = ['@Manager'];
 
       expect(component.commandItems.map((c) => c.name)).toEqual([
@@ -765,7 +770,7 @@ describe('ProcessUserInputComponent', () => {
       nodesSubject.next([
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
       ]);
-      commandsByAgentSubject.next({ '@Manager': [INTERNAL, HIRE, ROSTER] });
+      commandsById['mgr-1'] = [INTERNAL, HIRE, ROSTER];
       component.selectedAgents = ['@Manager'];
 
       // `_expand_media_refs` is internal — only user commands remain.
@@ -791,14 +796,29 @@ describe('ProcessUserInputComponent', () => {
           parentId: 'mgr-1',
         }),
       ]);
-      commandsByAgentSubject.next({
-        '@Manager': [HIRE],
-        '@Developer': [ROSTER],
-      });
+      commandsById['mgr-1'] = [HIRE];
+      commandsById['dev-1'] = [ROSTER];
       component.selectedAgents = [];
 
-      // Supervisor = the agent whose parent is @Human → @Manager.
+      // Supervisor = the agent whose parent is @Human → @Manager (agent_id mgr-1).
       expect(component.commandItems.map((c) => c.name)).toEqual(['hire_member']);
+    });
+
+    it('AC-2: name-reuse non-bleed — same display name, different agent_ids resolve correctly', () => {
+      // Two nodes have shared the display name '@Manager' history but the LIVE
+      // roster carries the re-hired one (agent_id mgr-new). The list must be the
+      // resolved node's agent_id list, never a stale name-keyed entry.
+      nodesSubject.next([
+        makeNode({ name: 'mgr-new', actorName: '@Manager', role: 'Worker' }),
+      ]);
+      // The fired agent (mgr-old) still has a seeded entry; the re-hired one a
+      // different list. The resolved target's agent_id is mgr-new.
+      commandsById['mgr-old'] = [HIRE];
+      commandsById['mgr-new'] = [ROSTER];
+      component.selectedAgents = ['@Manager'];
+
+      // Correct agent's commands (mgr-new → roster), no bleed from mgr-old.
+      expect(component.commandItems.map((c) => c.name)).toEqual(['roster']);
     });
 
     it('AC-4: with multiple Send-to recipients, the / list is empty', () => {
@@ -806,7 +826,8 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
         makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
       ]);
-      commandsByAgentSubject.next({ '@Manager': [HIRE], '@Developer': [ROSTER] });
+      commandsById['mgr-1'] = [HIRE];
+      commandsById['dev-1'] = [ROSTER];
       component.selectedAgents = ['@Manager', '@Developer'];
 
       expect(component.commandItems).toEqual([]);
@@ -816,7 +837,7 @@ describe('ProcessUserInputComponent', () => {
       nodesSubject.next([
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
       ]);
-      // commandsByAgent$ stays {} (no event arrived yet).
+      // commands store is empty (no event arrived yet).
       component.selectedAgents = ['@Manager'];
 
       expect(component.commandItems).toEqual([]);
@@ -879,10 +900,13 @@ describe('ProcessUserInputComponent', () => {
         makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
       ]);
       // Stored order: TeamTool first, PlanningTool names reversed — neither
-      // tool-grouped nor globally alphabetical.
-      commandsByAgentSubject.next({
-        '@Manager': [TEAM_ROSTER, PLAN_BREAKDOWN, TEAM_HIRE, PLAN_AUDIT],
-      });
+      // tool-grouped nor globally alphabetical. Seeded under agent_id mgr-1.
+      commandsById['mgr-1'] = [
+        TEAM_ROSTER,
+        PLAN_BREAKDOWN,
+        TEAM_HIRE,
+        PLAN_AUDIT,
+      ];
       component.selectedAgents = ['@Manager'];
 
       // PlanningTool family (audit, breakdown) before TeamTool family

--- a/src/app/process/user-input/user-input.component.ts
+++ b/src/app/process/user-input/user-input.component.ts
@@ -54,14 +54,6 @@ export class ProcessUserInputComponent implements OnInit {
   mentionItems: { name: string; actorName: string; agentId: string }[] = [];
 
   /**
-   * ADR-013: latest per-agent slash-command store (keyed by raw actor
-   * `name`, e.g. `@Manager-…`). Snapshot of `ActorMessageService
-   * .commandsByAgent$`; read by the targeted-agent selector to build the `/`
-   * mention list. Empty until a `CommandsAnnouncedEvent` arrives (AC-6).
-   */
-  commandsByAgent: Record<string, CommandDescriptor[]> = {};
-
-  /**
    * ADR-013: live snapshot of the graph nodes — used to derive the
    * supervisor / entry-point default target for the main chat (Task 2.1).
    */
@@ -76,15 +68,6 @@ export class ProcessUserInputComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
-    // ADR-013: keep a live snapshot of the per-agent slash-command store so
-    // the `/` mention list (built by the targeted-agent selector) reflects the
-    // latest CommandsAnnouncedEvent. Component-scoped (NFR1).
-    this.messageService.commandsByAgent$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((byAgent) => {
-        this.commandsByAgent = byAgent;
-      });
-
     // Subscribe to nodes to populate mention items and dropdown agents
     this.graphDataService.nodes$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -198,7 +181,8 @@ export class ProcessUserInputComponent implements OnInit {
 
   /**
    * ADR-013 §3 — resolve the SINGLE agent the `/` command list targets in the
-   * MAIN chat, by raw actor `name` (the `commandsByAgent$` / Send-to key):
+   * MAIN chat, by raw actor `name` (the Send-to key); `targetedAgentId()` then
+   * maps that name to the agent's `agent_id` for the `store.commands` lookup:
    *   - exactly one "Send to" recipient   → that recipient;
    *   - zero recipients                   → supervisor / entry-point default;
    *   - multiple recipients (broadcast)   → null (no single target, AC-4).
@@ -231,19 +215,37 @@ export class ProcessUserInputComponent implements OnInit {
   }
 
   /**
-   * ADR-013 — the `/` mention candidate list: the resolved targeted agent's
-   * command descriptors, mapped to dropdown items (`name` + `description` +
-   * ordered `args`). Empty when no single target resolves (none/ambiguous,
-   * AC-4) or no CommandsAnnouncedEvent has arrived yet for it (AC-6).
+   * Epic 17 (ADR-014 §2 / ADR-013 §3) — resolve the `/` target to its immutable
+   * `agent_id`. `resolveTargetedAgent()` still returns an actor `name`; this maps
+   * that name → the matching graph node's `name` field (which IS the `agent_id`
+   * UUID, the same value placed in `mentionItems[i].agentId`). A name that does
+   * not resolve to a live node yields `null` → empty `/` list (acceptable
+   * transient, same posture as the just-hired case, ADR-013 §3). Keying by
+   * `agent_id` (not the friendly name) is the ADR-013 keying fix: a display-name
+   * reused after a fire/re-hire can never serve the wrong agent's commands.
+   */
+  private targetedAgentId(): string | null {
+    const target = this.resolveTargetedAgent();
+    if (!target) return null;
+    const node = this.nodes.find((n) => n.actorName === target);
+    return node ? node.name : null;
+  }
+
+  /**
+   * ADR-013 / Epic 17 (ADR-014) — the `/` mention candidate list: the resolved
+   * targeted agent's command descriptors (read from `store.commands` by
+   * `agent_id`), mapped to dropdown items (`name` + `description` + ordered
+   * `args`). Empty when no single target resolves (none/ambiguous, AC-4) or no
+   * CommandsAnnouncedEvent has arrived yet for it (AC-6).
    */
   get commandItems(): {
     name: string;
     description: string;
     args: CommandDescriptor['args'];
   }[] {
-    const target = this.resolveTargetedAgent();
-    if (!target) return [];
-    const descriptors = this.commandsByAgent[target] ?? [];
+    const agentId = this.targetedAgentId();
+    if (!agentId) return [];
+    const descriptors = this.messageService.commands.snapshot(agentId) ?? [];
     return descriptors
       // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
       // user-invocable — keep them out of the `/` dropdown.

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -546,16 +546,26 @@ describe('ActorMessageService — Story 6.1 (frame-batched log ingestion)', () =
 });
 
 // ---------------------------------------------------------------------------
-// Epic 15 / Story 15-1 (ADR-013) — commandsByAgent$ from CommandsAnnouncedEvent
+// Epic 17 / Story 17-3 (ADR-014 §5, ADR-013) — `commands` PerAgentStore
+//
+// Re-homes Story 15-1/15-2: the bespoke `commandsByAgent$` (name-keyed) is gone;
+// `commands` is a PerAgentStore folded off log$ by the registry, keyed by the
+// emitting agent's `sender.agent_id` (the ADR-013 keying fix). These tests drive
+// the REAL log fold (no store mocking) per the story's testing standards:
+// announce a CommandsAnnouncedEvent EventMessage, read commands.snapshot(id) /
+// forAgent(id); replace-on-re-announce; replay-vs-live parity; reset-on-switch;
+// and the name-reuse non-bleed correctness proof.
 // ---------------------------------------------------------------------------
 
-describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () => {
+describe('ActorMessageService — commands PerAgentStore (Story 17-3, ADR-014/ADR-013)', () => {
   let service: ActorMessageService;
-  let chatService: ChatService;
   let fakeSocket: Subject<any>;
 
+  /** A CommandsAnnouncedEvent EventMessage. The outer `sender.agent_id` is the
+   *  registry key; the inner `agent` mirrors it (sender === emitting agent). */
   function mkCommandsEvent(
     agentName: string,
+    agentId: string,
     commands: any[],
     id = 'cmd-evt',
   ): any {
@@ -564,13 +574,13 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
       parent_id: null,
       team_id: 'team-X',
       timestamp: '2026-06-13T00:00:00Z',
-      sender: makeAddress({ name: agentName, agent_id: 'a-' + agentName }),
+      sender: makeAddress({ name: agentName, agent_id: agentId }),
       display_type: 'other',
       content: null,
       __model__: 'akgentic.core.messages.orchestrator.EventMessage',
       event: {
         __model__: 'akgentic.tool.commands.CommandsAnnouncedEvent',
-        agent: makeAddress({ name: agentName, agent_id: 'a-' + agentName }),
+        agent: makeAddress({ name: agentName, agent_id: agentId }),
         commands,
       },
     };
@@ -614,7 +624,6 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
       ],
     });
     service = TestBed.inject(ActorMessageService);
-    chatService = TestBed.inject(ChatService);
 
     spyOn<any>(service, 'createWebSocket').and.returnValue(
       fakeSocket as unknown as WebSocketSubject<any>,
@@ -630,101 +639,136 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
     jasmine.clock().uninstall();
   });
 
-  it('AC-1: a CommandsAnnouncedEvent accumulates the agent\'s descriptors under its name', async () => {
+  it('AC1: a CommandsAnnouncedEvent yields the agent\'s descriptors keyed by agent_id', async () => {
     await service.init('proc-1', true);
 
-    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE, ROSTER]));
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE, ROSTER]));
     jasmine.clock().tick(17);
 
-    const byAgent = service.commandsByAgent$.getValue();
-    expect(byAgent['@Manager']).toBeDefined();
-    expect(byAgent['@Manager'].map((c) => c.name)).toEqual([
+    // Keyed by agent_id, NOT by name.
+    expect(service.commands.snapshot('agent-mgr')?.map((c) => c.name)).toEqual([
       'hire_member',
+      'roster',
+    ]);
+    expect(service.commands.snapshot('@Manager')).toBeUndefined();
+  });
+
+  it('AC1: forAgent(id) delivers the current list to a late subscriber', async () => {
+    await service.init('proc-1', true);
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE]));
+    jasmine.clock().tick(17);
+
+    let seen: any = 'unset';
+    const sub = service.commands.forAgent('agent-mgr').subscribe((v) => (seen = v));
+    expect((seen as any[]).map((c) => c.name)).toEqual(['hire_member']);
+    sub.unsubscribe();
+  });
+
+  it('AC1: a later event for the same agent_id REPLACES that list', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE, ROSTER], 'e1'));
+    jasmine.clock().tick(17);
+    expect(service.commands.snapshot('agent-mgr')?.length).toBe(2);
+
+    // Re-announce with a shorter list — must replace, not merge.
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [ROSTER], 'e2'));
+    jasmine.clock().tick(17);
+
+    expect(service.commands.snapshot('agent-mgr')?.map((c) => c.name)).toEqual([
       'roster',
     ]);
   });
 
-  it('AC-1: a later event for the same agent REPLACES that entry', async () => {
+  it('AC1: events for different agent_ids are kept under distinct keys', async () => {
     await service.init('proc-1', true);
 
-    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE, ROSTER], 'e1'));
-    jasmine.clock().tick(17);
-    expect(service.commandsByAgent$.getValue()['@Manager'].length).toBe(2);
-
-    // Re-announce with a shorter list — must replace, not merge.
-    fakeSocket.next(mkCommandsEvent('@Manager', [ROSTER], 'e2'));
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE], 'e1'));
+    fakeSocket.next(mkCommandsEvent('@Developer', 'agent-dev', [ROSTER], 'e2'));
     jasmine.clock().tick(17);
 
-    const byAgent = service.commandsByAgent$.getValue();
-    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['roster']);
+    expect(service.commands.snapshot('agent-mgr')?.map((c) => c.name)).toEqual([
+      'hire_member',
+    ]);
+    expect(service.commands.snapshot('agent-dev')?.map((c) => c.name)).toEqual([
+      'roster',
+    ]);
   });
 
-  it('AC-1: events for different agents are kept under distinct keys', async () => {
+  it('AC2: name-reuse non-bleed — same display name, different agent_ids stay separate', async () => {
     await service.init('proc-1', true);
 
-    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE], 'e1'));
-    fakeSocket.next(mkCommandsEvent('@Developer', [ROSTER], 'e2'));
+    // Two agents that have shared the display name '@Manager' at different times
+    // (fire/re-hire) but have DISTINCT agent_ids. Each announces its own list.
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-old', [HIRE], 'e1'));
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-new', [ROSTER], 'e2'));
     jasmine.clock().tick(17);
 
-    const byAgent = service.commandsByAgent$.getValue();
-    expect(Object.keys(byAgent).sort()).toEqual(['@Developer', '@Manager']);
-    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['hire_member']);
-    expect(byAgent['@Developer'].map((c) => c.name)).toEqual(['roster']);
+    // A name-keyed store would have collapsed these into one wrong entry; the
+    // agent_id-keyed store keeps them separate (the ADR-013 keying fix).
+    expect(service.commands.snapshot('agent-old')?.map((c) => c.name)).toEqual([
+      'hire_member',
+    ]);
+    expect(service.commands.snapshot('agent-new')?.map((c) => c.name)).toEqual([
+      'roster',
+    ]);
   });
 
-  it('Task 1.3: init() resets commandsByAgent$ to {}', async () => {
+  it('AC6/AC7: a team switch (init reset) clears commands — no process-A leak', async () => {
     await service.init('proc-A', true);
-    fakeSocket.next(mkCommandsEvent('@Manager', [HIRE]));
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE]));
     jasmine.clock().tick(17);
-    expect(Object.keys(service.commandsByAgent$.getValue()).length).toBe(1);
+    expect(service.commands.snapshot('agent-mgr')?.length).toBe(1);
 
-    // Re-init (team switch) — store must be cleared synchronously.
+    // Re-init (team switch) → log.reset() → registry clears its maps.
     const socketB = new Subject<any>();
     (service as any).createWebSocket = jasmine
       .createSpy('createWebSocket')
       .and.returnValue(socketB as unknown as WebSocketSubject<any>);
     await service.init('proc-B', true);
 
-    expect(service.commandsByAgent$.getValue()).toEqual({});
+    expect(service.commands.snapshot('agent-mgr')).toBeUndefined();
     socketB.complete();
   });
 
-  it('AC-1: a CommandsAnnouncedEvent without an agent name is ignored (no partial populate)', async () => {
-    await service.init('proc-1', true);
-
-    fakeSocket.next({
-      id: 'bad',
-      parent_id: null,
-      team_id: 'team-X',
-      timestamp: '2026-06-13T00:00:00Z',
-      sender: makeAddress(),
-      display_type: 'other',
-      content: null,
-      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
-      event: {
-        __model__: 'akgentic.tool.commands.CommandsAnnouncedEvent',
-        commands: [HIRE],
-      },
-    });
+  it('AC6: stopped-team REST replay yields the SAME commands as the live WS path', async () => {
+    // Live WS ingestion of a fixture sequence.
+    await service.init('proc-live', true);
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [HIRE, ROSTER], 'e1'));
+    // Later live event for the same agent_id replaces the earlier one.
+    fakeSocket.next(mkCommandsEvent('@Manager', 'agent-mgr', [ROSTER], 'e2'));
+    fakeSocket.next(mkCommandsEvent('@Developer', 'agent-dev', [HIRE], 'e3'));
     jasmine.clock().tick(17);
+    const liveMgr = service.commands.snapshot('agent-mgr');
+    const liveDev = service.commands.snapshot('agent-dev');
 
-    expect(service.commandsByAgent$.getValue()).toEqual({});
-  });
-
-  it('Replay: stopped-team getEvents() rebuilds commandsByAgent$', async () => {
+    // REST replay of the SAME ordered events as one getEvents() batch.
     const apiService = TestBed.inject(ApiService) as any;
     apiService.getEvents.and.resolveTo([
-      { event: mkCommandsEvent('@Manager', [HIRE, ROSTER], 'r1') },
-      // Later replay event for @Manager replaces the earlier one.
-      { event: mkCommandsEvent('@Manager', [ROSTER], 'r2') },
-      { event: mkCommandsEvent('@Developer', [HIRE], 'r3') },
+      { event: mkCommandsEvent('@Manager', 'agent-mgr', [HIRE, ROSTER], 'r1') },
+      { event: mkCommandsEvent('@Manager', 'agent-mgr', [ROSTER], 'r2') },
+      { event: mkCommandsEvent('@Developer', 'agent-dev', [HIRE], 'r3') },
     ]);
-
+    const socketB = new Subject<any>();
+    (service as any).createWebSocket = jasmine
+      .createSpy('createWebSocket')
+      .and.returnValue(socketB as unknown as WebSocketSubject<any>);
     await service.init('proc-stopped', false);
 
-    const byAgent = service.commandsByAgent$.getValue();
-    expect(byAgent['@Manager'].map((c) => c.name)).toEqual(['roster']);
-    expect(byAgent['@Developer'].map((c) => c.name)).toEqual(['hire_member']);
+    expect(service.commands.snapshot('agent-mgr')).toEqual(liveMgr);
+    expect(service.commands.snapshot('agent-dev')).toEqual(liveDev);
+    expect(service.commands.snapshot('agent-mgr')?.map((c) => c.name)).toEqual([
+      'roster',
+    ]);
+    socketB.complete();
+  });
+
+  it('AC8: commandsByAgent$ field no longer exists on the service', async () => {
+    await service.init('proc-1', true);
+    expect((service as any).commandsByAgent$).toBeUndefined();
+    // The migrated surface exposes forAgent/snapshot, not a dict of subjects.
+    expect(typeof service.commands.forAgent).toBe('function');
+    expect(typeof service.commands.snapshot).toBe('function');
   });
 });
 
@@ -734,11 +778,12 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
 // ADR-005 §Decision 5: stateDict$ / contextDict$ / commandsByAgent$ were the
 // imperative per-agent state containers on ActorMessageService.
 // "Adding an exception requires a new ADR. This test is the automated guard."
-// Epic 17 (ADR-014) migrated `state` and `context` to PerAgentStore instances
-// (folded off log$ by the registry — NOT BehaviorSubject fields), so the probe
-// now sees only the remaining bespoke exception, commandsByAgent$ (Story 17-3
-// migrates it next). The invariant test itself is RETIRED in Story 17-4; this
-// is the minimal symbol-count adjustment to keep it compiling + green.
+// Epic 17 (ADR-014) migrated `state` + `context` (Story 17-2) and `commands`
+// (Story 17-3) to PerAgentStore instances (folded off log$ by the registry —
+// NOT BehaviorSubject fields), so the probe now sees ZERO bespoke per-agent
+// exceptions. The invariant test itself is RETIRED in Story 17-4; this is the
+// minimal symbol-count adjustment (singleton → empty set) to keep it compiling
+// + green now that the last exception (commandsByAgent$) is gone.
 // ---------------------------------------------------------------------------
 
 /**
@@ -746,7 +791,8 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
  * return the set of own-property names whose runtime shape is an imperative
  * state container — a direct `BehaviorSubject` field, or a per-agent dict
  * `{ [k: string]: BehaviorSubject<...> }`. PerAgentStore instances (the
- * Epic 17 `state` / `context`) are NOT BehaviorSubjects and are not counted.
+ * Epic 17 `state` / `context` / `commands`) are NOT BehaviorSubjects and are
+ * not counted.
  */
 function probeStateContainers(service: object): string[] {
   return Object.getOwnPropertyNames(service).filter((name) => {
@@ -755,8 +801,9 @@ function probeStateContainers(service: object): string[] {
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       const values = Object.values(v);
       // Empty dicts cannot be distinguished structurally from other empty
-      // objects, so the empty case is not counted (the only remaining
-      // exception, commandsByAgent$, is a populated BehaviorSubject).
+      // objects, so the empty case is not counted. With commandsByAgent$ now
+      // migrated to the `commands` PerAgentStore (Story 17-3), no bespoke
+      // populated per-agent BehaviorSubject dict remains.
       if (values.length === 0) return false;
       return values.every((x) => x instanceof BehaviorSubject);
     }
@@ -783,15 +830,15 @@ describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NF
     });
   });
 
-  it('public data surface is exactly {commandsByAgent$}', () => {
+  it('public data surface has NO bespoke per-agent BehaviorSubject exception', () => {
     const service = TestBed.inject(ActorMessageService);
     // The probe MUST NOT rely on a name allow-list — it walks
     // `Object.getOwnPropertyNames` with a runtime `instanceof` check so that
     // any new `BehaviorSubject` field (regardless of name) forces this test
-    // to fail. Epic 17 (ADR-014) moved state/context to PerAgentStore
-    // instances; commandsByAgent$ is the last bespoke exception (Story 17-3).
+    // to fail. Epic 17 (ADR-014) moved state/context (17-2) and commands (17-3)
+    // to PerAgentStore instances, so the bespoke-exception set is now EMPTY.
     const containers = probeStateContainers(service);
-    expect(new Set(containers)).toEqual(new Set(['commandsByAgent$']));
+    expect(new Set(containers)).toEqual(new Set([]));
   });
 
   it('negative probe: adding another exception fails the invariant', () => {
@@ -799,9 +846,9 @@ describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NF
     // Simulate the "someone added a new BehaviorSubject" diff.
     (service as any).extraDict$ = { agent: new BehaviorSubject<any>(null) };
     const containers = probeStateContainers(service);
-    // The probe MUST detect the addition (set is no longer the documented
-    // singleton). Without this guard, the invariant test would silently pass.
-    expect(new Set(containers)).not.toEqual(new Set(['commandsByAgent$']));
+    // The probe MUST detect the addition (set is no longer empty). Without
+    // this guard, the invariant test would silently pass.
+    expect(new Set(containers)).not.toEqual(new Set([]));
     expect(containers).toContain('extraDict$');
   });
 

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -7,7 +7,7 @@ import { ActorMessageService } from './message.service';
 import { ApiService } from './api.service';
 import { ChatService } from './chat.service';
 import { MessageLogService } from './message-log.service';
-import { PerAgentStoreRegistry } from './per-agent-store';
+import { PerAgentStore, PerAgentStoreRegistry } from './per-agent-store';
 import { ActorAddress } from '../models/message.types';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
@@ -773,37 +773,39 @@ describe('ActorMessageService — commands PerAgentStore (Story 17-3, ADR-014/AD
 });
 
 // ---------------------------------------------------------------------------
-// Story 6.4 (AC5) — sanctioned-exceptions invariant (NFR9)
+// Epic 17 (ADR-014) — registry-is-the-only-per-agent-owner invariant
 //
-// ADR-005 §Decision 5: stateDict$ / contextDict$ / commandsByAgent$ were the
-// imperative per-agent state containers on ActorMessageService.
-// "Adding an exception requires a new ADR. This test is the automated guard."
-// Epic 17 (ADR-014) migrated `state` + `context` (Story 17-2) and `commands`
-// (Story 17-3) to PerAgentStore instances (folded off log$ by the registry —
-// NOT BehaviorSubject fields), so the probe now sees ZERO bespoke per-agent
-// exceptions. The invariant test itself is RETIRED in Story 17-4; this is the
-// minimal symbol-count adjustment (singleton → empty set) to keep it compiling
-// + green now that the last exception (commandsByAgent$) is gone.
+// Supersedes the retired ADR-005 §Decision 5 "≤2 sanctioned exceptions" probe
+// (Story 6.4, NFR9). With all four per-agent concerns migrated to PerAgentStore
+// instances (state/context — 17-2; commands — 17-3; systemPrompt — 17-4), the
+// "count bespoke exceptions" framing is obsolete. The structural guarantee now
+// is: the four per-agent derived values are PerAgentStore instances owned by
+// the single PerAgentStoreRegistry, and ActorMessageService introduces NO
+// per-agent BehaviorSubject of its own. The negative guard still bites: adding
+// a bespoke per-agent BehaviorSubject field MUST be detected.
+//
+// This is a runtime STRUCTURAL probe (instance types + a BehaviorSubject
+// own-property scan), never a documentation/ADR-string assertion.
 // ---------------------------------------------------------------------------
 
 /**
- * Probe the public surface of an `ActorMessageService` (or subclass) and
- * return the set of own-property names whose runtime shape is an imperative
- * state container — a direct `BehaviorSubject` field, or a per-agent dict
- * `{ [k: string]: BehaviorSubject<...> }`. PerAgentStore instances (the
- * Epic 17 `state` / `context` / `commands`) are NOT BehaviorSubjects and are
- * not counted.
+ * Probe the public surface of an `ActorMessageService` (or subclass) and return
+ * the own-property names whose runtime shape is a bespoke per-agent
+ * `BehaviorSubject` state container — a direct `BehaviorSubject` field, or a
+ * dict `{ [k: string]: BehaviorSubject<...> }`. `PerAgentStore` instances (the
+ * Epic 17 `state` / `context` / `commands` / `systemPrompt`) are NOT
+ * `BehaviorSubject`s and are explicitly NOT counted — they are the sanctioned,
+ * registry-owned mechanism. Probed via `instanceof`, never a name allow-list.
  */
-function probeStateContainers(service: object): string[] {
+function probePerAgentBehaviorSubjects(service: object): string[] {
   return Object.getOwnPropertyNames(service).filter((name) => {
     const v = (service as any)[name];
+    if (v instanceof PerAgentStore) return false;
     if (v instanceof BehaviorSubject) return true;
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       const values = Object.values(v);
       // Empty dicts cannot be distinguished structurally from other empty
-      // objects, so the empty case is not counted. With commandsByAgent$ now
-      // migrated to the `commands` PerAgentStore (Story 17-3), no bespoke
-      // populated per-agent BehaviorSubject dict remains.
+      // objects, so the empty case is not counted.
       if (values.length === 0) return false;
       return values.every((x) => x instanceof BehaviorSubject);
     }
@@ -811,7 +813,7 @@ function probeStateContainers(service: object): string[] {
   });
 }
 
-describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NFR9; ADR-014)', () => {
+describe('ActorMessageService — registry is the only per-agent owner (Epic 17, ADR-014)', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -830,31 +832,36 @@ describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NF
     });
   });
 
-  it('public data surface has NO bespoke per-agent BehaviorSubject exception', () => {
+  it('the four per-agent concerns are registry-owned PerAgentStore instances', () => {
     const service = TestBed.inject(ActorMessageService);
-    // The probe MUST NOT rely on a name allow-list — it walks
-    // `Object.getOwnPropertyNames` with a runtime `instanceof` check so that
-    // any new `BehaviorSubject` field (regardless of name) forces this test
-    // to fail. Epic 17 (ADR-014) moved state/context (17-2) and commands (17-3)
-    // to PerAgentStore instances, so the bespoke-exception set is now EMPTY.
-    const containers = probeStateContainers(service);
+    expect(service.state).toBeInstanceOf(PerAgentStore);
+    expect(service.context).toBeInstanceOf(PerAgentStore);
+    expect(service.commands).toBeInstanceOf(PerAgentStore);
+    expect(service.systemPrompt).toBeInstanceOf(PerAgentStore);
+  });
+
+  it('introduces NO bespoke per-agent BehaviorSubject of its own', () => {
+    const service = TestBed.inject(ActorMessageService);
+    // Runtime structural probe: any per-agent BehaviorSubject field (regardless
+    // of name) would surface here. PerAgentStore instances are not counted —
+    // the registry is the sole per-agent-map owner.
+    const containers = probePerAgentBehaviorSubjects(service);
     expect(new Set(containers)).toEqual(new Set([]));
   });
 
-  it('negative probe: adding another exception fails the invariant', () => {
+  it('negative guard: adding a bespoke per-agent BehaviorSubject fails the probe', () => {
     const service = TestBed.inject(ActorMessageService);
-    // Simulate the "someone added a new BehaviorSubject" diff.
+    // Simulate the regression the old invariant policed: a new per-agent
+    // BehaviorSubject field bypassing the registry.
     (service as any).extraDict$ = { agent: new BehaviorSubject<any>(null) };
-    const containers = probeStateContainers(service);
-    // The probe MUST detect the addition (set is no longer empty). Without
-    // this guard, the invariant test would silently pass.
+    const containers = probePerAgentBehaviorSubjects(service);
     expect(new Set(containers)).not.toEqual(new Set([]));
     expect(containers).toContain('extraDict$');
   });
 
-  it('non-state observables (Subjects, Subscriptions, WebSocketSubject) are NOT counted as exceptions', () => {
+  it('non-state observables (Subjects, Subscriptions, WebSocketSubject) are NOT counted', () => {
     const service = TestBed.inject(ActorMessageService);
-    const containers = probeStateContainers(service);
+    const containers = probePerAgentBehaviorSubjects(service);
     expect(containers).not.toContain('_wsInbound$');
     expect(containers).not.toContain('bufferSub');
     expect(containers).not.toContain('spinnerSub');

--- a/src/app/services/message.service.spec.ts
+++ b/src/app/services/message.service.spec.ts
@@ -7,6 +7,7 @@ import { ActorMessageService } from './message.service';
 import { ApiService } from './api.service';
 import { ChatService } from './chat.service';
 import { MessageLogService } from './message-log.service';
+import { PerAgentStoreRegistry } from './per-agent-store';
 import { ActorAddress } from '../models/message.types';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
@@ -51,6 +52,7 @@ describe('ActorMessageService.init — loadingProcess$ spinner window (Story 4-1
     TestBed.configureTestingModule({
       providers: [
         MessageLogService,
+        PerAgentStoreRegistry,
         ActorMessageService,
         ChatService,
         {
@@ -284,6 +286,7 @@ describe('ActorMessageService — Story 6.1 (frame-batched log ingestion)', () =
     TestBed.configureTestingModule({
       providers: [
         MessageLogService,
+        PerAgentStoreRegistry,
         ActorMessageService,
         ChatService,
         {
@@ -356,8 +359,8 @@ describe('ActorMessageService — Story 6.1 (frame-batched log ingestion)', () =
     sub.unsubscribe();
   });
 
-  // ---------- AC4 ----------
-  it('AC4: batched subscriber updates stateDict$ and contextDict$ in same pass', async () => {
+  // ---------- AC4 (Epic 17) ----------
+  it('AC4: batched frame folds state + context off log$ in same pass', async () => {
     await service.init('proc-1', true);
 
     const stateChanged = {
@@ -406,16 +409,16 @@ describe('ActorMessageService — Story 6.1 (frame-batched log ingestion)', () =
     fakeSocket.next(llmEvent);
     jasmine.clock().tick(17);
 
-    // Both dicts populated by the BATCHED subscriber path.
-    expect(service.stateDict$['agent-X']).toBeDefined();
-    expect(service.stateDict$['agent-X'].value.state).toEqual({ phase: 'thinking' });
-    expect(service.contextDict$['agent-Y']).toBeDefined();
-    // NOTE: PR 1 is parallel populate — the per-__model__ dispatch in
-    // webSocket.subscribe.next ALSO appends to contextDict$ (existing
-    // handleEventMessage). So the ctx array may contain the same message
-    // twice (batched + existing). The invariant we care about for AC4 is
-    // that AT LEAST one update happened in the batched pass.
-    expect(service.contextDict$['agent-Y'].value.length).toBeGreaterThanOrEqual(1);
+    // Epic 17: both stores folded off log$ by the registry's single
+    // subscription — `state` is latest-wins `{ schema, state }`, `context`
+    // is the appended inner `message[]`.
+    expect(service.state.snapshot('agent-X')).toEqual({
+      schema: {},
+      state: { phase: 'thinking' },
+    });
+    expect(service.context.snapshot('agent-Y')).toEqual([
+      { role: 'assistant', content: 'hi' },
+    ]);
     // Log also contains both messages in arrival order.
     expect(log.snapshot().length).toBe(2);
   });
@@ -598,6 +601,7 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
     TestBed.configureTestingModule({
       providers: [
         MessageLogService,
+        PerAgentStoreRegistry,
         ActorMessageService,
         ChatService,
         {
@@ -727,19 +731,22 @@ describe('ActorMessageService — commandsByAgent$ (Story 15-1, ADR-013)', () =>
 // ---------------------------------------------------------------------------
 // Story 6.4 (AC5) — sanctioned-exceptions invariant (NFR9)
 //
-// ADR-005 §Decision 5: stateDict$ and contextDict$ were the ONLY imperative
-// state containers on ActorMessageService after the Story 6.4 refactor.
+// ADR-005 §Decision 5: stateDict$ / contextDict$ / commandsByAgent$ were the
+// imperative per-agent state containers on ActorMessageService.
 // "Adding an exception requires a new ADR. This test is the automated guard."
-// ADR-013 adds a third sanctioned exception, commandsByAgent$ (the per-agent
-// slash-command store driven by CommandsAnnouncedEvent).
+// Epic 17 (ADR-014) migrated `state` and `context` to PerAgentStore instances
+// (folded off log$ by the registry — NOT BehaviorSubject fields), so the probe
+// now sees only the remaining bespoke exception, commandsByAgent$ (Story 17-3
+// migrates it next). The invariant test itself is RETIRED in Story 17-4; this
+// is the minimal symbol-count adjustment to keep it compiling + green.
 // ---------------------------------------------------------------------------
 
 /**
  * Probe the public surface of an `ActorMessageService` (or subclass) and
  * return the set of own-property names whose runtime shape is an imperative
- * state container — either a direct `BehaviorSubject` field, or a per-agent
- * dict `{ [k: string]: BehaviorSubject<...> }` (the `stateDict$` /
- * `contextDict$` shape; counted as ONE exception each, regardless of cardinality).
+ * state container — a direct `BehaviorSubject` field, or a per-agent dict
+ * `{ [k: string]: BehaviorSubject<...> }`. PerAgentStore instances (the
+ * Epic 17 `state` / `context`) are NOT BehaviorSubjects and are not counted.
  */
 function probeStateContainers(service: object): string[] {
   return Object.getOwnPropertyNames(service).filter((name) => {
@@ -747,22 +754,22 @@ function probeStateContainers(service: object): string[] {
     if (v instanceof BehaviorSubject) return true;
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       const values = Object.values(v);
-      // Empty dicts that match the documented dict-name suffix still count
-      // — the contract is structural, not population-dependent.
-      if (values.length === 0) {
-        return /(stateDict|contextDict)\$$/.test(name);
-      }
+      // Empty dicts cannot be distinguished structurally from other empty
+      // objects, so the empty case is not counted (the only remaining
+      // exception, commandsByAgent$, is a populated BehaviorSubject).
+      if (values.length === 0) return false;
       return values.every((x) => x instanceof BehaviorSubject);
     }
     return false;
   });
 }
 
-describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NFR9; ADR-013)', () => {
+describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NFR9; ADR-014)', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         MessageLogService,
+        PerAgentStoreRegistry,
         ActorMessageService,
         ChatService,
         {
@@ -776,29 +783,25 @@ describe('ActorMessageService — sanctioned-exceptions invariant (Story 6.4, NF
     });
   });
 
-  it('public data surface is exactly {stateDict$, contextDict$, commandsByAgent$}', () => {
+  it('public data surface is exactly {commandsByAgent$}', () => {
     const service = TestBed.inject(ActorMessageService);
-    // AC5 spec: the probe MUST NOT rely on a name allow-list — it walks
+    // The probe MUST NOT rely on a name allow-list — it walks
     // `Object.getOwnPropertyNames` with a runtime `instanceof` check so that
     // any new `BehaviorSubject` field (regardless of name) forces this test
-    // to fail. Per ADR-005 §Decision 5, adding an exception requires a new
-    // ADR — ADR-013 sanctioned commandsByAgent$ (the third exception).
+    // to fail. Epic 17 (ADR-014) moved state/context to PerAgentStore
+    // instances; commandsByAgent$ is the last bespoke exception (Story 17-3).
     const containers = probeStateContainers(service);
-    expect(new Set(containers)).toEqual(
-      new Set(['stateDict$', 'contextDict$', 'commandsByAgent$']),
-    );
+    expect(new Set(containers)).toEqual(new Set(['commandsByAgent$']));
   });
 
-  it('negative probe: adding a fourth exception fails the invariant', () => {
+  it('negative probe: adding another exception fails the invariant', () => {
     const service = TestBed.inject(ActorMessageService);
     // Simulate the "someone added a new BehaviorSubject" diff.
     (service as any).extraDict$ = { agent: new BehaviorSubject<any>(null) };
     const containers = probeStateContainers(service);
     // The probe MUST detect the addition (set is no longer the documented
-    // trio). Without this guard, the invariant test would silently pass.
-    expect(new Set(containers)).not.toEqual(
-      new Set(['stateDict$', 'contextDict$', 'commandsByAgent$']),
-    );
+    // singleton). Without this guard, the invariant test would silently pass.
+    expect(new Set(containers)).not.toEqual(new Set(['commandsByAgent$']));
     expect(containers).toContain('extraDict$');
   });
 
@@ -830,6 +833,7 @@ describe('ActorMessageService — Story 8-2 (persistent disconnect toast)', () =
     TestBed.configureTestingModule({
       providers: [
         MessageLogService,
+        PerAgentStoreRegistry,
         ActorMessageService,
         ChatService,
         {
@@ -959,5 +963,240 @@ describe('ActorMessageService — Story 8-2 (persistent disconnect toast)', () =
 
     // flipOnFirstEvent was called — spinner is now false.
     expect(chatService.loadingProcess$.value).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Epic 17 / Story 17-2 (ADR-014) — `state` + `context` PerAgentStore instances
+//
+// Behavior-parity for the migrated state/context surface: the deleted
+// stateDict$ produced `{ schema: {}, state }` latest-wins per agent; the
+// deleted contextDict$ appended the inner `message` per LlmMessageEvent. These
+// tests drive the same fixtures through the live WS path and the REST replay
+// path and assert identical `forAgent`/`snapshot` results, plus automatic
+// reset-on-team-switch and O(Δ) (no per-message re-fold). They drive the real
+// log fold (no store mocking) per the story's testing standards.
+// ---------------------------------------------------------------------------
+
+describe('ActorMessageService — state + context PerAgentStore (Story 17-2)', () => {
+  let service: ActorMessageService;
+  let registry: PerAgentStoreRegistry;
+  let log: MessageLogService;
+  let fakeSocket: Subject<any>;
+
+  function mkStateChanged(agentId: string, state: any, id: string): any {
+    return {
+      id,
+      parent_id: null,
+      team_id: 'team-X',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: makeAddress({ name: '@' + agentId, agent_id: agentId }),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.StateChangedMessage',
+      state,
+    };
+  }
+
+  function mkLlmEvent(agentId: string, message: any, id: string): any {
+    return {
+      id,
+      parent_id: null,
+      team_id: 'team-X',
+      timestamp: '2026-06-13T00:00:00Z',
+      sender: makeAddress({ name: '@' + agentId, agent_id: agentId }),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      event: {
+        __model__: 'akgentic.llm.event.LlmMessageEvent',
+        message,
+      },
+    };
+  }
+
+  /** An EventMessage carrying an LlmMessageEvent with NO inner message — must
+   *  be skipped by the context spec (mirrors the old guard). */
+  function mkLlmEventNoMessage(agentId: string, id: string): any {
+    const e = mkLlmEvent(agentId, null, id);
+    delete e.event.message;
+    return e;
+  }
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+
+    fakeSocket = new Subject<any>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MessageLogService,
+        PerAgentStoreRegistry,
+        ActorMessageService,
+        ChatService,
+        {
+          provide: ApiService,
+          useValue: {
+            getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+          },
+        },
+        { provide: MessageService, useValue: { add: jasmine.createSpy('add'), clear: jasmine.createSpy('clear') } },
+      ],
+    });
+    service = TestBed.inject(ActorMessageService);
+    registry = TestBed.inject(PerAgentStoreRegistry);
+    log = TestBed.inject(MessageLogService);
+
+    spyOn<any>(service, 'createWebSocket').and.returnValue(
+      fakeSocket as unknown as WebSocketSubject<any>,
+    );
+  });
+
+  afterEach(() => {
+    try {
+      fakeSocket.complete();
+    } catch {
+      /* already closed */
+    }
+    jasmine.clock().uninstall();
+  });
+
+  it('AC1: state is latest-wins {schema:{}, state}; context is the appended inner message[]', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkStateChanged('agent-X', { phase: 'a' }, 's1'));
+    fakeSocket.next(mkStateChanged('agent-X', { phase: 'b' }, 's2'));
+    fakeSocket.next(mkLlmEvent('agent-X', { role: 'user', content: 'hi' }, 'e1'));
+    fakeSocket.next(
+      mkLlmEvent('agent-X', { role: 'assistant', content: 'yo' }, 'e2'),
+    );
+    jasmine.clock().tick(17);
+
+    // state: latest-wins, schema is an empty object literal exactly as the old
+    // dict produced.
+    expect(service.state.snapshot('agent-X')).toEqual({
+      schema: {},
+      state: { phase: 'b' },
+    });
+    // context: ordered array of the inner `message` objects.
+    expect(service.context.snapshot('agent-X')).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'yo' },
+    ]);
+  });
+
+  it('AC1: an LlmMessageEvent with no inner message is skipped (mirror old guard)', async () => {
+    await service.init('proc-1', true);
+
+    fakeSocket.next(mkLlmEventNoMessage('agent-X', 'e0'));
+    fakeSocket.next(mkLlmEvent('agent-X', { role: 'user', content: 'kept' }, 'e1'));
+    jasmine.clock().tick(17);
+
+    expect(service.context.snapshot('agent-X')).toEqual([
+      { role: 'user', content: 'kept' },
+    ]);
+  });
+
+  it('AC4: stopped-team REST replay yields the SAME state/context as the live WS path', async () => {
+    // Live WS ingestion of a fixture sequence.
+    await service.init('proc-live', true);
+    fakeSocket.next(mkStateChanged('A', { v: 1 }, 's1'));
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'm1' }, 'e1'));
+    fakeSocket.next(mkStateChanged('A', { v: 2 }, 's2'));
+    fakeSocket.next(mkLlmEvent('B', { role: 'user', content: 'm2' }, 'e2'));
+    jasmine.clock().tick(17);
+    const liveStateA = service.state.snapshot('A');
+    const liveCtxA = service.context.snapshot('A');
+    const liveCtxB = service.context.snapshot('B');
+
+    // REST replay of the SAME ordered events as one getEvents() batch.
+    const apiService = TestBed.inject(ApiService) as any;
+    apiService.getEvents.and.resolveTo([
+      { event: mkStateChanged('A', { v: 1 }, 'r-s1') },
+      { event: mkLlmEvent('A', { role: 'user', content: 'm1' }, 'r-e1') },
+      { event: mkStateChanged('A', { v: 2 }, 'r-s2') },
+      { event: mkLlmEvent('B', { role: 'user', content: 'm2' }, 'r-e2') },
+    ]);
+    const socketB = new Subject<any>();
+    (service as any).createWebSocket = jasmine
+      .createSpy('createWebSocket')
+      .and.returnValue(socketB as unknown as WebSocketSubject<any>);
+    await service.init('proc-stopped', false);
+
+    expect(service.state.snapshot('A')).toEqual(liveStateA);
+    expect(service.context.snapshot('A')).toEqual(liveCtxA);
+    expect(service.context.snapshot('B')).toEqual(liveCtxB);
+    expect(service.state.snapshot('A')).toEqual({ schema: {}, state: { v: 2 } });
+    socketB.complete();
+  });
+
+  it('AC5: a team switch (init reset) clears state/context — no process-A leak into process-B', async () => {
+    await service.init('proc-A', true);
+    fakeSocket.next(mkStateChanged('A', { v: 1 }, 's1'));
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'm1' }, 'e1'));
+    jasmine.clock().tick(17);
+    expect(service.state.snapshot('A')).toEqual({ schema: {}, state: { v: 1 } });
+    expect(service.context.snapshot('A')).toEqual([
+      { role: 'user', content: 'm1' },
+    ]);
+
+    // Re-init (team switch) → log.reset() → registry clears its maps.
+    const socketB = new Subject<any>();
+    (service as any).createWebSocket = jasmine
+      .createSpy('createWebSocket')
+      .and.returnValue(socketB as unknown as WebSocketSubject<any>);
+    await service.init('proc-B', true);
+
+    expect(service.state.snapshot('A')).toBeUndefined();
+    expect(service.context.snapshot('A')).toBeUndefined();
+    socketB.complete();
+  });
+
+  it('AC6: context append is O(Δ)/frame — cursor advances by tail length, no re-fold', async () => {
+    await service.init('proc-1', true);
+
+    // Frame 1: two messages → cursor advances by 2.
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'm1' }, 'e1'));
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'm2' }, 'e2'));
+    jasmine.clock().tick(17);
+    expect(registry.cursor).toBe(2);
+
+    // Frame 2: one more message → cursor advances by exactly 1 (only the new
+    // tail is folded; the prior two are NOT re-walked).
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'm3' }, 'e3'));
+    jasmine.clock().tick(17);
+    expect(registry.cursor).toBe(3);
+    expect(service.context.snapshot('A')).toEqual([
+      { role: 'user', content: 'm1' },
+      { role: 'user', content: 'm2' },
+      { role: 'user', content: 'm3' },
+    ]);
+  });
+
+  it('AC7: state/context are PerAgentStore instances, NOT BehaviorSubject fields', () => {
+    // The bespoke dicts are gone; no `stateDict$` / `contextDict$` own property.
+    expect((service as any).stateDict$).toBeUndefined();
+    expect((service as any).contextDict$).toBeUndefined();
+    // The migrated surface exposes forAgent/snapshot, not a dict of subjects.
+    expect(typeof service.state.forAgent).toBe('function');
+    expect(typeof service.context.forAgent).toBe('function');
+  });
+
+  it('AC2/AC3: forAgent delivers the current value to a late subscriber (shareReplay)', async () => {
+    await service.init('proc-1', true);
+    fakeSocket.next(mkStateChanged('A', { v: 9 }, 's1'));
+    fakeSocket.next(mkLlmEvent('A', { role: 'user', content: 'late' }, 'e1'));
+    jasmine.clock().tick(17);
+
+    let state: any = 'unset';
+    let ctx: any = 'unset';
+    const subS = service.state.forAgent('A').subscribe((v) => (state = v));
+    const subC = service.context.forAgent('A').subscribe((v) => (ctx = v));
+    // Late subscribe still sees the current value immediately.
+    expect(state).toEqual({ schema: {}, state: { v: 9 } });
+    expect(ctx).toEqual([{ role: 'user', content: 'late' }]);
+    subS.unsubscribe();
+    subC.unsubscribe();
   });
 });

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -7,14 +7,47 @@ import { ConfigService } from './config.service';
 import {
   AkgenticMessage,
   CommandDescriptor,
+  EventMessage,
   isCommandsAnnouncedEvent,
+  isEventMessage,
+  isStateChangedMessage,
+  StateChangedMessage,
 } from '../models/message.types';
 import { EventResponse } from '../models/team.interface';
 
 import { ApiService } from '../services/api.service';
 import { ChatService } from './chat.service';
 import { MessageLogService } from './message-log.service';
+import {
+  appendWith,
+  PerAgentStore,
+  PerAgentStoreRegistry,
+  replaceWith,
+} from './per-agent-store';
 import { MessageService } from 'primeng/api';
+
+/**
+ * Per-agent `state` value shape (Epic 17 / ADR-014 §5). Mirrors what the
+ * deleted `stateDict$` produced for `AkgentStateComponent.generateForm`:
+ * V2 sends an empty schema and the raw state is rendered as JSON.
+ */
+interface AgentStateValue {
+  schema: object;
+  state: unknown;
+}
+
+/**
+ * Inner-event reader for the `context` instance (Epic 17 / ADR-014 §5).
+ * Mirrors the exact predicate the deleted `applyEventMessageDicts` /
+ * replay loop used: an `EventMessage` whose inner `__model__` includes
+ * `LlmMessageEvent` AND whose inner `message` is present. Returns the inner
+ * `message` to append, or `undefined` when the guard does not hold.
+ */
+function innerLlmMessage(msg: AkgenticMessage): unknown {
+  const inner = (msg as EventMessage).event;
+  if (!inner?.__model__?.includes('LlmMessageEvent')) return undefined;
+  return inner.message ?? undefined;
+}
 
 /**
  * Story 4-10 (AC7): minimum visible duration of the loading spinner.
@@ -25,21 +58,20 @@ import { MessageService } from 'primeng/api';
 const SPINNER_MIN_VISIBLE_MS = 500;
 
 /**
- * `ActorMessageService` — minimal ingestion surface (post Story 6.4):
- *   - REST init replays events into `MessageLogService.log$` and seeds the
- *     two per-agent exception dicts (`stateDict$`, `contextDict$`).
- *   - WS `bufferTime(16)` ingestion appends to the log + per-agent dicts.
+ * `ActorMessageService` — minimal ingestion surface (post Story 6.4 / Epic 17):
+ *   - REST init replays events into `MessageLogService.log$`; the registry
+ *     folds that replay tail exactly as it folds live WS frames.
+ *   - WS `bufferTime(16)` ingestion appends to the log; the registry derives
+ *     per-agent `state` / `context` from `log$` (O(Δ), automatic replay/reset).
  *   - Spinner floor (`loadingProcess$` on `ChatService`, AC7) — UX concern.
  *
- * Three documented exceptions (NFR9 / ADR-005 §Decision 5; ADR-013):
- *   - `stateDict$`       — driven by `StateChangedMessage`
- *   - `contextDict$`     — driven by `LlmMessageEvent`
- *   - `commandsByAgent$` — driven by `CommandsAnnouncedEvent` (ADR-013); the
- *     per-agent slash-command store consumed by the `/` mention. ADR-005
- *     §Decision 5 requires a new ADR to add an exception — ADR-013 is that ADR.
- *
- * Adding a fourth exception requires a new ADR.
- * `message.service.spec.ts` enforces this invariant by test (Story 6.4 AC5).
+ * Per-agent state (Epic 17 / ADR-014): `state` and `context` are now
+ * `PerAgentStore` instances owned by the component-scoped
+ * `PerAgentStoreRegistry` (single `log$` subscription, replay + reset for
+ * free). `commandsByAgent$` remains the last bespoke per-agent exception
+ * (driven by `CommandsAnnouncedEvent`, ADR-013) until Story 17-3 migrates it.
+ * `message.service.spec.ts` enforces the remaining-exception invariant by test
+ * (its full retirement is Story 17-4).
  */
 @Injectable()
 export class ActorMessageService {
@@ -57,10 +89,46 @@ export class ActorMessageService {
    */
   private log: MessageLogService = inject(MessageLogService);
 
+  /**
+   * Epic 17 (ADR-014): component-scoped registry that folds `log$` into the
+   * per-agent `state` / `context` maps (single subscription, O(Δ), automatic
+   * replay + reset). Provided on `ProcessComponent` alongside
+   * `MessageLogService`. Owns the maps the deleted dicts used to hold.
+   */
+  private registry: PerAgentStoreRegistry = inject(PerAgentStoreRegistry);
+
   webSocket: WebSocketSubject<any> = new WebSocketSubject({ url: '' });
 
-  contextDict$: { [key: string]: BehaviorSubject<any[]> } = {};
-  stateDict$: { [key: string]: BehaviorSubject<any> } = {};
+  /**
+   * Epic 17 (ADR-014 §5): per-agent latest `{ schema, state }` derived from
+   * `StateChangedMessage`. Replaces the bespoke `stateDict$`. Default key
+   * `sender.agent_id`; `schema` is an empty object literal exactly as before
+   * (V2 sends an empty schema; raw state rendered as JSON). Read via
+   * `state.forAgent(id)`.
+   */
+  readonly state: PerAgentStore<AgentStateValue> =
+    this.registry.register<AgentStateValue>({
+      name: 'state',
+      match: isStateChangedMessage,
+      reduce: replaceWith<AgentStateValue>((m) => ({
+        schema: {},
+        state: (m as StateChangedMessage).state,
+      })),
+    });
+
+  /**
+   * Epic 17 (ADR-014 §5): per-agent ordered conversation array derived by
+   * appending each `LlmMessageEvent` envelope's inner `message`. Replaces the
+   * bespoke `contextDict$`. Default key `sender.agent_id`; the append is
+   * O(Δ)/frame (the registry walks only `log.slice(processedCount)` and
+   * `appendWith` concats once per new message). Read via `context.forAgent(id)`.
+   */
+  readonly context: PerAgentStore<unknown[]> =
+    this.registry.register<unknown[]>({
+      name: 'context',
+      match: (m) => isEventMessage(m) && innerLlmMessage(m) !== undefined,
+      reduce: appendWith((m) => innerLlmMessage(m)),
+    });
 
   /**
    * ADR-013 (third NFR9 exception): per-agent slash-command store, keyed by
@@ -127,11 +195,11 @@ export class ActorMessageService {
     // `resetForTeam()` calls required.
 
     // --- ADR-005 §Decision 6 step (b) ---------------------------------
-    // Reset the log and clear the per-agent exception dicts BEFORE any
-    // replay / WS wiring so process-A state cannot leak into process-B.
+    // Reset the log BEFORE any replay / WS wiring so process-A state cannot
+    // leak into process-B. Epic 17 (ADR-014 §Decision 3): the `state` /
+    // `context` registry detects this log shrink, clears its maps, and rewinds
+    // its cursor automatically — no bespoke per-store reset needed.
     this.log.reset();
-    this.stateDict$ = {};
-    this.contextDict$ = {};
     // ADR-013: clear the per-agent slash-command store so process-A's
     // announced commands cannot leak into process-B.
     this.commandsByAgent$.next({});
@@ -157,67 +225,35 @@ export class ActorMessageService {
         await this.apiService.getEvents(processId);
 
       // --- ADR-005 §Decision 6 step (c) -------------------------------
-      // log.appendAll runs FIRST (atomic snapshot of the full replay),
-      // BEFORE per-dict seeding. Story 6.1 Task 3.2 documents this choice:
-      // selectors in PR 2/3 fold `log$`; the per-agent dicts are imperative
-      // side state and are seeded by the loop below in the same synchronous
-      // pass.
+      // log.appendAll is the ONLY replay seeding for state/context now.
+      // Epic 17 (ADR-014 §Decision 3): the registry folds this replay tail
+      // exactly as it folds live WS frames, so `state` / `context` are
+      // reconstructed for free — replay is just another `log$` tail. The
+      // bespoke `latestStates` / `contextArrays` reconstruction is deleted.
       const replayMessages: AkgenticMessage[] = eventResponses
         .map((er: EventResponse) => er.event as AkgenticMessage)
         .filter((evt) => !!evt && !!evt.__model__);
       this.log.appendAll(replayMessages);
 
-      // Reconstruct stateDict$ and contextDict$ from persisted events.
-      // Events arrive sorted by sequence (ascending) from the API.
-      // - StateChangedMessage: later events overwrite earlier (keeps latest state per agent)
-      // - LlmMessageEvent: messages appended in chronological order (ordered context)
-      const latestStates: { [agentId: string]: any } = {};
-      const contextArrays: { [agentId: string]: any[] } = {};
-      // ADR-013: rebuild the per-agent slash-command store from persisted
-      // events too, so a stopped-team reopen still shows the `/` list. Keyed
-      // by agent friendly name; a later replay event REPLACES the entry
-      // (consistent with the live replace-on-reannounce semantics).
+      // ADR-013 (Story 17-3 scope): rebuild the per-agent slash-command store
+      // from persisted events so a stopped-team reopen still shows the `/`
+      // list. Keyed by agent friendly name; a later replay event REPLACES the
+      // entry (consistent with the live replace-on-reannounce semantics).
       const commandsByAgent: Record<string, CommandDescriptor[]> = {};
 
       for (const er of eventResponses) {
         const evt = er.event;
         if (!evt || !evt.__model__) continue;
-
-        if (evt.__model__.includes('StateChangedMessage')) {
-          const agentId = evt.sender?.agent_id;
-          if (agentId) {
-            latestStates[agentId] = evt.state;
-          }
-        } else if (evt.__model__.includes('EventMessage')) {
-          const inner = evt.event;
-          if (inner?.__model__?.includes('LlmMessageEvent')) {
-            const agentId = evt.sender?.agent_id;
-            if (agentId && inner.message) {
-              if (!contextArrays[agentId]) contextArrays[agentId] = [];
-              contextArrays[agentId].push(inner.message);
-            }
-          } else if (isCommandsAnnouncedEvent(inner)) {
-            const agentName = inner.agent?.name;
-            if (agentName) commandsByAgent[agentName] = inner.commands ?? [];
-          }
-          // Story 6.2 (ADR-005 §Decision 4): `ToolStateEvent` is now folded
-          // into `knowledgeGraph$` via `kgFold` over `log$` (seeded above by
-          // `log.appendAll`). No explicit reducer drive required.
+        if (!evt.__model__.includes('EventMessage')) continue;
+        const inner = evt.event;
+        if (isCommandsAnnouncedEvent(inner)) {
+          const agentName = inner.agent?.name;
+          if (agentName) commandsByAgent[agentName] = inner.commands ?? [];
         }
       }
 
       if (Object.keys(commandsByAgent).length > 0) {
         this.commandsByAgent$.next(commandsByAgent);
-      }
-
-      for (const [agentId, state] of Object.entries(latestStates)) {
-        this.initDict(this.stateDict$, agentId, null);
-        this.stateDict$[agentId].next({ schema: {}, state });
-      }
-
-      for (const [agentId, msgs] of Object.entries(contextArrays)) {
-        this.initDict(this.contextDict$, agentId, []);
-        this.contextDict$[agentId].next(msgs);
       }
 
       // Story 6.4 (AC1): `GRAPH_RELEVANT_MODELS` filtering and the
@@ -362,9 +398,9 @@ export class ActorMessageService {
    * Story 6.1 (ADR-005 §Decision 3 + §Decision 5): frame-batched consumer
    * of the raw WS inbound stream. `bufferTime(16)` coalesces every message
    * that lands in a single 16ms window into one `log.appendAll` call and
-   * one `log$` emission (AC3). Per-agent exception-dict updates
-   * (`stateDict$`, `contextDict$`) run in the SAME synchronous pass inside
-   * the subscriber callback (AC4).
+   * one `log$` emission (AC3). Epic 17 (ADR-014): `state` / `context` are now
+   * folded off `log$` by the registry, so the only remaining per-message
+   * dispatch is the `commandsByAgent$` arm (Story 17-3 scope).
    */
   private setupBatchedSubscriber(): void {
     this.bufferSub = this._wsInbound$
@@ -376,9 +412,7 @@ export class ActorMessageService {
         this.log.appendAll(batch);
         for (const msg of batch) {
           if (!msg.__model__) continue;
-          if (msg.__model__.includes('StateChangedMessage')) {
-            this.applyStateChanged(msg as any);
-          } else if (msg.__model__.includes('EventMessage')) {
+          if (msg.__model__.includes('EventMessage')) {
             this.applyEventMessageDicts(msg as any);
           }
         }
@@ -399,40 +433,18 @@ export class ActorMessageService {
   }
 
   /**
-   * Story 6.1 (Task 2.4): apply a `StateChangedMessage` to `stateDict$`.
-   * Extracted from the bufferSub callback to keep the subscribe body <10
-   * LoC (CLAUDE.md ~50-line ceiling).
-   */
-  private applyStateChanged(event: any): void {
-    const agentId = event?.sender?.agent_id;
-    if (!agentId) return;
-    this.initDict(this.stateDict$, agentId, null);
-    this.stateDict$[agentId].next({ schema: {}, state: event.state });
-  }
-
-  /**
-   * Story 6.1 (Task 2.4): apply an `EventMessage` carrying an
-   * `LlmMessageEvent` / `ToolStateEvent` to the exception dicts and to the
-   * KG reducer. Story 6.4 made the batched subscriber the SOLE producer of
-   * dict updates (the parallel per-message dispatch in `webSocket.subscribe`
-   * has been deleted).
+   * Story 6.1 (Task 2.4) / Epic 17 (ADR-014): apply the inner-event arms of
+   * an `EventMessage` that are NOT yet folded off `log$`. The `LlmMessageEvent`
+   * arm has been deleted — `context` is now a `PerAgentStore` instance. Only
+   * the `CommandsAnnouncedEvent` arm remains (Story 17-3 scope). `ToolStateEvent`
+   * is covered by `KGStateReducer.knowledgeGraph$` (pure selector over `log$`).
    */
   private applyEventMessageDicts(event: any): void {
     const inner = event?.event;
     if (!inner?.__model__) return;
-    if (inner.__model__.includes('LlmMessageEvent')) {
-      const agentId = event.sender?.agent_id;
-      if (agentId && inner.message) {
-        this.initDict(this.contextDict$, agentId, []);
-        const current = this.contextDict$[agentId].getValue();
-        this.contextDict$[agentId].next([...current, inner.message]);
-      }
-    } else if (isCommandsAnnouncedEvent(inner)) {
+    if (isCommandsAnnouncedEvent(inner)) {
       this.applyCommandsAnnounced(inner);
     }
-    // Story 6.2 (ADR-005 §Decision 4): `ToolStateEvent` is now covered
-    // entirely by `KGStateReducer.knowledgeGraph$` (pure selector over
-    // `log$`). The batched subscriber no longer drives the reducer.
   }
 
   /**
@@ -514,15 +526,6 @@ export class ActorMessageService {
       sticky: true,
       closable: false,
     });
-  }
-
-  initDict(
-    dict: { [key: string]: BehaviorSubject<any[]> },
-    key: string,
-    defaultValue: any
-  ) {
-    if (dict[key]) return;
-    dict[key] = new BehaviorSubject<any>(defaultValue);
   }
 
   ngOnDestroy() {

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -1,12 +1,13 @@
 import { inject, Injectable } from '@angular/core';
 
-import { BehaviorSubject, Subject, Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { bufferTime, filter, take } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { ConfigService } from './config.service';
 import {
   AkgenticMessage,
   CommandDescriptor,
+  CommandsAnnouncedEvent,
   EventMessage,
   isCommandsAnnouncedEvent,
   isEventMessage,
@@ -50,6 +51,19 @@ function innerLlmMessage(msg: AkgenticMessage): unknown {
 }
 
 /**
+ * Inner-event reader for the `commands` instance (Epic 17 / ADR-014 §5).
+ * Mirrors `innerLlmMessage`: reads the inner `event` of an `EventMessage` and
+ * returns it iff it passes `isCommandsAnnouncedEvent`, else `undefined`. Keeps
+ * the `commands` spec's `match` and `reduce` reading the SAME inner payload.
+ */
+function innerCommandsEvent(
+  msg: AkgenticMessage,
+): CommandsAnnouncedEvent | undefined {
+  const inner = (msg as EventMessage).event;
+  return isCommandsAnnouncedEvent(inner) ? inner : undefined;
+}
+
+/**
  * Story 4-10 (AC7): minimum visible duration of the loading spinner.
  * When the first event / WS error / stopped-team replay lands before this
  * floor, the flip to `loadingProcess$.next(false)` is deferred so users
@@ -65,13 +79,13 @@ const SPINNER_MIN_VISIBLE_MS = 500;
  *     per-agent `state` / `context` from `log$` (O(Δ), automatic replay/reset).
  *   - Spinner floor (`loadingProcess$` on `ChatService`, AC7) — UX concern.
  *
- * Per-agent state (Epic 17 / ADR-014): `state` and `context` are now
- * `PerAgentStore` instances owned by the component-scoped
+ * Per-agent state (Epic 17 / ADR-014): `state`, `context`, and `commands` are
+ * all `PerAgentStore` instances owned by the component-scoped
  * `PerAgentStoreRegistry` (single `log$` subscription, replay + reset for
- * free). `commandsByAgent$` remains the last bespoke per-agent exception
- * (driven by `CommandsAnnouncedEvent`, ADR-013) until Story 17-3 migrates it.
- * `message.service.spec.ts` enforces the remaining-exception invariant by test
- * (its full retirement is Story 17-4).
+ * free). Story 17-3 migrated `commands` (driven by `CommandsAnnouncedEvent`,
+ * ADR-013) off the bespoke `commandsByAgent$` `BehaviorSubject` and re-keyed it
+ * by `sender.agent_id`, removing the last per-agent dict exception. Only the
+ * `SystemPromptSelector` façade remains pending (Story 17-4).
  */
 @Injectable()
 export class ActorMessageService {
@@ -131,16 +145,26 @@ export class ActorMessageService {
     });
 
   /**
-   * ADR-013 (third NFR9 exception): per-agent slash-command store, keyed by
-   * agent friendly name (the `@`-prefixed actor `name`, e.g. `@Manager`).
-   * Driven by `CommandsAnnouncedEvent` riding the existing `EventMessage`
-   * passthrough; a later event for an agent REPLACES that agent's entry (the
-   * backend re-emits the full list on change). Consumed by the `/` mention's
-   * targeted-agent selector. Reset on every `init()` alongside the other
-   * per-team dicts.
+   * Epic 17 (ADR-014 §5): per-agent slash-command store derived from
+   * `CommandsAnnouncedEvent` riding the `EventMessage` passthrough. Replaces
+   * the bespoke `commandsByAgent$`. Default key `sender.agent_id` (ADR-013
+   * keying fix — the emitting agent is the outer sender, so
+   * `sender.agent_id === inner.agent.agent_id`, ADR-014 §2), so a fired/re-hired
+   * display-name reuse can never serve the wrong agent's commands. `replaceWith`
+   * gives the same replace-on-re-announce semantics the backend relies on (the
+   * full list is re-emitted on change). Read via `commands.forAgent(id)` /
+   * `commands.snapshot(id)` by the `/` mention consumers.
    */
-  commandsByAgent$: BehaviorSubject<Record<string, CommandDescriptor[]>> =
-    new BehaviorSubject<Record<string, CommandDescriptor[]>>({});
+  readonly commands: PerAgentStore<CommandDescriptor[]> =
+    this.registry.register<CommandDescriptor[]>({
+      name: 'commands',
+      match: (m) =>
+        isEventMessage(m) &&
+        isCommandsAnnouncedEvent((m as EventMessage).event),
+      reduce: replaceWith<CommandDescriptor[]>(
+        (m) => innerCommandsEvent(m)?.commands ?? [],
+      ),
+    });
 
   processId: string = '';
 
@@ -197,12 +221,9 @@ export class ActorMessageService {
     // --- ADR-005 §Decision 6 step (b) ---------------------------------
     // Reset the log BEFORE any replay / WS wiring so process-A state cannot
     // leak into process-B. Epic 17 (ADR-014 §Decision 3): the `state` /
-    // `context` registry detects this log shrink, clears its maps, and rewinds
-    // its cursor automatically — no bespoke per-store reset needed.
+    // `context` / `commands` registry detects this log shrink, clears its maps,
+    // and rewinds its cursor automatically — no bespoke per-store reset needed.
     this.log.reset();
-    // ADR-013: clear the per-agent slash-command store so process-A's
-    // announced commands cannot leak into process-B.
-    this.commandsByAgent$.next({});
 
     // Story 8-2: clear any stale toasts from a prior init() cycle
     // so process-A's warnings do not persist into process-B.
@@ -225,36 +246,16 @@ export class ActorMessageService {
         await this.apiService.getEvents(processId);
 
       // --- ADR-005 §Decision 6 step (c) -------------------------------
-      // log.appendAll is the ONLY replay seeding for state/context now.
-      // Epic 17 (ADR-014 §Decision 3): the registry folds this replay tail
-      // exactly as it folds live WS frames, so `state` / `context` are
-      // reconstructed for free — replay is just another `log$` tail. The
-      // bespoke `latestStates` / `contextArrays` reconstruction is deleted.
+      // log.appendAll is the ONLY replay seeding now. Epic 17 (ADR-014
+      // §Decision 3): the registry folds this replay tail exactly as it folds
+      // live WS frames, so `state` / `context` / `commands` are reconstructed
+      // for free — replay is just another `log$` tail. The bespoke
+      // `latestStates` / `contextArrays` / `commandsByAgent` reconstruction
+      // loops are deleted (Story 17-2 / 17-3).
       const replayMessages: AkgenticMessage[] = eventResponses
         .map((er: EventResponse) => er.event as AkgenticMessage)
         .filter((evt) => !!evt && !!evt.__model__);
       this.log.appendAll(replayMessages);
-
-      // ADR-013 (Story 17-3 scope): rebuild the per-agent slash-command store
-      // from persisted events so a stopped-team reopen still shows the `/`
-      // list. Keyed by agent friendly name; a later replay event REPLACES the
-      // entry (consistent with the live replace-on-reannounce semantics).
-      const commandsByAgent: Record<string, CommandDescriptor[]> = {};
-
-      for (const er of eventResponses) {
-        const evt = er.event;
-        if (!evt || !evt.__model__) continue;
-        if (!evt.__model__.includes('EventMessage')) continue;
-        const inner = evt.event;
-        if (isCommandsAnnouncedEvent(inner)) {
-          const agentName = inner.agent?.name;
-          if (agentName) commandsByAgent[agentName] = inner.commands ?? [];
-        }
-      }
-
-      if (Object.keys(commandsByAgent).length > 0) {
-        this.commandsByAgent$.next(commandsByAgent);
-      }
 
       // Story 6.4 (AC1): `GRAPH_RELEVANT_MODELS` filtering and the
       // `createAgentGraph$` / `messages$` emits below are deleted along with
@@ -398,9 +399,9 @@ export class ActorMessageService {
    * Story 6.1 (ADR-005 §Decision 3 + §Decision 5): frame-batched consumer
    * of the raw WS inbound stream. `bufferTime(16)` coalesces every message
    * that lands in a single 16ms window into one `log.appendAll` call and
-   * one `log$` emission (AC3). Epic 17 (ADR-014): `state` / `context` are now
-   * folded off `log$` by the registry, so the only remaining per-message
-   * dispatch is the `commandsByAgent$` arm (Story 17-3 scope).
+   * one `log$` emission (AC3). Epic 17 (ADR-014): `state` / `context` /
+   * `commands` are all folded off `log$` by the registry, so there is no
+   * remaining per-message dispatch — the batched subscriber only feeds the log.
    */
   private setupBatchedSubscriber(): void {
     this.bufferSub = this._wsInbound$
@@ -410,12 +411,6 @@ export class ActorMessageService {
       )
       .subscribe((batch: AkgenticMessage[]) => {
         this.log.appendAll(batch);
-        for (const msg of batch) {
-          if (!msg.__model__) continue;
-          if (msg.__model__.includes('EventMessage')) {
-            this.applyEventMessageDicts(msg as any);
-          }
-        }
       });
   }
 
@@ -430,41 +425,6 @@ export class ActorMessageService {
     this.spinnerSub = this._wsInbound$
       .pipe(take(1))
       .subscribe(() => this.scheduleSpinnerFlipFalse());
-  }
-
-  /**
-   * Story 6.1 (Task 2.4) / Epic 17 (ADR-014): apply the inner-event arms of
-   * an `EventMessage` that are NOT yet folded off `log$`. The `LlmMessageEvent`
-   * arm has been deleted — `context` is now a `PerAgentStore` instance. Only
-   * the `CommandsAnnouncedEvent` arm remains (Story 17-3 scope). `ToolStateEvent`
-   * is covered by `KGStateReducer.knowledgeGraph$` (pure selector over `log$`).
-   */
-  private applyEventMessageDicts(event: any): void {
-    const inner = event?.event;
-    if (!inner?.__model__) return;
-    if (isCommandsAnnouncedEvent(inner)) {
-      this.applyCommandsAnnounced(inner);
-    }
-  }
-
-  /**
-   * ADR-013: fold a `CommandsAnnouncedEvent` into `commandsByAgent$`. Keyed by
-   * the announcing agent's friendly `name` (the `@`-prefixed actor name, which
-   * the `/`-mention selector matches against the Send-to / panel agent). A
-   * later event for the same agent REPLACES that agent's entry. Ignored when
-   * the event carries no agent name (defensive — never partially populate).
-   */
-  private applyCommandsAnnounced(inner: {
-    agent?: { name?: string };
-    commands?: CommandDescriptor[];
-  }): void {
-    const agentName = inner.agent?.name;
-    if (!agentName) return;
-    const current = this.commandsByAgent$.getValue();
-    this.commandsByAgent$.next({
-      ...current,
-      [agentName]: inner.commands ?? [],
-    });
   }
 
   /**
@@ -552,9 +512,9 @@ export class ActorMessageService {
     this.bufferSub?.unsubscribe();
     this.spinnerSub?.unsubscribe();
     this._wsInbound$.complete();
-    // ADR-013: complete the slash-command store on teardown so no leaked
-    // subscriber survives the component.
-    this.commandsByAgent$.complete();
+    // Epic 17 (ADR-014): the `commands` store is owned by the registry; its
+    // single `log$` subscription is torn down by `PerAgentStoreRegistry`'s own
+    // ngOnDestroy — no per-store completion needed here.
     if (this.spinnerFlipTimer !== null) {
       clearTimeout(this.spinnerFlipTimer);
       this.spinnerFlipTimer = null;

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -25,6 +25,11 @@ import {
   PerAgentStoreRegistry,
   replaceWith,
 } from './per-agent-store';
+import {
+  SystemPromptValue,
+  systemPromptMatch,
+  systemPromptReduce,
+} from './system-prompt.selector';
 import { MessageService } from 'primeng/api';
 
 /**
@@ -79,13 +84,18 @@ const SPINNER_MIN_VISIBLE_MS = 500;
  *     per-agent `state` / `context` from `log$` (O(Δ), automatic replay/reset).
  *   - Spinner floor (`loadingProcess$` on `ChatService`, AC7) — UX concern.
  *
- * Per-agent state (Epic 17 / ADR-014): `state`, `context`, and `commands` are
- * all `PerAgentStore` instances owned by the component-scoped
- * `PerAgentStoreRegistry` (single `log$` subscription, replay + reset for
- * free). Story 17-3 migrated `commands` (driven by `CommandsAnnouncedEvent`,
- * ADR-013) off the bespoke `commandsByAgent$` `BehaviorSubject` and re-keyed it
- * by `sender.agent_id`, removing the last per-agent dict exception. Only the
- * `SystemPromptSelector` façade remains pending (Story 17-4).
+ * Per-agent state (Epic 17 / ADR-014): `state`, `context`, `commands`, and
+ * `systemPrompt` are ALL `PerAgentStore` instances owned by the
+ * component-scoped `PerAgentStoreRegistry` (single `log$` subscription, replay +
+ * reset for free). Story 17-3 migrated `commands` (driven by
+ * `CommandsAnnouncedEvent`, ADR-013) off the bespoke `commandsByAgent$`
+ * `BehaviorSubject` and re-keyed it by `sender.agent_id`. Story 17-4 migrated
+ * the last per-agent concern — the system-prompt head block — onto the
+ * `systemPrompt` instance (custom reducer: latest `LlmSystemPromptEvent` parts
+ * win, else first `LlmMessageEvent` system parts) and turned
+ * `SystemPromptSelector` into a thin delegating façade. The registry is now the
+ * SOLE owner of per-agent maps: adding a new per-agent event is a single
+ * `register({...})` call.
  */
 @Injectable()
 export class ActorMessageService {
@@ -164,6 +174,26 @@ export class ActorMessageService {
       reduce: replaceWith<CommandDescriptor[]>(
         (m) => innerCommandsEvent(m)?.commands ?? [],
       ),
+    });
+
+  /**
+   * Epic 17 (ADR-014 §5): per-agent system-prompt head block derived from
+   * `LlmSystemPromptEvent` (primary, latest-wins, FR1) with a first
+   * `LlmMessageEvent` system-part fallback (FR2). Replaces the bespoke
+   * `SystemPromptSelector` `log$` fold — the selector is now a thin façade that
+   * delegates to `systemPrompt.forAgent(id)`. The reducer is a custom one
+   * (`systemPromptReduce`) because the precedence is "latest primary OR first
+   * fallback", not a stock factory; `match` (`systemPromptMatch`) admits BOTH
+   * `LlmSystemPromptEvent` and `LlmMessageEvent` inners so both reach the
+   * reducer. Default key `sender.agent_id`. Read via the façade or directly via
+   * `systemPrompt.forAgent(id)` (value `{ rows, hasPrimary }`; the façade
+   * projects `.rows`).
+   */
+  readonly systemPrompt: PerAgentStore<SystemPromptValue> =
+    this.registry.register<SystemPromptValue>({
+      name: 'systemPrompt',
+      match: systemPromptMatch,
+      reduce: systemPromptReduce,
     });
 
   processId: string = '';

--- a/src/app/services/per-agent-store.spec.ts
+++ b/src/app/services/per-agent-store.spec.ts
@@ -1,0 +1,471 @@
+import { TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+
+import { AkgenticMessage } from '../models/message.types';
+import { MessageLogService } from './message-log.service';
+import {
+  AgentId,
+  appendWith,
+  firstWith,
+  PerAgentSpec,
+  PerAgentStoreRegistry,
+  replaceWith,
+} from './per-agent-store';
+
+// ---------------------------------------------------------------------
+// Fixtures
+//
+// Mirrors `system-prompt.selector.spec.ts`: module-scope builders producing
+// minimal `AkgenticMessage`-shaped objects. THIS story registers no real
+// instance, so fixtures use SYNTHETIC `__model__`s chosen so a test `match`
+// passes; no real type guard is needed.
+// ---------------------------------------------------------------------
+
+const MATCH_MODEL = 'test.PerAgentMatch';
+const UNRELATED_MODEL = 'test.Unrelated';
+
+function sender(agentId: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name: '@' + agentId,
+    role: 'Agent',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+let msgCounter = 0;
+
+/** A matching message for `agentId` carrying a projected `value` + `model`. */
+function makeMsg(
+  agentId: string,
+  value: string,
+  model = MATCH_MODEL,
+): AkgenticMessage {
+  return {
+    id: 'm-' + agentId + '-' + msgCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: value,
+    __model__: model,
+  } as unknown as AkgenticMessage;
+}
+
+/** A message whose `__model__` does not match the test spec. */
+function makeUnrelated(): AkgenticMessage {
+  return makeMsg('A', 'noise', UNRELATED_MODEL);
+}
+
+/** A matching message with NO `sender.agent_id` (default key resolves to undefined). */
+function makeMsgNoSender(value: string): AkgenticMessage {
+  return {
+    id: 'ns-' + msgCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: { __actor_address__: true, name: '?', role: 'Agent', squad_id: 's1' },
+    display_type: 'other',
+    content: value,
+    __model__: MATCH_MODEL,
+  } as unknown as AkgenticMessage;
+}
+
+const matchModel = (msg: AkgenticMessage): boolean =>
+  msg.__model__ === MATCH_MODEL;
+
+/** Spec under test: latest `content` per agent (replace semantics). */
+function replaceSpec(): PerAgentSpec<string> {
+  return {
+    name: 'latest-content',
+    match: matchModel,
+    reduce: replaceWith((m) => (m.content ?? '') as string),
+  };
+}
+
+interface Counted {
+  spec: PerAgentSpec<string>;
+  matchCalls: () => number;
+  reduceCalls: () => number;
+}
+
+/** A replace-spec instrumented to count `match` / `reduce` invocations (AC2). */
+function countedSpec(): Counted {
+  let matchCalls = 0;
+  let reduceCalls = 0;
+  const inner = replaceWith<string>((m) => (m.content ?? '') as string);
+  return {
+    spec: {
+      name: 'counted',
+      match: (m) => {
+        matchCalls++;
+        return matchModel(m);
+      },
+      reduce: (prev, m) => {
+        reduceCalls++;
+        return inner(prev, m);
+      },
+    },
+    matchCalls: () => matchCalls,
+    reduceCalls: () => reduceCalls,
+  };
+}
+
+function setup(): {
+  log: MessageLogService;
+  registry: PerAgentStoreRegistry;
+} {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [MessageLogService, PerAgentStoreRegistry],
+  });
+  return {
+    log: TestBed.inject(MessageLogService),
+    registry: TestBed.inject(PerAgentStoreRegistry),
+  };
+}
+
+// ---------------------------------------------------------------------
+// AC5 — reducer factories (pure, no TestBed)
+// ---------------------------------------------------------------------
+
+describe('reducer factories (pure)', () => {
+  it('replaceWith is latest-wins', () => {
+    const r = replaceWith<string>((m) => (m.content ?? '') as string);
+    const v1 = r('prev', makeMsg('A', 'v1'));
+    const v2 = r(v1, makeMsg('A', 'v2'));
+    expect(v1).toBe('v1');
+    expect(v2).toBe('v2');
+  });
+
+  it('appendWith accumulates and returns a FRESH array each time', () => {
+    const r = appendWith<string>((m) => (m.content ?? '') as string);
+    const a1 = r(undefined, makeMsg('A', 'x'));
+    const a2 = r(a1, makeMsg('A', 'y'));
+    expect(a1).toEqual(['x']);
+    expect(a2).toEqual(['x', 'y']);
+    expect(a2).not.toBe(a1); // fresh reference, not in-place mutation
+    expect(a1).toEqual(['x']); // prior array untouched
+  });
+
+  it('firstWith keeps the first value; later matches do not overwrite', () => {
+    const r = firstWith<string>((m) => (m.content ?? '') as string);
+    const f1 = r(undefined, makeMsg('A', 'first'));
+    const f2 = r(f1, makeMsg('A', 'second'));
+    expect(f1).toBe('first');
+    expect(f2).toBe('first');
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC1, AC8 — replace reduce + per-agent read + default key
+// ---------------------------------------------------------------------
+
+describe('PerAgentStore — replace reduce + read (AC1, AC8)', () => {
+  it('AC1 forAgent yields the latest value; snapshot mirrors it; unmatched agent is undefined', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    log.appendAll([makeMsg('A', 'v1'), makeMsg('A', 'v2')]);
+
+    let latest: string | undefined = 'unset';
+    const sub = store.forAgent('A').subscribe((v) => (latest = v));
+    expect(latest).toBe('v2');
+    expect(store.snapshot('A')).toBe('v2');
+
+    let other: string | undefined = 'unset';
+    const sub2 = store.forAgent('Z').subscribe((v) => (other = v));
+    expect(other).toBeUndefined();
+    expect(store.snapshot('Z')).toBeUndefined();
+
+    sub.unsubscribe();
+    sub2.unsubscribe();
+  });
+
+  it('AC8 default key is sender.agent_id; a message missing it is skipped (no undefined key)', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    log.appendAll([makeMsg('A', 'a'), makeMsgNoSender('orphan')]);
+
+    expect(store.snapshot('A')).toBe('a');
+    const all = collectAll(store.all$);
+    const map = all[all.length - 1];
+    expect(map.has(undefined as unknown as AgentId)).toBe(false);
+    expect([...map.keys()]).toEqual(['A']);
+  });
+
+  it('AC8 a spec MAY override key to read a different field', () => {
+    const { log, registry } = setup();
+    const store = registry.register<string>({
+      name: 'keyed-by-team',
+      match: matchModel,
+      key: (m) => m.team_id,
+      reduce: replaceWith((m) => (m.content ?? '') as string),
+    });
+
+    log.append(makeMsg('A', 'hello'));
+    expect(store.snapshot('team-1')).toBe('hello');
+    expect(store.snapshot('A')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC2 — O(Δ) cursor: only the new tail is walked
+// ---------------------------------------------------------------------
+
+describe('PerAgentStoreRegistry — O(Δ) cursor (AC2)', () => {
+  it('processes only log.slice(processedCount); cursor advances by the tail length', () => {
+    const { log, registry } = setup();
+    const counted = countedSpec();
+    registry.register(counted.spec);
+
+    // Frame 1: M matching messages.
+    log.appendAll([makeMsg('A', '1'), makeMsg('B', '2'), makeMsg('A', '3')]);
+    expect(registry.cursor).toBe(3);
+    expect(counted.reduceCalls()).toBe(3);
+    const matchAfterFrame1 = counted.matchCalls();
+
+    // Frame 2: a tail of N=2. Only the 2 new messages are reduced/matched.
+    log.appendAll([makeMsg('A', '4'), makeMsg('C', '5')]);
+    expect(registry.cursor).toBe(5);
+    expect(counted.reduceCalls()).toBe(5); // +2, NOT +5 (no re-fold of prefix)
+    expect(counted.matchCalls() - matchAfterFrame1).toBe(2);
+  });
+
+  it('a no-op append (dedup → no new tail) does not re-walk the prefix', () => {
+    const { log, registry } = setup();
+    const counted = countedSpec();
+    registry.register(counted.spec);
+
+    const m = makeMsg('A', '1');
+    log.append(m);
+    const reduceAfter = counted.reduceCalls();
+    const matchAfter = counted.matchCalls();
+
+    // Same id → MessageLogService dedup drops it → no log$ emission → no walk.
+    log.append(m);
+    expect(registry.cursor).toBe(1);
+    expect(counted.reduceCalls()).toBe(reduceAfter);
+    expect(counted.matchCalls()).toBe(matchAfter);
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC3 — automatic reset on log shrink
+// ---------------------------------------------------------------------
+
+describe('PerAgentStoreRegistry — reset on shrink (AC3)', () => {
+  it('clears all maps, resets cursor to 0, re-folds the smaller log — no per-store clear', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    log.appendAll([makeMsg('A', 'a'), makeMsg('B', 'b')]);
+    expect(store.snapshot('A')).toBe('a');
+    expect(registry.cursor).toBe(2);
+
+    const seen: (string | undefined)[] = [];
+    const sub = store.forAgent('A').subscribe((v) => seen.push(v));
+    expect(seen[seen.length - 1]).toBe('a');
+
+    log.reset();
+    expect(registry.cursor).toBe(0);
+    expect(store.snapshot('A')).toBeUndefined();
+    expect(seen[seen.length - 1]).toBeUndefined(); // forAgent re-emitted undefined
+
+    // Re-append a smaller log → re-folds correctly from the start.
+    log.appendAll([makeMsg('A', 'a2')]);
+    expect(registry.cursor).toBe(1);
+    expect(store.snapshot('A')).toBe('a2');
+    expect(seen[seen.length - 1]).toBe('a2');
+    sub.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC4 — replay / live parity (REST appendAll vs WS per-message append)
+// ---------------------------------------------------------------------
+
+describe('PerAgentStore — replay/live parity (AC4)', () => {
+  function fixture(): AkgenticMessage[] {
+    return [
+      makeMsg('A', 'a1'),
+      makeMsg('B', 'b1'),
+      makeMsg('A', 'a2'),
+      makeUnrelated(),
+      makeMsg('C', 'c1'),
+    ];
+  }
+
+  function ingest(mode: 'rest' | 'ws'): {
+    a: string | undefined;
+    b: string | undefined;
+    c: string | undefined;
+    all: Record<string, string>;
+  } {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+    const fx = fixture();
+    if (mode === 'rest') {
+      log.appendAll(fx);
+    } else {
+      for (const m of fx) log.append(m);
+    }
+    const all = collectAll(store.all$);
+    const map = all[all.length - 1];
+    return {
+      a: store.snapshot('A'),
+      b: store.snapshot('B'),
+      c: store.snapshot('C'),
+      all: Object.fromEntries(map),
+    };
+  }
+
+  it('REST batch and WS sequence produce identical forAgent/snapshot/all$ results', () => {
+    const rest = ingest('rest');
+    const ws = ingest('ws');
+    expect(JSON.stringify(rest)).toBe(JSON.stringify(ws));
+    expect(rest.a).toBe('a2'); // latest-wins folds identically
+    expect(rest.all).toEqual({ A: 'a2', B: 'b1', C: 'c1' });
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC5 (engine) — non-match / undefined-key passthrough never throws/partial
+// ---------------------------------------------------------------------
+
+describe('PerAgentStore — passthrough safety (AC5)', () => {
+  it('a non-matching message and an undefined-keyed message are silently skipped', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    expect(() =>
+      log.appendAll([
+        makeUnrelated(), // does not match → skipped
+        makeMsgNoSender('x'), // matches but key undefined → skipped
+        makeMsg('A', 'kept'),
+      ]),
+    ).not.toThrow();
+
+    expect(store.snapshot('A')).toBe('kept');
+    const all = collectAll(store.all$);
+    expect([...all[all.length - 1].keys()]).toEqual(['A']);
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC6 — all$ coalescing + distinctUntilChanged
+// ---------------------------------------------------------------------
+
+describe('PerAgentStore — all$ coalescing (AC6)', () => {
+  it('several agents changing in one frame → exactly ONE all$ emission carrying all of them', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    const frames: ReadonlyMap<AgentId, string>[] = [];
+    const sub = store.all$.subscribe((m) => frames.push(m));
+    const baseline = frames.length; // initial empty-map emission
+
+    log.appendAll([makeMsg('A', 'a'), makeMsg('B', 'b'), makeMsg('C', 'c')]);
+
+    // One frame → one new emission (not one per changed agent).
+    expect(frames.length - baseline).toBe(1);
+    const last = frames[frames.length - 1];
+    expect(Object.fromEntries(last)).toEqual({ A: 'a', B: 'b', C: 'c' });
+    sub.unsubscribe();
+  });
+
+  it('a frame in which no registered agent changed does NOT re-emit (distinctUntilChanged)', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    log.append(makeMsg('A', 'a'));
+    const frames: ReadonlyMap<AgentId, string>[] = [];
+    const sub = store.all$.subscribe((m) => frames.push(m));
+    const before = frames.length;
+
+    // A log tick that matches no spec → bucket unchanged → no all$ re-emit.
+    log.append(makeUnrelated());
+    expect(frames.length).toBe(before);
+    sub.unsubscribe();
+  });
+
+  it('all$ hands out a FRESH map reference on change (OnPush safety)', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    const frames: ReadonlyMap<AgentId, string>[] = [];
+    const sub = store.all$.subscribe((m) => frames.push(m));
+    log.append(makeMsg('A', 'a'));
+    log.append(makeMsg('B', 'b'));
+    expect(frames[frames.length - 1]).not.toBe(frames[frames.length - 2]);
+    sub.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC7 — forAgent stream semantics (shareReplay, distinctUntilChanged, refCount)
+// ---------------------------------------------------------------------
+
+describe('PerAgentStore — forAgent semantics (AC7)', () => {
+  it('a late subscriber receives the current value immediately (shareReplay(1))', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+    log.append(makeMsg('A', 'a'));
+
+    let received: string | undefined = 'unset';
+    const sub = store.forAgent('A').subscribe((v) => (received = v));
+    expect(received).toBe('a');
+    sub.unsubscribe();
+  });
+
+  it('a no-op frame for that agent does not re-emit (distinctUntilChanged)', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+
+    const emissions: (string | undefined)[] = [];
+    const sub = store.forAgent('A').subscribe((v) => emissions.push(v));
+
+    log.append(makeMsg('A', 'a'));
+    log.append(makeUnrelated()); // does not touch A
+    log.append(makeMsg('B', 'b')); // changes B, not A
+
+    expect(emissions).toEqual([undefined, 'a']); // no extra A re-emission
+    sub.unsubscribe();
+  });
+
+  it('the shared source is released when the last forAgent subscriber unsubscribes (refCount)', () => {
+    const { log, registry } = setup();
+    const store = registry.register(replaceSpec());
+    log.append(makeMsg('A', 'a'));
+
+    const stream = store.forAgent('A');
+    const s1 = stream.subscribe();
+    const s2 = stream.subscribe();
+    // Two subscribers share one source; releasing both tears it down. With
+    // refCount, a fresh subscribe re-primes from the current value cleanly.
+    s1.unsubscribe();
+    s2.unsubscribe();
+
+    let revived: string | undefined = 'unset';
+    const s3 = stream.subscribe((v) => (revived = v));
+    expect(revived).toBe('a'); // re-subscribe after refCount release still works
+    s3.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// Test helper: synchronously collect all$ emissions during a subscription.
+// ---------------------------------------------------------------------
+
+function collectAll<V>(
+  all$: Observable<ReadonlyMap<AgentId, V>>,
+): ReadonlyMap<AgentId, V>[] {
+  const out: ReadonlyMap<AgentId, V>[] = [];
+  const sub = all$.subscribe((m) => out.push(m));
+  sub.unsubscribe();
+  return out;
+}

--- a/src/app/services/per-agent-store.ts
+++ b/src/app/services/per-agent-store.ts
@@ -1,0 +1,258 @@
+import { inject, Injectable, OnDestroy } from '@angular/core';
+import {
+  distinctUntilChanged,
+  map,
+  Observable,
+  shareReplay,
+  Subject,
+  Subscription,
+} from 'rxjs';
+
+import { AkgenticMessage } from '../models/message.types';
+import { MessageLogService } from './message-log.service';
+
+/**
+ * Generic per-agent derived store — Epic 17 (ADR-014).
+ *
+ * Generalises the existing "pure fold over `MessageLogService.log$`" pattern
+ * (see `system-prompt.selector.ts`) into a single, keyed, O(Δ)-incremental
+ * reducer engine. A consumer registers a {@link PerAgentSpec} and gets back a
+ * {@link PerAgentStore} exposing `forAgent(id)` / `snapshot(id)` / `all$`,
+ * with replay and reset handled automatically — no bespoke per-agent
+ * `BehaviorSubject` dict, no manual clear-on-team-switch.
+ *
+ * APPEND-ONLY-OR-RESET PRECONDITION (NFR5):
+ *   The O(Δ) cursor below is correct ONLY because `MessageLogService.log$` is
+ *   append-only, with `reset()` (→ a strictly shorter array) as its sole
+ *   non-append mutation. The registry advances a `processedCount` cursor and
+ *   folds only `log.slice(processedCount)` per frame; a shrink is detected and
+ *   triggers a full clear + re-fold. If a future change gives `log$`
+ *   in-place / reorder / dedup-rewrite semantics (e.g. a log dedup-semantics
+ *   change), THIS precondition is violated and the cursor logic MUST be
+ *   revisited. This is documented prose, never a runtime assertion.
+ *
+ * SCOPING (NFR / ADR-005 parity):
+ *   {@link PerAgentStoreRegistry} is COMPONENT-SCOPED — it injects the
+ *   component-scoped `MessageLogService` and must be provided on
+ *   `ProcessComponent.providers` (NEVER `providedIn: 'root'`). A team switch
+ *   destroys the component, which destroys the registry (and its single
+ *   `log$` subscription), so no per-agent state leaks across processes. This
+ *   story (17-1) ships the class only; consumer wiring is Stories 17-2..17-4.
+ */
+
+/** Stable per-agent key. The ADR-013 keying convention is `sender.agent_id`. */
+export type AgentId = string;
+
+/**
+ * Declarative description of one per-agent derived value `V`.
+ *
+ * - `name`     — debug label AND the registry key (unique per registry).
+ * - `match`    — discriminator (on the outer or an inner `__model__`); only
+ *                messages for which it returns `true` are folded by this spec.
+ * - `key`      — resolves the {@link AgentId} a message contributes to.
+ *                Defaults to `msg.sender?.agent_id`. Returning `undefined`
+ *                silently skips the message for this spec (no `undefined` key).
+ * - `reduce`   — incremental fold: `(prev, msg) => next`. Returning `undefined`
+ *                leaves the agent absent. Reducers should return a FRESH
+ *                reference on real change (OnPush safety).
+ */
+export interface PerAgentSpec<V> {
+  name: string;
+  match: (msg: AkgenticMessage) => boolean;
+  key?: (msg: AkgenticMessage) => AgentId | undefined;
+  reduce: (prev: V | undefined, msg: AkgenticMessage) => V | undefined;
+}
+
+/** The framework-default key: the outer message's `sender.agent_id`. For
+ *  `EventMessage`-wrapped events the emitting agent is the outer sender, so
+ *  `msg.sender.agent_id === inner.agent.agent_id` (ADR-014 §Decision 2). */
+function defaultKey(msg: AkgenticMessage): AgentId | undefined {
+  return msg.sender?.agent_id;
+}
+
+// ---------------------------------------------------------------------------
+// Reducer factories (ADR-014 §Decision 1). Most real stores become one line.
+// ---------------------------------------------------------------------------
+
+/** Latest-wins: each matching message replaces the prior value. */
+export function replaceWith<V>(
+  project: (msg: AkgenticMessage) => V,
+): (prev: V | undefined, msg: AkgenticMessage) => V {
+  return (_prev, msg) => project(msg);
+}
+
+/** Accumulate: append the projected value to a FRESH array each time (never an
+ *  in-place mutation), so OnPush consumers see a new reference. */
+export function appendWith<T>(
+  project: (msg: AkgenticMessage) => T,
+): (prev: T[] | undefined, msg: AkgenticMessage) => T[] {
+  return (prev, msg) => [...(prev ?? []), project(msg)];
+}
+
+/** First-wins: keep the first projected value; later matches do not overwrite. */
+export function firstWith<V>(
+  project: (msg: AkgenticMessage) => V,
+): (prev: V | undefined, msg: AkgenticMessage) => V {
+  return (prev, msg) => prev ?? project(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Per-spec internal bucket: the map + a per-frame "changed" flag.
+// ---------------------------------------------------------------------------
+
+/** Internal per-spec state held by the registry. */
+class SpecBucket<V> {
+  readonly map = new Map<AgentId, V>();
+  /** Notified once per frame in which this bucket's map actually changed. */
+  readonly changed$ = new Subject<void>();
+
+  constructor(readonly spec: PerAgentSpec<V>) {}
+
+  /** Fold one message into the map. Returns `true` iff the map changed. */
+  apply(msg: AkgenticMessage): boolean {
+    if (!this.spec.match(msg)) return false;
+    const id = (this.spec.key ?? defaultKey)(msg);
+    if (id === undefined) return false;
+    const next = this.spec.reduce(this.map.get(id), msg);
+    if (next === undefined) return false;
+    this.map.set(id, next);
+    return true;
+  }
+
+  /** Clear the map (reset path). Returns `true` iff it held anything. */
+  clear(): boolean {
+    if (this.map.size === 0) return false;
+    this.map.clear();
+    return true;
+  }
+}
+
+/**
+ * Public per-spec read surface, returned from `register`. Derives both stream
+ * shapes (`forAgent` / `all$`) and the synchronous `snapshot` from one bucket.
+ */
+export class PerAgentStore<V> {
+  /** @internal — constructed by {@link PerAgentStoreRegistry}. */
+  constructor(private readonly bucket: SpecBucket<V>) {}
+
+  /**
+   * Per-agent stream: the current reduced value for `id`, re-emitting only on
+   * real change. `distinctUntilChanged` (reference) suppresses no-op frames;
+   * `shareReplay({ bufferSize: 1, refCount: true })` gives late subscribers the
+   * current value and releases the shared source when the last unsubscribes.
+   */
+  forAgent(id: AgentId): Observable<V | undefined> {
+    return this.bucket.changed$.pipe(
+      map(() => this.bucket.map.get(id)),
+      startWithCurrent(() => this.bucket.map.get(id)),
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+
+  /** Synchronous read of the current value for `id` (mirrors
+   *  `MessageLogService.snapshot()` ergonomics). */
+  snapshot(id: AgentId): V | undefined {
+    return this.bucket.map.get(id);
+  }
+
+  /**
+   * Whole-store stream: ONE coalesced emission per frame in which this store's
+   * map changed (not one per changed agent). Delivers a fresh read-only view of
+   * the map so OnPush consumers re-evaluate; a no-change frame does not re-emit.
+   */
+  get all$(): Observable<ReadonlyMap<AgentId, V>> {
+    return this.bucket.changed$.pipe(
+      map(() => new Map(this.bucket.map) as ReadonlyMap<AgentId, V>),
+      startWithCurrent(
+        () => new Map(this.bucket.map) as ReadonlyMap<AgentId, V>,
+      ),
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+}
+
+/**
+ * Prepend the current value at subscribe time so late subscribers see state
+ * that already exists, while subsequent emissions flow from `changed$`. Unlike
+ * a captured-once `startWith`, the value is read lazily per subscription.
+ */
+function startWithCurrent<T>(read: () => T) {
+  return (source: Observable<T>): Observable<T> =>
+    new Observable<T>((subscriber) => {
+      subscriber.next(read());
+      return source.subscribe(subscriber);
+    });
+}
+
+/**
+ * The registry: subscribes to `MessageLogService.log$` EXACTLY ONCE, holds a
+ * `processedCount` cursor, and folds each frame's new tail into every
+ * registered spec's map (O(Δ)). Reset and replay share one code path.
+ *
+ * Component-scoped (see module docstring). Provide on `ProcessComponent`'s
+ * `providers`; never `providedIn: 'root'`.
+ */
+@Injectable()
+export class PerAgentStoreRegistry implements OnDestroy {
+  private readonly log: MessageLogService = inject(MessageLogService);
+  private readonly buckets: SpecBucket<unknown>[] = [];
+  private processedCount = 0;
+  private logSub: Subscription | null = null;
+
+  /** Register a spec and obtain its read surface. The single `log$`
+   *  subscription is started on first registration. */
+  register<V>(spec: PerAgentSpec<V>): PerAgentStore<V> {
+    const bucket = new SpecBucket<V>(spec);
+    this.buckets.push(bucket as SpecBucket<unknown>);
+    this.ensureSubscribed();
+    return new PerAgentStore<V>(bucket);
+  }
+
+  /** Test/diagnostic accessor: how many log entries have been folded. */
+  get cursor(): number {
+    return this.processedCount;
+  }
+
+  ngOnDestroy(): void {
+    this.logSub?.unsubscribe();
+    this.logSub = null;
+    for (const bucket of this.buckets) bucket.changed$.complete();
+  }
+
+  /** Start the single shared `log$` subscription (idempotent). */
+  private ensureSubscribed(): void {
+    if (this.logSub) return;
+    this.logSub = this.log.log$.subscribe((log) => this.onFrame(log));
+  }
+
+  /**
+   * Process one `log$` emission. A shrink (`log.length < processedCount`) means
+   * `reset()` ran: clear every map and rewind the cursor to 0 so the now-smaller
+   * log is re-folded from the start (reset == replay, one code path). Each
+   * bucket that changed in this frame — whether by clearing or by folding new
+   * messages — emits EXACTLY ONCE (coalesced; `all$` / `forAgent` then suppress
+   * no-op values via `distinctUntilChanged`).
+   */
+  private onFrame(log: AkgenticMessage[]): void {
+    const changedThisFrame = new Set<SpecBucket<unknown>>();
+
+    if (log.length < this.processedCount) {
+      this.processedCount = 0;
+      for (const bucket of this.buckets) {
+        if (bucket.clear()) changedThisFrame.add(bucket);
+      }
+    }
+
+    for (let i = this.processedCount; i < log.length; i++) {
+      const msg = log[i];
+      for (const bucket of this.buckets) {
+        if (bucket.apply(msg)) changedThisFrame.add(bucket);
+      }
+    }
+    this.processedCount = log.length;
+
+    for (const bucket of changedThisFrame) bucket.changed$.next();
+  }
+}

--- a/src/app/services/system-prompt.selector.spec.ts
+++ b/src/app/services/system-prompt.selector.spec.ts
@@ -1,11 +1,16 @@
 import { TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
 
 import { AkgenticMessage } from '../models/message.types';
+import { ApiService } from './api.service';
+import { ChatService } from './chat.service';
 import { MessageLogService } from './message-log.service';
+import { ActorMessageService } from './message.service';
+import { PerAgentStore, PerAgentStoreRegistry } from './per-agent-store';
 import {
-  latestSystemPromptFold,
   SystemPromptRow,
   SystemPromptSelector,
+  SystemPromptValue,
   systemPromptLabel,
 } from './system-prompt.selector';
 
@@ -16,6 +21,13 @@ import {
 // and the existing `EventMessage(LlmMessageEvent)` envelope (the fallback path).
 // The backend emitter (akgentic-llm) need NOT be merged/released: the event
 // contract is frozen, so fixtures are a sufficient and authoritative source.
+//
+// Story 17-4 (Epic 17 / ADR-014): the whole-log `latestSystemPromptFold` is
+// retired; the latest-wins + FR2-fallback + row-mapping logic now lives in
+// `systemPromptReduce`, registered as the `systemPrompt` PerAgentStore instance
+// on `ActorMessageService`. These fixtures are the parity oracle — they are
+// driven through `MessageLogService` and read via `store.systemPrompt` and the
+// `SystemPromptSelector` façade, exercising the REAL fold (no mocking).
 // ---------------------------------------------------------------------
 
 interface PartSnapshot {
@@ -56,8 +68,8 @@ function makeSystemPromptEnvelope(
       __model__: 'akgentic.llm.event.LlmSystemPromptEvent',
       run_id: 'run-' + content_hash,
       content_hash,
-      // `parts` may be deliberately undefined (malformed-event fixture, AC6) —
-      // guard the eager map so the malformation reaches the fold, not the builder.
+      // `parts` may be deliberately undefined (malformed-event fixture) — guard
+      // the eager map so the malformation reaches the fold, not the builder.
       parts: parts?.map((p) => ({
         __model__: 'akgentic.llm.event.SystemPromptPartSnapshot',
         ...p,
@@ -110,12 +122,61 @@ function makeUnknownEnvelope(id: string): AkgenticMessage {
 }
 
 // ---------------------------------------------------------------------
-// Tests — pure fold export
+// TestBed wiring — drive the REAL store + façade via MessageLogService.
 // ---------------------------------------------------------------------
 
-describe('latestSystemPromptFold (pure function)', () => {
-  it('AC1 latest-wins: last LlmSystemPromptEvent for the agent yields its parts as rows', () => {
-    const log: AkgenticMessage[] = [
+function configureBed(): {
+  log: MessageLogService;
+  service: ActorMessageService;
+  selector: SystemPromptSelector;
+} {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      MessageLogService,
+      PerAgentStoreRegistry,
+      ActorMessageService,
+      SystemPromptSelector,
+      ChatService,
+      {
+        provide: ApiService,
+        useValue: {
+          getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+        },
+      },
+      {
+        provide: MessageService,
+        useValue: {
+          add: jasmine.createSpy('add'),
+          clear: jasmine.createSpy('clear'),
+        },
+      },
+    ],
+  });
+  return {
+    log: TestBed.inject(MessageLogService),
+    service: TestBed.inject(ActorMessageService),
+    selector: TestBed.inject(SystemPromptSelector),
+  };
+}
+
+/** Read the rendered rows for `agentId` straight off the store snapshot
+ *  (synchronous; exercises the real `systemPromptReduce`). */
+function storeRows(
+  store: PerAgentStore<SystemPromptValue>,
+  agentId: string,
+): SystemPromptRow[] {
+  return store.snapshot(agentId)?.rows ?? [];
+}
+
+// ---------------------------------------------------------------------
+// Tests — the systemPrompt reducer (parity with the retired fold)
+// ---------------------------------------------------------------------
+
+describe('systemPrompt store reducer (Epic 17 / ADR-014, parity oracle)', () => {
+  it('latest-wins: last LlmSystemPromptEvent for the agent yields its parts as rows', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
       makeSystemPromptEnvelope('A', [
         { dynamic_ref: 'team.roster', content: 'roster v1' },
       ]),
@@ -123,130 +184,146 @@ describe('latestSystemPromptFold (pure function)', () => {
         { dynamic_ref: 'team.roster', content: 'roster v2' },
         { dynamic_ref: null, content: 'backstory' },
       ]),
-    ];
-    const rows = latestSystemPromptFold(log, 'A');
-    expect(rows).toEqual([
+    ]);
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
       { type: 'system', name: 'roster', content: 'roster v2' },
       { type: 'system', name: 'System', content: 'backstory' },
     ]);
   });
 
-  it('AC1 label: dynamic_ref takes its trailing segment, null → "System"', () => {
-    const rows = latestSystemPromptFold(
-      [
-        makeSystemPromptEnvelope('A', [
-          { dynamic_ref: 'current_date', content: 'today' },
-          { dynamic_ref: 'a.b.c', content: 'deep' },
-          { dynamic_ref: null, content: 'static' },
-        ]),
-      ],
-      'A',
+  it('label: dynamic_ref takes its trailing segment, null → "System"', () => {
+    const { log, service } = configureBed();
+    log.append(
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'current_date', content: 'today' },
+        { dynamic_ref: 'a.b.c', content: 'deep' },
+        { dynamic_ref: null, content: 'static' },
+      ]),
     );
-    expect(rows.map((r) => r.name)).toEqual(['current_date', 'c', 'System']);
+    expect(storeRows(service.systemPrompt, 'A').map((r) => r.name)).toEqual([
+      'current_date',
+      'c',
+      'System',
+    ]);
   });
 
-  it('AC2 per-agent isolation: A reflects only A, B only B', () => {
-    const log: AkgenticMessage[] = [
+  it('per-agent isolation: A reflects only A, B only B', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
       makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'A-prompt' }]),
       makeSystemPromptEnvelope('B', [{ dynamic_ref: null, content: 'B-prompt' }]),
-    ];
-    expect(latestSystemPromptFold(log, 'A')).toEqual([
+    ]);
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
       { type: 'system', name: 'System', content: 'A-prompt' },
     ]);
-    expect(latestSystemPromptFold(log, 'B')).toEqual([
+    expect(storeRows(service.systemPrompt, 'B')).toEqual([
       { type: 'system', name: 'System', content: 'B-prompt' },
     ]);
   });
 
-  it('AC3 fallback: no LlmSystemPromptEvent → first LlmMessageEvent system parts', () => {
-    const log: AkgenticMessage[] = [
+  it('fallback: no LlmSystemPromptEvent → first LlmMessageEvent system parts (first-wins)', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
       makeLlmMessageEnvelope('A', [
         { dynamic_ref: 'team.roster', content: 'legacy roster' },
       ]),
       makeLlmMessageEnvelope('A', [
         { dynamic_ref: 'team.roster', content: 'second message roster' },
       ]),
-    ];
+    ]);
     // First such message wins for the fallback.
-    expect(latestSystemPromptFold(log, 'A')).toEqual([
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
       { type: 'system', name: 'roster', content: 'legacy roster' },
     ]);
   });
 
-  it('AC4 precedence: LlmSystemPromptEvent wins over LlmMessageEvent fallback', () => {
-    const log: AkgenticMessage[] = [
+  it('precedence: LlmSystemPromptEvent wins over an earlier LlmMessageEvent fallback (AC-2)', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
       makeLlmMessageEnvelope('A', [
         { dynamic_ref: 'team.roster', content: 'legacy roster' },
       ]),
       makeSystemPromptEnvelope('A', [
         { dynamic_ref: 'team.roster', content: 'event roster' },
       ]),
-    ];
-    expect(latestSystemPromptFold(log, 'A')).toEqual([
+    ]);
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
       { type: 'system', name: 'roster', content: 'event roster' },
     ]);
   });
 
-  it('AC6 passthrough: malformed/empty latest event yields [] (latest-wins still applies)', () => {
-    // Missing parts entirely.
-    expect(
-      latestSystemPromptFold(
-        [makeSystemPromptEnvelope('A', undefined as unknown as PartSnapshot[])],
-        'A',
-      ),
-    ).toEqual([]);
-    // Empty parts array.
-    expect(
-      latestSystemPromptFold([makeSystemPromptEnvelope('A', [])], 'A'),
-    ).toEqual([]);
-    // A malformed LATEST event above an earlier well-formed one → [] (latest-wins).
-    const log: AkgenticMessage[] = [
-      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'good' }]),
-      makeSystemPromptEnvelope('A', []),
-    ];
-    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
+  it('primary supersedes fallback even when the message event arrives AFTER (AC-2)', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'event roster' },
+      ]),
+      // A later LlmMessageEvent with system parts must NOT override the primary.
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'late legacy roster' },
+      ]),
+    ]);
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
+      { type: 'system', name: 'roster', content: 'event roster' },
+    ]);
   });
 
-  it('AC6 passthrough: a part missing content maps to empty string, no throw', () => {
-    const rows = latestSystemPromptFold(
-      [
-        makeSystemPromptEnvelope('A', [
-          { dynamic_ref: 'current_date' } as unknown as PartSnapshot,
-        ]),
-      ],
-      'A',
+  it('malformed/empty latest event yields [] (latest-wins still applies)', () => {
+    // Missing parts entirely.
+    {
+      const { log, service } = configureBed();
+      log.append(
+        makeSystemPromptEnvelope('A', undefined as unknown as PartSnapshot[]),
+      );
+      expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
+    }
+    // Empty parts array.
+    {
+      const { log, service } = configureBed();
+      log.append(makeSystemPromptEnvelope('A', []));
+      expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
+    }
+    // A malformed LATEST event above an earlier well-formed one → [] (latest-wins).
+    {
+      const { log, service } = configureBed();
+      log.appendAll([
+        makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'good' }]),
+        makeSystemPromptEnvelope('A', []),
+      ]);
+      expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
+    }
+  });
+
+  it('a part missing content maps to empty string, no throw', () => {
+    const { log, service } = configureBed();
+    log.append(
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'current_date' } as unknown as PartSnapshot,
+      ]),
     );
-    expect(rows).toEqual([
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([
       { type: 'system', name: 'current_date', content: '' },
     ]);
   });
 
-  it('AC6 passthrough: a log of only unrelated __model__s yields []', () => {
-    const log: AkgenticMessage[] = [
-      makeUnknownEnvelope('u1'),
-      makeUnknownEnvelope('u2'),
-    ];
-    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
+  it('a log of only unrelated __model__s yields [] for the agent', () => {
+    const { log, service } = configureBed();
+    log.appendAll([makeUnknownEnvelope('u1'), makeUnknownEnvelope('u2')]);
+    expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
   });
 
-  it('AC7 absent agent: empty log and no-match log both yield []', () => {
-    expect(latestSystemPromptFold([], 'A')).toEqual([]);
-    const log: AkgenticMessage[] = [
-      makeSystemPromptEnvelope('B', [{ dynamic_ref: null, content: 'B' }]),
-    ];
-    expect(latestSystemPromptFold(log, 'A')).toEqual([]);
-  });
-
-  it('AC9 fresh reference + no input mutation: two folds give distinct arrays, log untouched', () => {
-    const log: AkgenticMessage[] = [
-      makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'same' }]),
-    ];
-    const snapshot = JSON.stringify(log);
-    const r1 = latestSystemPromptFold(log, 'A');
-    const r2 = latestSystemPromptFold(log, 'A');
-    expect(r1).toEqual(r2);
-    expect(r1).not.toBe(r2);
-    expect(JSON.stringify(log)).toBe(snapshot); // input not mutated
+  it('absent agent: empty log and no-match log both yield []', () => {
+    {
+      const { service } = configureBed();
+      expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
+    }
+    {
+      const { log, service } = configureBed();
+      log.append(
+        makeSystemPromptEnvelope('B', [{ dynamic_ref: null, content: 'B' }]),
+      );
+      expect(storeRows(service.systemPrompt, 'A')).toEqual([]);
+    }
   });
 });
 
@@ -264,22 +341,12 @@ describe('systemPromptLabel (pure helper)', () => {
 });
 
 // ---------------------------------------------------------------------
-// Tests — Observable-level (SystemPromptSelector over MessageLogService.log$)
+// Tests — SystemPromptSelector façade (AC-3, AC-4)
 // ---------------------------------------------------------------------
 
-describe('SystemPromptSelector (log-driven selector)', () => {
-  let log: MessageLogService;
-  let selector: SystemPromptSelector;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [MessageLogService, SystemPromptSelector],
-    });
-    log = TestBed.inject(MessageLogService);
-    selector = TestBed.inject(SystemPromptSelector);
-  });
-
-  it('AC8 late-subscriber: shareReplay(1) delivers the current block synchronously', () => {
+describe('SystemPromptSelector (thin façade over store.systemPrompt)', () => {
+  it('AC-3 late-subscriber: forAgent replay delivers the current block synchronously', () => {
+    const { log, selector } = configureBed();
     log.appendAll([
       makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v1' }]),
       makeSystemPromptEnvelope('A', [{ dynamic_ref: null, content: 'v2' }]),
@@ -293,7 +360,19 @@ describe('SystemPromptSelector (log-driven selector)', () => {
     sub.unsubscribe();
   });
 
-  it('AC9 distinctUntilChanged: identical head block across a no-op log tick does not re-emit', () => {
+  it('AC-4 no-rows agent yields [] (never undefined)', () => {
+    const { selector } = configureBed();
+    let received: SystemPromptRow[] | undefined;
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => (received = r));
+    expect(received).toEqual([]);
+    expect(received).not.toBeUndefined();
+    sub.unsubscribe();
+  });
+
+  it('AC-3 no-op suppression: an unrelated log tick does not re-emit the same block', () => {
+    const { log, selector } = configureBed();
     const emissions: SystemPromptRow[][] = [];
     const sub = selector
       .latestSystemPrompt$('A')
@@ -305,9 +384,8 @@ describe('SystemPromptSelector (log-driven selector)', () => {
     // A log tick that does NOT change A's head block (an unrelated message).
     log.append(makeUnknownEnvelope('u1'));
 
-    // Initial [] + the v1 block. The unrelated tick yields the same [] -> no.
-    // Actually: subscribe emits [] (empty log), then v1 block. The unknown
-    // envelope leaves the v1 block identical, so it must NOT re-emit.
+    // Initial [] (empty), then the v1 block. The unrelated tick leaves A's
+    // value identical, so it must NOT re-emit.
     expect(emissions.length).toBe(2);
     expect(emissions[0]).toEqual([]);
     expect(emissions[1]).toEqual([
@@ -316,7 +394,8 @@ describe('SystemPromptSelector (log-driven selector)', () => {
     sub.unsubscribe();
   });
 
-  it('AC9 fresh reference on real change: distinct array objects across changes', () => {
+  it('AC-3 fresh reference on real change: distinct array objects across changes', () => {
+    const { log, selector } = configureBed();
     const emissions: SystemPromptRow[][] = [];
     const sub = selector
       .latestSystemPrompt$('A')
@@ -333,13 +412,37 @@ describe('SystemPromptSelector (log-driven selector)', () => {
     expect(emissions[1]).not.toBe(emissions[2]);
     sub.unsubscribe();
   });
+
+  it('AC-4 façade parity: selector yields the SAME rows the store yields', () => {
+    const { log, service, selector } = configureBed();
+    log.appendAll([
+      makeLlmMessageEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'legacy' },
+      ]),
+      makeSystemPromptEnvelope('A', [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+        { dynamic_ref: 'current_date', content: 'day 1' },
+      ]),
+    ]);
+
+    let received: SystemPromptRow[] | undefined;
+    const sub = selector
+      .latestSystemPrompt$('A')
+      .subscribe((r) => (received = r));
+    expect(received).toEqual(storeRows(service.systemPrompt, 'A'));
+    expect(received).toEqual([
+      { type: 'system', name: 'roster', content: 'roster v1' },
+      { type: 'system', name: 'current_date', content: 'day 1' },
+    ]);
+    sub.unsubscribe();
+  });
 });
 
 // ---------------------------------------------------------------------
-// Tests — REST/WS parity (AC5)
+// Tests — REST/WS replay-vs-live parity (Task 4)
 // ---------------------------------------------------------------------
 
-describe('SystemPromptSelector parity — REST batch vs WS per-message (AC5)', () => {
+describe('systemPrompt parity — REST batch vs WS per-message', () => {
   function buildFixture(): AkgenticMessage[] {
     return [
       makeLlmMessageEnvelope('A', [
@@ -357,19 +460,13 @@ describe('SystemPromptSelector parity — REST batch vs WS per-message (AC5)', (
   }
 
   function head(mode: 'rest' | 'ws'): SystemPromptRow[] {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      providers: [MessageLogService, SystemPromptSelector],
-    });
-    const log = TestBed.inject(MessageLogService);
-    const selector = TestBed.inject(SystemPromptSelector);
+    const { log, selector } = configureBed();
 
     const emissions: SystemPromptRow[][] = [];
     const sub = selector
       .latestSystemPrompt$('A')
       .subscribe((r) => emissions.push(r));
 
-    // Distinct envelopes per run so REST dedupe-by-id and WS yield same set.
     const fixture = buildFixture();
     if (mode === 'rest') {
       log.appendAll(fixture);
@@ -382,7 +479,7 @@ describe('SystemPromptSelector parity — REST batch vs WS per-message (AC5)', (
     return result;
   }
 
-  it('REST batch and WS sequence produce identical head blocks (AC5)', () => {
+  it('REST batch and WS sequence produce identical head blocks', () => {
     const rest = head('rest');
     const ws = head('ws');
     expect(JSON.stringify(rest)).toBe(JSON.stringify(ws));

--- a/src/app/services/system-prompt.selector.ts
+++ b/src/app/services/system-prompt.selector.ts
@@ -1,13 +1,14 @@
 import { inject, Injectable } from '@angular/core';
-import { distinctUntilChanged, map, Observable, shareReplay } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 import {
   AkgenticMessage,
+  EventMessage,
   isEventMessage,
   isLlmSystemPromptEvent,
   SystemPromptPartSnapshot,
 } from '../models/message.types';
-import { MessageLogService } from './message-log.service';
+import { ActorMessageService } from './message.service';
 
 /**
  * One rendered row of the trace head system block. Mirrors the shape the
@@ -23,7 +24,12 @@ export interface SystemPromptRow {
 
 // ---------------------------------------------------------------------------
 // Module-scope pure helpers (ADR-005 §Decision 4; ADR-004 §5b).
-// The fold allocates a fresh result array per call; it never mutates `log`.
+//
+// These are the SINGLE implementation of the system-prompt mapping + part
+// extraction logic. They are shared by the `systemPromptReduce` per-message
+// reducer (registered on the `systemPrompt` PerAgentStore in
+// `ActorMessageService`, Epic 17 / ADR-014) — there is no longer a whole-log
+// fold. Each maps to a fresh array; none mutates its input; none throws.
 // ---------------------------------------------------------------------------
 
 /**
@@ -59,106 +65,141 @@ function mapPartsToRows(
 }
 
 /**
- * Primary path (FR1, latest-wins): the `parts` of the LAST
- * `EventMessage(LlmSystemPromptEvent)` for `agentId`, in log order. Returns
- * `undefined` when the agent has no such event (so the caller can fall back).
- * The log is append-only and ordered — latest-wins is "last by position", not
- * a sort on `run_id`.
+ * Primary-path extraction (FR1): if `msg` is an
+ * `EventMessage(LlmSystemPromptEvent)`, return its `parts` (possibly undefined
+ * for a malformed event); otherwise `undefined`. Latest-wins is applied by the
+ * reducer (the LAST such event replaces the value), so this only reads ONE
+ * message's parts.
  */
-function latestSystemPromptParts(
-  log: AkgenticMessage[],
-  agentId: string,
+function systemPromptEventParts(
+  msg: AkgenticMessage,
 ): SystemPromptPartSnapshot[] | undefined {
-  let latest: SystemPromptPartSnapshot[] | undefined;
-  for (const msg of log) {
-    if (!isEventMessage(msg)) continue;
-    const inner = (msg as { event?: unknown }).event as
-      | { __model__?: string; parts?: SystemPromptPartSnapshot[] }
-      | undefined;
-    if (!isLlmSystemPromptEvent(inner)) continue;
-    if (msg.sender?.agent_id !== agentId) continue;
-    latest = inner.parts;
-  }
-  return latest;
+  if (!isEventMessage(msg)) return undefined;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string; parts?: SystemPromptPartSnapshot[] }
+    | undefined;
+  if (!isLlmSystemPromptEvent(inner)) return undefined;
+  return inner.parts;
 }
 
 /**
- * Fallback path (FR2): the `system-prompt` parts of the FIRST
- * `EventMessage(LlmMessageEvent)` for `agentId` (pre-event teams whose logs
- * predate `LlmSystemPromptEvent`). Mirrors the `contextDict$` seeding read in
- * `message.service.ts` (inner is the `ModelRequest`, whose `.parts` carry
- * `part_kind`). Returns `undefined` when no such message exists for the agent.
+ * Fallback-path extraction (FR2): if `msg` is an
+ * `EventMessage(LlmMessageEvent)` whose inner `message.parts` contain
+ * `part_kind === 'system-prompt'` entries, return those system parts; otherwise
+ * `undefined`. Mirrors the pre-event seeding read in `message.service.ts`
+ * (inner is the `ModelRequest`, whose `.parts` carry `part_kind`).
  */
-function fallbackSystemPromptParts(
-  log: AkgenticMessage[],
-  agentId: string,
+function llmMessageSystemParts(
+  msg: AkgenticMessage,
 ): Array<{ dynamic_ref?: string | null; content?: string }> | undefined {
-  for (const msg of log) {
-    if (!isEventMessage(msg)) continue;
-    const inner = (msg as { event?: unknown }).event as
-      | { __model__?: string; message?: { parts?: unknown[] } }
-      | undefined;
-    if (!inner?.__model__?.includes('LlmMessageEvent')) continue;
-    if (msg.sender?.agent_id !== agentId) continue;
-    const parts = (inner.message?.parts ?? []) as Array<{
-      part_kind?: string;
-      dynamic_ref?: string | null;
-      content?: string;
-    }>;
-    const systemParts = parts.filter((p) => p?.part_kind === 'system-prompt');
-    if (systemParts.length > 0) return systemParts;
-  }
-  return undefined;
+  if (!isEventMessage(msg)) return undefined;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string; message?: { parts?: unknown[] } }
+    | undefined;
+  if (!inner?.__model__?.includes('LlmMessageEvent')) return undefined;
+  const parts = (inner.message?.parts ?? []) as Array<{
+    part_kind?: string;
+    dynamic_ref?: string | null;
+    content?: string;
+  }>;
+  const systemParts = parts.filter((p) => p?.part_kind === 'system-prompt');
+  return systemParts.length > 0 ? systemParts : undefined;
 }
 
 /**
- * Pure fold over the message log producing the current head system block for
- * one agent (ADR-004 §5b step 1). Primary source: the LAST
- * `LlmSystemPromptEvent` for the agent (latest-wins, FR1). Fallback (FR2, only
- * when the agent has ZERO `LlmSystemPromptEvent`s): the system-prompt parts of
- * the FIRST `LlmMessageEvent` for the agent. Unknown/unrelated `__model__`s
- * pass through silently; never throws; allocates a fresh array per call.
+ * Per-agent reduced value for the `systemPrompt` store (Epic 17 / ADR-014). The
+ * incremental reducer cannot be a stock factory because the precedence is
+ * "latest primary OR first fallback" — it must remember whether a primary
+ * (`LlmSystemPromptEvent`) has ever been seen for the agent so a later
+ * `LlmMessageEvent` cannot clobber a primary, and a second `LlmMessageEvent`
+ * cannot overwrite an earlier fallback.
  *
- * Exported so tests can import it directly (no TestBed required).
+ * - `rows`       — the rendered head block (what the façade exposes).
+ * - `hasPrimary` — true once any `LlmSystemPromptEvent` has been folded for the
+ *                  agent (primary supersedes fallback from that point on).
  */
-export function latestSystemPromptFold(
-  log: AkgenticMessage[],
-  agentId: string,
-): SystemPromptRow[] {
-  const primary = latestSystemPromptParts(log, agentId);
-  if (primary !== undefined) return mapPartsToRows(primary);
-  return mapPartsToRows(fallbackSystemPromptParts(log, agentId));
-}
-
-/** Structural comparator so identical head blocks across no-op `log$` ticks do
- *  not re-emit (OnPush), while a real change emits a fresh reference (AC9). */
-function rowsEqual(a: SystemPromptRow[], b: SystemPromptRow[]): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+export interface SystemPromptValue {
+  rows: SystemPromptRow[];
+  hasPrimary: boolean;
 }
 
 /**
- * SystemPromptSelector — Story 16-1 (ADR-004 §5b step 1).
+ * Incremental per-message reducer (the store's `(prev, msg) => next` contract,
+ * ADR-014 §Decision 1 custom reducer) that reproduces EXACTLY the precedence of
+ * the old whole-log fold:
  *
- * Exposes `latestSystemPrompt$(agentId)` as a pure selector over
- * `MessageLogService.log$`, mirroring `KGStateReducer.knowledgeGraph$`. NO new
- * imperative per-agent dict / `BehaviorSubject` — the head block is derived by
- * folding the unified log, preserving frontend ADR-005's two-exception
- * invariant (NFR1). `shareReplay(1)` gives late subscribers the current block
- * synchronously (AC8); the structural `distinctUntilChanged` suppresses no-op
- * re-emissions while still emitting a fresh array on real change (AC9).
+ *   1. Primary (latest-wins, FR1): a `LlmSystemPromptEvent` always replaces the
+ *      value with its parts and marks `hasPrimary` — the LAST one wins.
+ *   2. Fallback (FR2, ONLY while `!hasPrimary`): the FIRST `LlmMessageEvent`
+ *      with system parts captures the value; once captured, later
+ *      `LlmMessageEvent`s do NOT overwrite it (first-wins fallback). A
+ *      `LlmMessageEvent` never overrides a primary.
+ *   3. Anything else (unrelated inner, no system parts) → passthrough `prev`.
+ *
+ * Malformed/empty parts map to `[]` without throwing (defensive `mapPartsToRows`).
+ * Returns a FRESH `rows` array on real change (OnPush safety).
+ */
+export function systemPromptReduce(
+  prev: SystemPromptValue | undefined,
+  msg: AkgenticMessage,
+): SystemPromptValue | undefined {
+  const primary = systemPromptEventParts(msg);
+  if (primary !== undefined) {
+    return { rows: mapPartsToRows(primary), hasPrimary: true };
+  }
+  // Primary already established → a message-event fallback never overrides it.
+  if (prev?.hasPrimary) return prev;
+  // Fallback already captured → first-wins; later message events do not replace.
+  if (prev !== undefined) return prev;
+  const fallback = llmMessageSystemParts(msg);
+  if (fallback !== undefined) {
+    return { rows: mapPartsToRows(fallback), hasPrimary: false };
+  }
+  return prev;
+}
+
+/**
+ * `match` predicate for the `systemPrompt` spec: admit BOTH inner model types
+ * so both reach `systemPromptReduce` (the reducer — not `match` — decides
+ * primary-vs-fallback). Any `EventMessage` whose inner is a
+ * `LlmSystemPromptEvent` OR a `LlmMessageEvent` is folded.
+ */
+export function systemPromptMatch(msg: AkgenticMessage): boolean {
+  if (!isEventMessage(msg)) return false;
+  return (
+    systemPromptEventParts(msg) !== undefined ||
+    llmMessageSystemParts(msg) !== undefined
+  );
+}
+
+/**
+ * SystemPromptSelector — Story 16-1 (ADR-004 §5b step 1), thin façade since
+ * Epic 17 / Story 17-4 (ADR-014).
+ *
+ * `latestSystemPrompt$(agentId)` now DELEGATES to the `systemPrompt`
+ * `PerAgentStore` instance owned by `ActorMessageService` (registered on the
+ * single `PerAgentStoreRegistry` alongside `state` / `context` / `commands`).
+ * The selector holds NO per-agent state of its own and no `log$` fold pipeline —
+ * the latest-wins + FR2 fallback + row-mapping logic lives in
+ * `systemPromptReduce`. `forAgent` already applies a reference
+ * `distinctUntilChanged` + `shareReplay({ bufferSize: 1, refCount: true })` with
+ * a lazy current-value replay, covering the late-subscriber + no-op-suppression
+ * + fresh-array-on-change semantics the head block relies on. The façade
+ * coalesces the store's `undefined` (agent never folded) to `[]` so the
+ * head-block consumer always receives `SystemPromptRow[]`, never `undefined`
+ * (AC-4 parity with the old fold's `[]`-for-no-rows contract).
  *
  * Scope: component-scoped (NOT `providedIn: 'root'`) — it injects the
- * component-scoped `MessageLogService` from `ProcessComponent.providers`.
+ * component-scoped `ActorMessageService` from `ProcessComponent.providers`.
  */
 @Injectable()
 export class SystemPromptSelector {
-  private readonly log: MessageLogService = inject(MessageLogService);
+  private readonly messageService: ActorMessageService =
+    inject(ActorMessageService);
 
   latestSystemPrompt$(agentId: string): Observable<SystemPromptRow[]> {
-    return this.log.log$.pipe(
-      map((log) => latestSystemPromptFold(log, agentId)),
-      distinctUntilChanged(rowsEqual),
-      shareReplay(1),
-    );
+    return this.messageService.systemPrompt
+      .forAgent(agentId)
+      .pipe(map((value) => value?.rows ?? []));
   }
 }


### PR DESCRIPTION
## Epic 17 — Generic Per-Agent Store (ADR-014)

Umbrella PR for Epic 17. One generic `PerAgentStore` — a keyed O(Δ) reducer over
`MessageLogService.log$` — replaces the bespoke per-agent dicts
(`stateDict$` / `contextDict$` / `commandsByAgent$`) and the `SystemPromptSelector` fold.
Behavior-preserving refactor, sequential within `akgentic-frontend`. No backend/infra work.

Branch: `feat/146-epic-17-generic-per-agent-store` (shared epic branch; umbrella PR reused by all four stories).

## Stories

- [x] 17-1-per-agent-store-foundation — PerAgentStore foundation + registry + reducer factories, dark (Relates to #146)
- [x] 17-2-migrate-state-and-context-delete-replay-and-resets — migrate `state` + `context`, delete replay loop + resets (Relates to #148)
- [x] 17-3-commands-instance-agent-id-keying — `commands` instance, agent_id keying (re-homes Story 15-2) (Relates to #149)
- [x] 17-4-system-prompt-instance-facade-and-retire-exceptions-invariant — system-prompt instance facade + retire the "≤N exceptions" invariant (Relates to #150)

## Review status

**17-1-per-agent-store-foundation — APPROVED (done).** Reviewed commit `ece2e48`.

- All 8 ACs implemented and exercised by behavioral tests (replace reduce, O(Δ) cursor via instrumented
  counter, automatic reset-on-shrink, REST/WS replay parity, the three reducer factories, `all$`
  coalescing + distinctUntilChanged + fresh-map reference, `forAgent` shareReplay(1) + distinctUntilChanged
  + refCount, default `sender.agent_id` key + missing-sender skip).
- No HIGH/MEDIUM findings; no fixup commit produced.
- Local quality gate green: Karma headless **827 SUCCESS** (800 pre-existing + 27 new), `ng build` clean
  (only the pre-existing lodash CommonJS warning). No `lint` script / ESLint config in this package — the
  enforceable gates are Karma + build, both green. No remote CI gates `akgentic-frontend`.

Full review recorded in the story file's Code Review section.

- 17-2 review: **PASS** — reviewed commit `6a5e835`. All 8 ACs satisfied; behavior-preserving migration of `state` + `context` to `PerAgentStore` instances on the component-scoped registry. The bespoke `stateDict$`/`contextDict$` fields, their `init()` resets, the stopped-team replay reconstruction loop, the `StateChangedMessage` dispatch, `applyStateChanged`, the `LlmMessageEvent` arm of `applyEventMessageDicts`, and `initDict` are all deleted; `commandsByAgent$` and its branches correctly retained for 17-3. Replay-vs-live parity, reset-on-team-switch (no process-A→B leak), and O(Δ)/frame append verified by new behavioral specs. No HIGH/MEDIUM findings; no fixup commit produced. Local gate green: Karma headless **839 SUCCESS**, `ng build` clean (pre-existing lodash CommonJS warning only). All changes confined to `packages/akgentic-frontend/`.

- 17-3 review: **PASS** — reviewed commit `c3fa033`. All 9 ACs satisfied. `commands` registered as a `PerAgentStore<CommandDescriptor[]>` on the component-scoped registry (`replaceWith(innerCommandsEvent(m)?.commands ?? [])`, matched on `isEventMessage(m) && isCommandsAnnouncedEvent(event)`, default key `sender.agent_id` — the ADR-013 keying fix). The entire `commandsByAgent$` surface is deleted (field, `init()` reset, stopped-team replay rebuild, the `applyEventMessageDicts` / `applyCommandsAnnounced` batched arm, and the `ngOnDestroy` complete — the batched subscriber now only calls `log.appendAll(batch)`). Main chat resolves the Send-to/supervisor target name to its `agent_id` via the new `targetedAgentId()` helper, then reads `commands.snapshot(agentId)`; member chat reads `commands.snapshot(this.agentId)`. The `_`-prefix internal-command filter, the `tool_card`-then-`name` ordering on a fresh array, and `disableSort: true` on the `/` mentionConfig are preserved byte-for-byte in both consumers. Name-reuse non-bleed proven by new tests in both the service spec (agent-old/agent-new) and the main-chat spec (mgr-old/mgr-new); replay-vs-live parity and reset-on-team-switch verified. NFR9 "≤2 exceptions" probe adjusted to the now-empty exception set (retirement is 17-4); 15-1/15-3 ordering/filter specs stay green. One LOW (non-blocking, no fixup): `chat-panel.component.spec.ts` (outside the File List) still stubs the removed `commandsByAgent$`; harmless because the embedded `<app-user-input>` resolves no target there so `commandItems` short-circuits before touching `.commands`. No HIGH/MEDIUM findings; no fixup commit produced. Local gate green: Karma headless **842 SUCCESS** (0 failures), `npm run build` clean (pre-existing lodash CommonJS warning only). All changes confined to `packages/akgentic-frontend/`.

- 17-4 review: **PASS** — reviewed commit `e8b6223`. All 9 ACs satisfied; no fixup commit needed. `systemPrompt` is now a `PerAgentStore<{ rows, hasPrimary }>` registered alongside `state`/`context`/`commands` with a custom `systemPromptReduce` reducer that reproduces the retired whole-log fold's precedence EXACTLY (latest `LlmSystemPromptEvent` parts win and set `hasPrimary`; first `LlmMessageEvent` system-part fallback captured ONLY while `!hasPrimary`, first-wins, never overrides a primary; malformed/empty parts → `[]` without throwing). `SystemPromptSelector.latestSystemPrompt$` is a thin façade — `forAgent(id).pipe(map(v => v?.rows ?? []))` — holding no per-agent state and no `log$` fold; the `undefined → []` coalescing is covered by an explicit no-rows test, and `forAgent`'s `distinctUntilChanged` + `shareReplay({bufferSize:1,refCount:true})` + lazy current-value replay subsume the old `shareReplay(1)` + structural `distinctUntilChanged`. The Story 16 head-block consumers (`akgent-chat.component.ts`, `process.component.ts` providers) are untouched; the consumer specs were re-wired to a REAL `systemPrompt` store via a `useFactory` provider, with the render assertions unchanged — true façade parity. The ADR-005 NFR9 "≤2 exceptions" `describe` + `probeStateContainers` are deleted and replaced by a structural runtime probe: all four concerns asserted `instanceof PerAgentStore`, a `BehaviorSubject` own-property scan finds none (PerAgentStore excluded via `instanceof`, no name allow-list), and the negative `extraDict$` guard still bites. The selector spec is ported onto the real store + façade as the parity oracle (latest-wins, fallback first-wins, primary-supersedes-fallback both orderings, malformed → `[]`, per-agent isolation, late-subscriber, no-op suppression, fresh reference, REST/WS replay parity). The stale `commandsByAgent$` stub in `chat-panel.component.spec.ts` is replaced with a `commands`-shaped `{ snapshot: () => [] }` stub. No dangling reference to any removed symbol (`latestSystemPromptFold`/`latestSystemPromptParts`/`fallbackSystemPromptParts`/`rowsEqual`/`commandsByAgent$`) remains in `src/`; `SystemPromptRow` + `systemPromptLabel` stay exported. No ADR-string/comment/docstring assertions (Golden Rule #8 clean). Local gate green: Karma headless **845 SUCCESS** (0 failures), `npm run build` clean (pre-existing lodash CommonJS warning only). All changes confined to `packages/akgentic-frontend/`.

## Epic 17 slice complete

All four stories have landed on this branch. **One mechanism — `PerAgentStore` (a keyed O(Δ) reducer over `MessageLogService.log$`, owned by the component-scoped `PerAgentStoreRegistry`) — now owns every per-agent concern: `state`, `context`, `commands`, and `systemPrompt`.** The bespoke per-agent dicts (`stateDict$` / `contextDict$` / `commandsByAgent$`), the stopped-team replay-reconstruction loop, the per-`init()` resets, and the `SystemPromptSelector` whole-log fold are all deleted. Replay == live and reset == log-shrink are now structural (one code path in the registry), and the old "≤N sanctioned exceptions" invariant is replaced by a "registry is the only per-agent owner" probe that cannot be eroded. Adding a new per-agent event is now a single `register({...})` call.

**ADR-014 is `Proposed` — ratify it to `Accepted` before merging this umbrella PR** (pre-merge gate below).

## Scope guard

All changes in this PR stay inside `packages/akgentic-frontend/`. Story 17-1 adds exactly two new files
(`src/app/services/per-agent-store.ts`, `src/app/services/per-agent-store.spec.ts`) with NO consumer
wiring, NO deletions of the existing bespoke dicts / replay loop / resets, and `ActorMessageService`
untouched. Stories 17-2/17-3/17-4 modify only existing files under `packages/akgentic-frontend/src/`.
No cross-submodule changes.

## Pre-merge gate

ADR-014 (`decisions/adr-014-generic-per-agent-store.md`) is currently **Proposed**. Per the epic, it MUST
be ratified to **Accepted** before this umbrella PR merges.
