### PR TITLE
feat(akgentic-frontend): epic 19 — Top-Anchored Chat Scroll (ADR-016) (19-1-anchor-primitive-just-sent-signal-spacer-scroll-to-top → 19-3-jump-to-latest-indicator-and-follow-mode)

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -6,7 +6,7 @@
   block nor a long conversation can overflow the clipped tab container and push
   the chat input out of reach.
 -->
-<div class="trace-scroll" #traceScroll>
+<div class="trace-scroll" #traceScroll (scroll)="onScroll()">
   <!--
     Head system block — sourced ONCE from `systemPrompt$` (SystemPromptSelector,
     Story 16-1), independently of `context.length`. Latest-wins. `*ngIf ... as
@@ -34,11 +34,7 @@
        scroll region (hover-pauses auto-scroll via the table's mouse events). -->
   <div class="collapsible-container" *ngIf="context.length">
     <div class="collapsible">
-      <p-table
-        [value]="context"
-        (mouseenter)="isMouseOverTable = true"
-        (mouseleave)="isMouseOverTable = false"
-      >
+      <p-table [value]="context" [rowTrackBy]="trackByIndex">
       <ng-template #body let-message>
         <div class="card-container">
           <div class="card-header">
@@ -100,6 +96,18 @@
 </div>
 
 <div class="input-container">
+  <!-- "Messages" / "Auto scrolling" status pill, anchored on top of the input.
+       Click → follow (auto-scroll to the bottom). Hidden when the newest message
+       is on screen. -->
+  <button
+    *ngIf="indicatorLabel"
+    type="button"
+    class="jump-to-latest"
+    (click)="onFollowLatest()"
+  >
+    <i class="pi" [ngClass]="indicatorIcon"></i>
+    <span>{{ indicatorLabel }}</span>
+  </button>
   <p-floatlabel variant="in">
     <div class="input-row">
       <div class="input-row-textarea">
@@ -108,7 +116,6 @@
           rows="4"
           cols="50"
           [(ngModel)]="userInput"
-          (click)="scroll()"
           [mentionConfig]="mentionConfig"
           [mentionListTemplate]="mentionItemTemplate"
         ></textarea>

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
@@ -32,9 +32,39 @@
 
 .input-container {
     padding: 1rem 0rem 0rem;
+    position: relative;
     textarea {
     width: 100%;
     margin-bottom: 0.5rem;
+    }
+
+    // "Messages" / "Auto scrolling" pill — floats just above the input, centered.
+    .jump-to-latest {
+        position: absolute;
+        left: 50%;
+        bottom: 95%;
+        transform: translateX(-50%);
+        z-index: 5;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.35rem 0.9rem;
+        border: none;
+        border-radius: 999px;
+        background-color: #fff;
+        color: #475569;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+
+        .pi {
+            font-size: 0.85rem;
+        }
+
+        &:hover {
+            background-color: #f2f7f9;
+        }
     }
 }
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1,5 +1,5 @@
 import { SimpleChange } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
 
@@ -554,4 +554,177 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
     );
     expect(component.context.some((m) => m.type === 'system')).toBeFalse();
   });
+});
+
+describe('AkgentChatComponent — follow mode + status pill', () => {
+  let running: BehaviorSubject<boolean>;
+
+  function setup(): { component: AkgentChatComponent } {
+    running = new BehaviorSubject<boolean>(true);
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: running,
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        provideNoopAnimations(),
+      ],
+    });
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = 'a-mgr';
+    component.agentName = '@a-mgr';
+    return { component };
+  }
+
+  /** Install a mock trace-scroll element with controllable geometry. */
+  function installScroll(
+    component: AkgentChatComponent,
+    scrollHeight: number,
+    clientHeight: number,
+    scrollTop = 0,
+  ): { scrollHeight: number; clientHeight: number; scrollTop: number } {
+    const el = {
+      scrollHeight,
+      clientHeight,
+      scrollTop,
+      scrollTo(o: { top: number; behavior: ScrollBehavior }) {
+        this.scrollTop = o.top;
+      },
+    };
+    (component as any).traceScroll = { nativeElement: el };
+    return el;
+  }
+
+  it('does NOT auto-scroll a new message when not following', fakeAsync(() => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 0); // scrolled up, content below
+    component.updateContext([{ type: 'ai', name: 'x', content: 'hi' }] as any);
+    tick(0); // flush the post-render setTimeout
+    expect(el.scrollTop).toBe(0); // stayed put
+    expect(component.indicatorLabel).toBe('Messages'); // newest below the fold
+  }));
+
+  it('submitting enters follow mode and scrolls to the bottom', async () => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 0);
+    component.userInput = 'hello';
+    await component.sendMessage();
+    expect((component as any).following).toBeTrue();
+    expect(el.scrollTop).toBe(2000);
+    expect(component.indicatorLabel).toBe('Auto scrolling');
+  });
+
+  it('clicking the pill enters follow mode, scrolls down, shows "Auto scrolling"', () => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 0);
+    component.onFollowLatest();
+    expect((component as any).following).toBeTrue();
+    expect(el.scrollTop).toBe(2000);
+    expect(component.indicatorLabel).toBe('Auto scrolling');
+  });
+
+  it('shows "Messages" when the newest message is below the fold (not following)', () => {
+    const { component } = setup();
+    installScroll(component, 2000, 500, 100); // far from bottom
+    component.onScroll();
+    expect(component.indicatorLabel).toBe('Messages');
+  });
+
+  it('reaching the bottom activates follow ("Auto scrolling")', () => {
+    const { component } = setup();
+    installScroll(component, 2000, 500, 1500); // at the bottom (dist 0)
+    component.onScroll();
+    expect((component as any).following).toBeTrue();
+    expect(component.indicatorLabel).toBe('Auto scrolling');
+  });
+
+  it('a manual upward scroll exits follow mode → "Messages"', () => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 1500);
+    (component as any).following = true;
+    (component as any).lastScrollTop = 1500;
+    el.scrollTop = 200; // user scrolled up
+    component.onScroll();
+    expect((component as any).following).toBeFalse();
+    expect(component.indicatorLabel).toBe('Messages');
+  });
+
+  it('the smooth tail (moving DOWN) does not exit follow mode', () => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 1500);
+    (component as any).following = true;
+    (component as any).lastScrollTop = 1000; // tail moved down the page
+    void el;
+    component.onScroll();
+    expect((component as any).following).toBeTrue();
+    expect(component.indicatorLabel).toBe('Auto scrolling');
+  });
+
+  it('does NOT show "Auto scrolling" when the process is stopped', () => {
+    const { component } = setup();
+    running.next(false);
+    installScroll(component, 2000, 500, 1500);
+    (component as any).following = true;
+    component.onScroll();
+    expect(component.indicatorLabel).not.toBe('Auto scrolling');
+  });
+
+  it('in follow mode, a new message tails to the bottom', fakeAsync(() => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 0);
+    (component as any).following = true;
+    component.updateContext([{ type: 'ai', name: 'x', content: 'hi' }] as any);
+    tick(0);
+    expect(el.scrollTop).toBe(2000);
+  }));
+
+  it('switching member jumps the trace to the TOP (instant), no follow carry-over', fakeAsync(() => {
+    const { component } = setup();
+    const el = installScroll(component, 2000, 500, 1500); // prev agent: scrolled down
+    (component as any).following = true; // was following the previous member
+    component.agentId = 'a-other';
+    component.ngOnChanges({
+      agentId: new SimpleChange('a-mgr', 'a-other', false),
+    });
+    tick(0); // post-render scroll-to-top
+    expect((component as any).following).toBeFalse();
+    expect(el.scrollTop).toBe(0); // jumped to the top
+
+    // The new member's content streams in — it must STAY at the top (not tail).
+    component.updateContext([{ type: 'ai', name: 'x', content: 'hi' }] as any);
+    tick(0);
+    expect(el.scrollTop).toBe(0);
+  }));
 });

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -104,6 +104,17 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['agentId'] && !changes['agentId'].firstChange) {
       this.bindSystemPrompt();
+      // Switching members reuses this component (only the table content swaps),
+      // so start FRESH: drop any carried-over follow mode and jump the trace to
+      // the TOP — instantly, after the new content renders. `scrollTop = 0` is the
+      // top regardless of content height.
+      this.following = false;
+      this.lastScrollTop = 0;
+      setTimeout(() => {
+        const el = this.traceScroll?.nativeElement;
+        if (el) el.scrollTop = 0;
+        this.updateIndicator();
+      }, 0);
     }
   }
 
@@ -112,14 +123,21 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     // Subsequent agent switches re-bind it in ngOnChanges — see above.
     this.bindSystemPrompt();
 
-    // Subscribe to context$ for the selected agent.
+    // Subscribe to context$ for the selected agent. No scroll on enter / on every
+    // message — the panel only auto-scrolls while in FOLLOW mode (see updateContext).
     this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((ctx) => {
-      if (this.isLoading) {
-        setTimeout(() => this.scroll(), 10);
-      }
       this.isLoading = false;
       this.updateContext(ctx);
     });
+
+    // "Auto scrolling" only applies to a RUNNING process — exit follow + refresh
+    // the pill when the process stops.
+    this.contextService.currentTeamRunning$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((running) => {
+        if (!running) this.following = false;
+        this.updateIndicator();
+      });
   }
 
   /** Point `systemPrompt$` at the current `agentId`'s head system block. The
@@ -361,8 +379,11 @@ export class AkgentChatComponent implements OnInit, OnChanges {
       (message: any) => message.type !== 'tool_return_data'
     );
 
-    setTimeout(() => this.scroll(), 0);
-    this.initialLoad = false;
+    // Post-render: tail to the bottom ONLY while following; refresh the pill.
+    setTimeout(() => {
+      if (this.following) this.scrollToBottom();
+      this.updateIndicator();
+    }, 0);
   }
 
   userInput = '';
@@ -370,6 +391,9 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   async sendMessage() {
     if (!this.contextService.currentTeamRunning$.value) return;
     this.isLoading = true;
+    // Submitting enters FOLLOW mode and scrolls to the bottom (the input click no
+    // longer scrolls). Subsequent replies tail via updateContext.
+    this.following = true;
     const processId = this.contextService.currentProcessId$.value;
     try {
       await this.apiService.sendMessage(
@@ -381,14 +405,83 @@ export class AkgentChatComponent implements OnInit, OnChanges {
       this.isLoading = false;
     }
     this.userInput = '';
+    this.scrollToBottom();
+    this.updateIndicator();
   }
 
-  initialLoad = true;
-  isMouseOverTable: boolean = false; // Track mouse hover state
-  scroll(behavior: ScrollBehavior = 'smooth') {
+  /** Stable row identity for the trace table. Without it, p-table is given a
+   *  brand-new array on every context update and tears down/rebuilds ALL rows,
+   *  which momentarily shrinks scrollHeight, clamps scrollTop down, and fires a
+   *  spurious scroll event that looks like a user scroll-up (turning off follow
+   *  mid-stream). Index-based identity preserves the DOM on append. */
+  trackByIndex = (index: number): number => index;
+
+  // --- follow mode + "Messages" status pill (simplified member-chat scroll) ----
+  /** FOLLOW mode: auto-scroll to the bottom on every new message. */
+  following = false;
+  /** Status-pill label: 'Auto scrolling' (following + running), 'Messages'
+   *  (newest below the fold, not following), or null (hidden). */
+  indicatorLabel: string | null = null;
+  /** Last scrollTop — tells a user scroll-UP from our own smooth scroll. */
+  private lastScrollTop = 0;
+  /** Within this many px of the bottom counts as "at the bottom". */
+  private readonly NEAR_BOTTOM = 40;
+
+  /** Scroll handler (template `(scroll)`). A user scroll-up exits follow; the
+   *  pill is re-derived from the new position. */
+  onScroll(): void {
     const el = this.traceScroll?.nativeElement;
-    if (el && !this.isMouseOverTable && !this.initialLoad) {
-      el.scrollTo({ top: el.scrollHeight, behavior });
+    if (!el) return;
+    const movedUp = el.scrollTop < this.lastScrollTop - 2;
+    this.lastScrollTop = el.scrollTop;
+    // Reaching the bottom turns auto-scroll ON; scrolling up turns it off.
+    if (!this.newestBelowFold()) {
+      this.following = true;
+    } else if (this.following && movedUp) {
+      this.following = false;
     }
+    this.updateIndicator();
+  }
+
+  /** Pill click — jump to the bottom and start following. */
+  onFollowLatest(): void {
+    this.following = true;
+    this.scrollToBottom();
+    this.updateIndicator();
+  }
+
+  /** True when the newest message is below the visible viewport. No spacer in the
+   *  member chat, so distance-to-bottom is exact. */
+  private newestBelowFold(): boolean {
+    const el = this.traceScroll?.nativeElement;
+    if (!el) return false;
+    return el.scrollHeight - el.scrollTop - el.clientHeight > this.NEAR_BOTTOM;
+  }
+
+  /** Recompute the status-pill label. "Auto scrolling" only while the process is
+   *  running; otherwise "Messages" when the newest message is below the fold. */
+  private updateIndicator(): void {
+    if (this.following && this.contextService.currentTeamRunning$.value) {
+      this.indicatorLabel = 'Auto scrolling';
+    } else {
+      this.indicatorLabel = this.newestBelowFold() ? 'Messages' : null;
+    }
+  }
+
+  /** Icon for the pill — a "following" glyph while auto scrolling, else a down-arrow. */
+  get indicatorIcon(): string {
+    return this.indicatorLabel === 'Auto scrolling' ? 'pi-sync' : 'pi-arrow-down';
+  }
+
+  private scrollToBottom(): void {
+    const el = this.traceScroll?.nativeElement;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: this.scrollBehavior() });
+  }
+
+  /** Smooth by default; instant under reduced motion. */
+  private scrollBehavior(): ScrollBehavior {
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+      ? 'auto'
+      : 'smooth';
   }
 }

--- a/src/app/components/process/components/chat/chat-panel.component.html
+++ b/src/app/components/process/components/chat/chat-panel.component.html
@@ -1,4 +1,4 @@
-<div class="chat-container" (mouseenter)="onMouseEnter()" (mouseleave)="onMouseLeave()">
+<div class="chat-container">
   <ng-container *ngIf="displayItems.length > 0; else noMessagesPlaceholder">
     <div
       class="message-list"
@@ -25,10 +25,10 @@
           (toggleExpanded)="onToggleThinkingExpanded($event)"
         ></app-chat-thinking>
       </ng-container>
-      <!-- Story 19-1 (ADR-016 §Decision 2): trailing spacer reserves scroll
-           room so the anchored turn can park at the top. Plain element AFTER
-           the *ngFor — never iterated by trackByDisplayItem. -->
-      <div class="message-spacer" [style.min-height.px]="spacerHeight"></div>
+      <!-- ADR-016: trailing spacer reserves scroll room so the just-sent message
+           can park at the top. Plain element AFTER the *ngFor (never iterated by
+           trackByDisplayItem); its min-height is written imperatively. -->
+      <div class="message-spacer" #spacer></div>
     </div>
   </ng-container>
   <ng-template #noMessagesPlaceholder>
@@ -55,21 +55,23 @@
       </div>
     </ng-template>
   </ng-template>
-  <!-- Story 19-3 (ADR-016 §Decision 6): jump-to-latest indicator. Overlays the
-       bottom edge of the message list, above <app-user-input>. OUTSIDE
-       #scrollContainer so it does not change scrollHeight. *ngIf-gated so it is
-       absent from the DOM (and captures no pointer events) when hidden. The
-       click handler is the ONLY entry into follow mode. -->
-  <button
-    *ngIf="showJumpToLatest"
-    type="button"
-    class="jump-to-latest"
-    (click)="onJumpToLatest()"
-  >
-    <i class="pi pi-arrow-down"></i>
-    <span>New messages</span>
-  </button>
-  <app-user-input [processId]="processId"></app-user-input>
+  <!-- The "New messages" indicator sits directly ON TOP of the input field
+       (positioned against `.input-area`, which wraps the input). OUTSIDE
+       #scrollContainer so it never changes scrollHeight; *ngIf-gated so it is
+       absent (and captures no pointer events) when hidden. Its click handler is
+       the ONLY entry into follow mode. -->
+  <div class="input-area">
+    <button
+      *ngIf="indicatorLabel"
+      type="button"
+      class="jump-to-latest"
+      (click)="onJumpToLatest()"
+    >
+      <i class="pi" [ngClass]="indicatorIcon"></i>
+      <span>{{ indicatorLabel }}</span>
+    </button>
+    <app-user-input [processId]="processId"></app-user-input>
+  </div>
   <app-chat-human-modal
     [visible]="modalVisible"
     [agentPair]="modalAgentPair"

--- a/src/app/components/process/components/chat/chat-panel.component.html
+++ b/src/app/components/process/components/chat/chat-panel.component.html
@@ -55,6 +55,20 @@
       </div>
     </ng-template>
   </ng-template>
+  <!-- Story 19-3 (ADR-016 §Decision 6): jump-to-latest indicator. Overlays the
+       bottom edge of the message list, above <app-user-input>. OUTSIDE
+       #scrollContainer so it does not change scrollHeight. *ngIf-gated so it is
+       absent from the DOM (and captures no pointer events) when hidden. The
+       click handler is the ONLY entry into follow mode. -->
+  <button
+    *ngIf="showJumpToLatest"
+    type="button"
+    class="jump-to-latest"
+    (click)="onJumpToLatest()"
+  >
+    <i class="pi pi-arrow-down"></i>
+    <span>New messages</span>
+  </button>
   <app-user-input [processId]="processId"></app-user-input>
   <app-chat-human-modal
     [visible]="modalVisible"

--- a/src/app/components/process/components/chat/chat-panel.component.html
+++ b/src/app/components/process/components/chat/chat-panel.component.html
@@ -4,6 +4,7 @@
       <ng-container *ngFor="let item of displayItems; trackBy: trackByDisplayItem">
         <app-chat-message
           *ngIf="item.kind === 'message'"
+          [attr.data-message-id]="item.data.id"
           [message]="item.data"
           [selected]="item.data.id === selectedMessageId"
           [notification]="hasNotification(item.data)"
@@ -19,6 +20,10 @@
           (toggleExpanded)="onToggleThinkingExpanded($event)"
         ></app-chat-thinking>
       </ng-container>
+      <!-- Story 19-1 (ADR-016 §Decision 2): trailing spacer reserves scroll
+           room so the anchored turn can park at the top. Plain element AFTER
+           the *ngFor — never iterated by trackByDisplayItem. -->
+      <div class="message-spacer" [style.min-height.px]="spacerHeight"></div>
     </div>
   </ng-container>
   <ng-template #noMessagesPlaceholder>

--- a/src/app/components/process/components/chat/chat-panel.component.html
+++ b/src/app/components/process/components/chat/chat-panel.component.html
@@ -1,6 +1,11 @@
 <div class="chat-container" (mouseenter)="onMouseEnter()" (mouseleave)="onMouseLeave()">
   <ng-container *ngIf="displayItems.length > 0; else noMessagesPlaceholder">
-    <div class="message-list" #scrollContainer (click)="onBackgroundClick()">
+    <div
+      class="message-list"
+      #scrollContainer
+      (click)="onBackgroundClick()"
+      (scroll)="onScroll()"
+    >
       <ng-container *ngFor="let item of displayItems; trackBy: trackByDisplayItem">
         <app-chat-message
           *ngIf="item.kind === 'message'"

--- a/src/app/components/process/components/chat/chat-panel.component.scss
+++ b/src/app/components/process/components/chat/chat-panel.component.scss
@@ -26,8 +26,15 @@
     overflow-anchor: none;
   }
 
-  app-user-input {
+  // Wraps the input field; the positioning context for the "New messages" pill
+  // so the pill sits directly on top of the input regardless of its height.
+  .input-area {
     flex: 0 0 auto;
+    position: relative;
+  }
+
+  app-user-input {
+    display: block;
     padding: 0.5rem 1.2rem;
     background-color: #fff;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -35,16 +42,14 @@
     border-bottom-right-radius: 6px;
   }
 
-  // Story 19-3 (ADR-016 §Decision 6): jump-to-latest pill. Absolutely
-  // positioned (the .chat-container is `position: relative`) so it overlays the
-  // bottom edge of the message list, centered, sitting just above the
-  // app-user-input band. High z-index floats it over the message list; it stays
-  // below any modal overlay. It is NOT a flex child of .message-list, so it does
-  // not shift the message list layout or change the scroll container height.
+  // "New messages" pill — anchored to the TOP edge of the input area
+  // (`bottom: 100%`), centered, floating just above the input field. Not a flex
+  // child of .message-list, so it never shifts the list or changes scrollHeight.
   .jump-to-latest {
     position: absolute;
     left: 50%;
-    bottom: 4.5rem;
+    bottom: 100%;
+    //margin-bottom: 0.5rem;
     transform: translateX(-50%);
     z-index: 5;
     display: inline-flex;

--- a/src/app/components/process/components/chat/chat-panel.component.scss
+++ b/src/app/components/process/components/chat/chat-panel.component.scss
@@ -34,6 +34,40 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
+
+  // Story 19-3 (ADR-016 §Decision 6): jump-to-latest pill. Absolutely
+  // positioned (the .chat-container is `position: relative`) so it overlays the
+  // bottom edge of the message list, centered, sitting just above the
+  // app-user-input band. High z-index floats it over the message list; it stays
+  // below any modal overlay. It is NOT a flex child of .message-list, so it does
+  // not shift the message list layout or change the scroll container height.
+  .jump-to-latest {
+    position: absolute;
+    left: 50%;
+    bottom: 4.5rem;
+    transform: translateX(-50%);
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.9rem;
+    border: none;
+    border-radius: 999px;
+    background-color: #fff;
+    color: #475569;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+
+    .pi {
+      font-size: 0.85rem;
+    }
+
+    &:hover {
+      background-color: #f2f7f9;
+    }
+  }
 }
 
 .empty-section {

--- a/src/app/components/process/components/chat/chat-panel.component.scss
+++ b/src/app/components/process/components/chat/chat-panel.component.scss
@@ -17,6 +17,15 @@
     padding-bottom: 0.5rem;
   }
 
+  // Story 19-1 (ADR-016 §Decision 2): trailing spacer — visually inert flex
+  // child that reserves scroll room below the anchored turn. No background /
+  // border; `overflow-anchor: none` so the browser's scroll-anchoring never
+  // pins to it; non-focusable (a <div> with no tabindex).
+  .message-spacer {
+    flex: 0 0 auto;
+    overflow-anchor: none;
+  }
+
   app-user-input {
     flex: 0 0 auto;
     padding: 0.5rem 1.2rem;

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -974,7 +974,14 @@ describe('ChatPanelComponent', () => {
     });
   });
 
-  describe('Hover-aware auto-scroll lock (Story 4.4)', () => {
+  // -------------------------------------------------------------------------
+  // Story 19-2 (ADR-016) — retire default autoscroll, idle/anchored state
+  // machine, one-shot mount scroll, programmatic-vs-user guard, typed hover
+  // owed-action. The legacy Story 4.4 default-autoscroll specs are rewritten
+  // here for the new state machine (the old `shouldScrollToBottom`/
+  // `checkShouldAutoScroll` default re-pin no longer exists).
+  // -------------------------------------------------------------------------
+  describe('Story 19-2: state machine, mount scroll, programmatic guard, hover owed-action', () => {
     // Helper to install a mock scrollContainer with controllable
     // scrollTop/scrollHeight/clientHeight on the component.
     function installMockScrollContainer(
@@ -987,82 +994,208 @@ describe('ChatPanelComponent', () => {
       return mockEl;
     }
 
-    it('(a) auto-scroll fires when NOT hovered and a new message arrives', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      // Not hovered (default)
-      expect((component as any).isHovered).toBe(false);
-      // Simulate DOM growth from a new message.
-      mockEl.scrollHeight = 1200;
-      component.ngAfterViewChecked();
-      expect(mockEl.scrollTop).toBe(1200);
-    });
-
-    it('(b) auto-scroll is SUSPENDED when hovered; pendingCatchUpScroll is set', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 850; // near bottom so shouldScrollToBottom will be true
-      (component as any).checkShouldAutoScroll();
-      component.onMouseEnter();
-      expect((component as any).isHovered).toBe(true);
-
-      // New message arrives while hovered.
+    function sendUserTurn(id: string, ts = '2026-06-14T10:00:00Z') {
       const sent = makeSentMessage(
         { name: '@Human', role: 'Human' },
         { name: '@Manager', role: 'Manager' },
-        'hovered-arrival',
-        'hov-1',
+        'user turn',
+        id,
       );
-      messagesSubject.next([sent]);
-      mockEl.scrollHeight = 1200;
-      component.ngAfterViewChecked();
+      sent.timestamp = ts;
+      sent.message.timestamp = ts;
+      return sent;
+    }
 
-      // scrollTop was NOT moved to bottom — hover suspends.
-      expect(mockEl.scrollTop).toBe(850);
-      expect((component as any).pendingCatchUpScroll).toBe(true);
+    // --- AC #1: no-jump-while-streaming / idle ---------------------------------
+    it('AC #1: in idle, repeated growth does NOT move scrollTop (no autoscroll)', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 200; // user parked somewhere, not at bottom
+      // Latch the mount scroll so it does not fire (we test pure idle growth).
+      (component as any).hasDoneInitialScroll = true;
+      expect((component as any).scrollMode).toBe('idle');
+
+      // Several emissions grow the content.
+      for (const h of [1200, 1500, 1800]) {
+        mockEl.scrollHeight = h;
+        component.ngAfterViewChecked();
+      }
+      // Idle never moves the view on its own.
+      expect(mockEl.scrollTop).toBe(200);
     });
 
-    it('(c) mouseleave performs catch-up when a message arrived during hover', fakeAsync(() => {
+    // --- AC #4: one-shot mount scroll + latch ---------------------------------
+    it('AC #4: mount fires exactly ONE instant scroll-to-bottom, then never again', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      expect((component as any).hasDoneInitialScroll).toBe(false);
+
+      component.ngAfterViewChecked();
+      // Instant jump to bottom on the first laid-out view-settle.
+      expect(mockEl.scrollTop).toBe(1000);
+      expect((component as any).hasDoneInitialScroll).toBe(true);
+      // After mount the panel is idle (does not keep tailing).
+      expect((component as any).scrollMode).toBe('idle');
+
+      // Subsequent growth / view-checks must NOT re-fire the mount scroll.
+      mockEl.scrollTop = 300; // user scrolled up
+      mockEl.scrollHeight = 1600;
+      component.ngAfterViewChecked();
+      component.ngAfterViewChecked();
+      expect(mockEl.scrollTop).toBe(300);
+    });
+
+    it('AC #4: mount scroll does not fire while scrollHeight is 0 (not laid out)', () => {
+      const mockEl = installMockScrollContainer(0, 400);
+      component.ngAfterViewChecked();
+      expect((component as any).hasDoneInitialScroll).toBe(false);
+      expect(mockEl.scrollTop).toBe(0);
+
+      // Once content lays out, it fires once.
+      mockEl.scrollHeight = 900;
+      component.ngAfterViewChecked();
+      expect((component as any).hasDoneInitialScroll).toBe(true);
+      expect(mockEl.scrollTop).toBe(900);
+    });
+
+    it('AC #4: anchor precedence — mount scroll is skipped when a turn is anchored', () => {
+      const mockEl = installMockScrollContainer(1000, 400) as any;
+      // The anchor path runs first in ngAfterViewChecked; give the container a
+      // querySelector (anchor not yet rendered → null) so it no-ops cleanly.
+      mockEl.querySelector = (_sel: string) => null;
+      // A send arrived before mount settled.
+      (component as any).anchorMessageId = 'pending-anchor';
+      component.ngAfterViewChecked();
+      // Mount scroll did not fire (anchor owns the first frame).
+      expect((component as any).hasDoneInitialScroll).toBe(false);
+      expect(mockEl.scrollTop).toBe(0);
+    });
+
+    // --- AC #5: programmatic-vs-user scroll discrimination --------------------
+    it('AC #5: a programmatic write does NOT release the anchor', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-1';
+      // Simulate the bracket a programmatic write opens.
+      (component as any).isProgrammaticScroll = true;
+      // The write moved us above the near-bottom threshold...
+      mockEl.scrollTop = 0;
+      component.onScroll();
+      // ...but the guard suppresses the release.
+      expect((component as any).scrollMode).toBe('anchored');
+      expect((component as any).anchorMessageId).toBe('a-1');
+    });
+
+    it('AC #5: a genuine user scroll past the threshold DOES release the anchor', () => {
+      const mockEl = installMockScrollContainer(2000, 400);
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-2';
+      (component as any).anchorScrollDone = true;
+      (component as any).lastAnchorOffsetTop = 600;
+      component.spacerHeight = 300;
+      (component as any).isProgrammaticScroll = false;
+      // User scrolled to the top — far above the near-bottom threshold
+      // (distanceFromBottom = 2000 - 0 - 400 = 1600 > 100).
+      mockEl.scrollTop = 0;
+
+      component.onScroll();
+
+      expect((component as any).scrollMode).toBe('idle');
+      expect((component as any).anchorMessageId).toBeNull();
+      expect((component as any).anchorScrollDone).toBe(false);
+      expect((component as any).lastAnchorOffsetTop).toBeNull();
+      expect(component.spacerHeight).toBe(0);
+    });
+
+    it('AC #5: a user scroll that stays near the bottom does NOT release', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-3';
+      (component as any).isProgrammaticScroll = false;
+      // distanceFromBottom = 1000 - 550 - 400 = 50 <= 100 (near bottom).
+      mockEl.scrollTop = 550;
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('anchored');
+    });
+
+    it('AC #5: the programmatic guard clears after a microtask so a later user scroll releases', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(2000, 400);
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-4';
+      // Open the guard window the way scrollToBottom() does.
+      (component as any).beginProgrammaticScroll();
+      expect((component as any).isProgrammaticScroll).toBe(true);
+
+      flushMicrotasks();
+      expect((component as any).isProgrammaticScroll).toBe(false);
+
+      // A genuine user scroll in a later tick now releases.
+      mockEl.scrollTop = 0;
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('idle');
+    }));
+
+    // --- AC #6: typed hover owed-action --------------------------------------
+    it('AC #6: a new message during hover (turn anchored) owes a top-anchor', () => {
       const mockEl = installMockScrollContainer(1000, 400);
       mockEl.scrollTop = 850;
-      (component as any).checkShouldAutoScroll();
-      component.onMouseEnter();
+      (component as any).anchorMessageId = 'hov-anchor';
 
+      component.onMouseEnter();
+      messagesSubject.next([sendUserTurn('hov-1')]);
+      // anchorMessageId stays non-null (already set) — owed kind is top-anchor.
+      expect((component as any).owedScroll).toBe('top-anchor');
+    });
+
+    it('AC #6: a new message during hover (no anchor, near bottom) owes a mount-bottom', () => {
+      const mockEl = installMockScrollContainer(1000, 400);
+      mockEl.scrollTop = 850; // near bottom (distanceFromBottom = 1000-850-400 < 0)
+      (component as any).anchorMessageId = null;
+
+      component.onMouseEnter();
       const sent = makeSentMessage(
-        { name: '@Human', role: 'Human' },
         { name: '@Manager', role: 'Manager' },
-        'catch-up',
-        'cu-1',
+        { name: '@Human', role: 'Human' },
+        'arrival',
+        'mb-1',
       );
       messagesSubject.next([sent]);
-      mockEl.scrollHeight = 1200;
-      component.ngAfterViewChecked();
-      expect(mockEl.scrollTop).toBe(850);
-      expect((component as any).pendingCatchUpScroll).toBe(true);
+      expect((component as any).owedScroll).toBe('mount-bottom');
+    });
+
+    it('AC #6: mouseleave replays a top-anchor owed action via the anchor scroll', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(1200, 500) as any;
+      // Give the container a resolvable anchor element + scrollTo recorder.
+      mockEl.scrollTop = 0;
+      mockEl.lastScrollTo = null;
+      mockEl.scrollTo = (opts: { top: number; behavior: string }) => {
+        mockEl.lastScrollTo = opts;
+        mockEl.scrollTop = opts.top;
+      };
+      mockEl.querySelector = (_sel: string) => ({ offsetTop: 600 });
+      (component as any).anchorMessageId = 'owed-anchor';
+      (component as any).owedScroll = 'top-anchor';
+      spyOn(window, 'matchMedia').and.returnValue({ matches: true } as any);
 
       component.onMouseLeave();
       flushMicrotasks();
 
-      expect(mockEl.scrollTop).toBe(1200);
-      expect((component as any).pendingCatchUpScroll).toBe(false);
-      expect((component as any).isHovered).toBe(false);
+      // The anchor scroll replayed (offsetTop 600 - padding 8 = 592).
+      expect(mockEl.lastScrollTo?.top).toBe(592);
+      expect((component as any).owedScroll).toBeNull();
     }));
 
-    it('(d) mouseleave does NOT catch-up if no message arrived during hover', fakeAsync(() => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 850;
-      (component as any).checkShouldAutoScroll();
+    it('AC #6: mouseleave replays a mount-bottom owed action via scrollToBottom', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(1300, 400);
+      mockEl.scrollTop = 0;
+      (component as any).owedScroll = 'mount-bottom';
 
-      component.onMouseEnter();
-      // No message arrives — scrollHeight unchanged.
-      component.ngAfterViewChecked();
       component.onMouseLeave();
       flushMicrotasks();
 
-      expect(mockEl.scrollTop).toBe(850);
-      expect((component as any).pendingCatchUpScroll).toBe(false);
+      expect(mockEl.scrollTop).toBe(1300);
+      expect((component as any).owedScroll).toBeNull();
     }));
 
-    it('(e) collapse toggle during hover does NOT queue a catch-up', fakeAsync(() => {
-      // Seed a Rule 4 message so we have something to toggle.
+    it('AC #6: collapse toggle during hover does NOT queue an owed scroll', fakeAsync(() => {
       const r4 = makeSentMessage(
         { name: '@Worker', role: 'Worker' },
         { name: '@Manager', role: 'Manager' },
@@ -1074,25 +1207,20 @@ describe('ChatPanelComponent', () => {
 
       const mockEl = installMockScrollContainer(1000, 400);
       mockEl.scrollTop = 850;
-      (component as any).checkShouldAutoScroll();
+      (component as any).hasDoneInitialScroll = true;
 
       component.onMouseEnter();
-
-      // User toggles collapse — this changes DOM height but is NOT a
-      // message-arrival event, so pendingCatchUpScroll MUST remain false.
+      // A collapse toggle changes DOM height but is NOT a message-arrival event.
       component.onToggleCollapse(component.chatMessages[0]);
-      mockEl.scrollHeight = 1100; // toggle grew the bubble
+      mockEl.scrollHeight = 1100;
       component.ngAfterViewChecked();
 
-      // Hover still suspends the scroll.
+      // No owed scroll queued for a collapse toggle; view unmoved.
+      expect((component as any).owedScroll).toBeNull();
       expect(mockEl.scrollTop).toBe(850);
-      // CRITICAL: no catch-up queued for a collapse toggle.
-      expect((component as any).pendingCatchUpScroll).toBe(false);
 
       component.onMouseLeave();
       flushMicrotasks();
-
-      // No catch-up fired — scrollTop still at 850.
       expect(mockEl.scrollTop).toBe(850);
     }));
   });
@@ -1340,6 +1468,168 @@ describe('ChatPanelComponent', () => {
       expect(list!.lastElementChild).toBe(spacer);
       // It is not a DisplayItem — only the message is.
       expect(component.displayItems.length).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Story 19-2 (ADR-016) — anchored-holds / release / re-anchor state
+  // transitions (driven through the anchor mock container, like 19-1).
+  // -------------------------------------------------------------------------
+  describe('Story 19-2: anchored-holds, release, re-anchor transitions', () => {
+    interface MockAnchorEl {
+      offsetTop: number;
+    }
+    interface MockContainer {
+      clientHeight: number;
+      scrollHeight: number;
+      scrollTop: number;
+      lastScrollTo: { top: number; behavior: string } | null;
+      scrollToCalls: number;
+      _anchor: MockAnchorEl | null;
+      querySelector(sel: string): MockAnchorEl | null;
+      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
+    }
+
+    function installContainer(
+      anchor: MockAnchorEl | null,
+      clientHeight = 500,
+      scrollHeight = 1200,
+    ): MockContainer {
+      const container: MockContainer = {
+        clientHeight,
+        scrollHeight,
+        scrollTop: 0,
+        lastScrollTo: null,
+        scrollToCalls: 0,
+        _anchor: anchor,
+        querySelector() {
+          return this._anchor;
+        },
+        scrollTo(opts) {
+          this.scrollToCalls += 1;
+          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
+          this.scrollTop = opts.top;
+        },
+      };
+      (component as any).scrollContainer = { nativeElement: container };
+      return container;
+    }
+
+    function mockReducedMotion(matches: boolean): void {
+      spyOn(window, 'matchMedia').and.returnValue({ matches } as any);
+    }
+
+    function sendUserMessage(id: string, ts = '2026-06-14T10:00:00Z') {
+      const sent = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'user turn',
+        id,
+      );
+      sent.timestamp = ts;
+      sent.message.timestamp = ts;
+      return sent;
+    }
+
+    function seedTurn(
+      id: string,
+      key: string,
+      anchor: MockAnchorEl | null,
+      clientHeight = 500,
+      scrollHeight = 1200,
+    ): MockContainer {
+      (component.chatService as any).emitJustSent(key);
+      messagesSubject.next([sendUserMessage(id)]);
+      return installContainer(anchor, clientHeight, scrollHeight);
+    }
+
+    it('AC #2: first anchor sets scrollMode = anchored', () => {
+      mockReducedMotion(false);
+      seedTurn('a-1', '1000', { offsetTop: 600 });
+      expect((component as any).scrollMode).toBe('idle');
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+    });
+
+    it('AC #1/#2: anchored holds — answer-below growth does not move the scroll', () => {
+      mockReducedMotion(false);
+      const anchorEl = { offsetTop: 600 };
+      const container = seedTurn('hold-1', '1000', anchorEl, 500, 1200);
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+      const parkedTop = container.scrollTop;
+
+      // Several downstream growths (streamed tokens) — offsetTop unchanged.
+      for (const h of [1600, 2000, 2400]) {
+        container.scrollHeight = h;
+        component.ngAfterViewChecked();
+      }
+      expect(container.scrollToCalls).toBe(1); // no extra scroll writes
+      expect(container.scrollTop).toBe(parkedTop);
+      expect((component as any).scrollMode).toBe('anchored');
+    });
+
+    it('AC #3: a user scroll event past the threshold releases the anchor to idle', () => {
+      mockReducedMotion(false);
+      const container = seedTurn('rel-1', '1000', { offsetTop: 600 }, 500, 2000);
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+
+      // Let the programmatic-guard window close, then simulate a genuine user
+      // scroll to the top (distanceFromBottom = 2000 - 0 - 500 = 1500 > 100).
+      (component as any).isProgrammaticScroll = false;
+      container.scrollTop = 0;
+      component.onScroll();
+
+      expect((component as any).scrollMode).toBe('idle');
+      expect((component as any).anchorMessageId).toBeNull();
+      expect(component.spacerHeight).toBe(0);
+    });
+
+    it('AC #3: natural scroll-off (anchor pushed above the fold) releases to idle', () => {
+      mockReducedMotion(false);
+      const anchorEl = { offsetTop: 600 };
+      const container = seedTurn('off-1', '1000', anchorEl, 500, 1200);
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+
+      // The answer grew so the anchor scrolled above the top of the viewport:
+      // offsetTop - scrollTop < topPadding (8). With scrollTop parked at 592,
+      // an anchor offsetTop of 595 means 595 - 592 = 3 < 8 → scrolled off.
+      anchorEl.offsetTop = 595;
+      component.ngAfterViewChecked();
+
+      expect((component as any).scrollMode).toBe('idle');
+      expect((component as any).anchorMessageId).toBeNull();
+      expect(container.scrollToCalls).toBe(1); // released, NOT re-pinned
+    });
+
+    it('AC #3: re-anchor on send — idle → (send) → anchored', () => {
+      mockReducedMotion(false);
+      const container = seedTurn('re-1', '1000', { offsetTop: 600 }, 500, 2000);
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+
+      // Release via user scroll.
+      (component as any).isProgrammaticScroll = false;
+      container.scrollTop = 0;
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('idle');
+
+      // A new turn is sent → latch resets, scrollMode returns to idle-intent,
+      // and the next matching emission re-anchors.
+      const key2 = String(Date.parse('2026-06-14T10:05:01Z'));
+      (component.chatService as any).emitJustSent(key2);
+      expect((component as any).scrollMode).toBe('idle');
+      messagesSubject.next([
+        sendUserMessage('re-1', '2026-06-14T10:00:00Z'),
+        sendUserMessage('re-2', '2026-06-14T10:06:00Z'),
+      ]);
+      expect((component as any).anchorMessageId).toBe('re-2');
+      const container2 = installContainer({ offsetTop: 800 }, 500, 2000);
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+      expect(container2.scrollToCalls).toBe(1);
     });
   });
 });

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -1,4 +1,11 @@
-import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  flushMicrotasks,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -1116,18 +1123,51 @@ describe('ChatPanelComponent', () => {
       expect((component as any).scrollMode).toBe('anchored');
     });
 
-    it('AC #5: the programmatic guard clears after a microtask so a later user scroll releases', fakeAsync(() => {
+    it('AC #5: the programmatic guard clears on the trailing debounce so a later user scroll releases', fakeAsync(() => {
       const mockEl = installMockScrollContainer(2000, 400);
       (component as any).scrollMode = 'anchored';
       (component as any).anchorMessageId = 'a-4';
-      // Open the guard window the way scrollToBottom() does.
+      // Open the guard window the way scrollToBottom()/applyAnchorScroll() do.
       (component as any).beginProgrammaticScroll();
       expect((component as any).isProgrammaticScroll).toBe(true);
 
+      // The guard outlasts a microtask checkpoint (a smooth scrollTo dispatches
+      // its `scroll` events across later frames, not the current microtask).
       flushMicrotasks();
+      expect((component as any).isProgrammaticScroll).toBe(true);
+
+      // Once the settle window elapses with no further scroll events, it drops.
+      tick((component as any).programmaticScrollSettleMs);
       expect((component as any).isProgrammaticScroll).toBe(false);
 
       // A genuine user scroll in a later tick now releases.
+      mockEl.scrollTop = 0;
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('idle');
+    }));
+
+    it('AC #5: the anchor does NOT release itself when its own async programmatic scroll events fire', fakeAsync(() => {
+      const mockEl = installMockScrollContainer(2000, 400);
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-5';
+      // Open the guard the way a smooth anchor write does.
+      (component as any).beginProgrammaticScroll();
+
+      // The smooth scroll parks the view near the TOP — its own `scroll` frames
+      // arrive across several later ticks, each below the near-bottom threshold.
+      // These are the animation's frames, not a user exit: the anchor must hold.
+      for (let i = 0; i < 4; i++) {
+        mockEl.scrollTop = i * 10; // still far above near-bottom (distance > 100)
+        component.onScroll();
+        tick(50); // less than the settle window — guard stays armed
+      }
+      expect((component as any).scrollMode).toBe('anchored');
+      expect((component as any).anchorMessageId).toBe('a-5');
+
+      // After the events stop for the full settle window, the guard drops and a
+      // genuine later user scroll releases.
+      tick((component as any).programmaticScrollSettleMs);
+      expect((component as any).isProgrammaticScroll).toBe(false);
       mockEl.scrollTop = 0;
       component.onScroll();
       expect((component as any).scrollMode).toBe('idle');
@@ -1181,6 +1221,7 @@ describe('ChatPanelComponent', () => {
       // The anchor scroll replayed (offsetTop 600 - padding 8 = 592).
       expect(mockEl.lastScrollTo?.top).toBe(592);
       expect((component as any).owedScroll).toBeNull();
+      flush(); // drain the programmatic-scroll settle timer the replay armed
     }));
 
     it('AC #6: mouseleave replays a mount-bottom owed action via scrollToBottom', fakeAsync(() => {
@@ -1193,6 +1234,7 @@ describe('ChatPanelComponent', () => {
 
       expect(mockEl.scrollTop).toBe(1300);
       expect((component as any).owedScroll).toBeNull();
+      flush(); // drain the programmatic-scroll settle timer the replay armed
     }));
 
     it('AC #6: collapse toggle during hover does NOT queue an owed scroll', fakeAsync(() => {

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -23,6 +23,7 @@ import { ChatMessage, classifyMessage } from '../../selectors/chat-message.model
 import { ApiService } from '../../../../core/http/api.service';
 import { AkgentService } from '../../../../core/ui/akgent.service';
 import { GraphDataService } from '../../selectors/graph.selector';
+import { ContextService } from '../../../../core/context/context.service';
 import { IngestionService } from '../../event/ingestion.service';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
@@ -982,966 +983,343 @@ describe('ChatPanelComponent', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Story 19-2 (ADR-016) — retire default autoscroll, idle/anchored state
-  // machine, one-shot mount scroll, programmatic-vs-user guard, typed hover
-  // owed-action. The legacy Story 4.4 default-autoscroll specs are rewritten
-  // here for the new state machine (the old `shouldScrollToBottom`/
-  // `checkShouldAutoScroll` default re-pin no longer exists).
+  // ADR-016 (simplified) — anchor-on-send + opt-in follow mode.
+  // Mocks model the REAL browser: scrollTo/scrollTop clamps, scrollHeight clamps
+  // UP to clientHeight, and the spacer's min-height feeds scrollHeight.
   // -------------------------------------------------------------------------
-  describe('Story 19-2: state machine, mount scroll, programmatic guard, hover owed-action', () => {
-    // Helper to install a mock scrollContainer with controllable
-    // scrollTop/scrollHeight/clientHeight on the component.
-    function installMockScrollContainer(
-      initialHeight = 1000,
-      clientHeight = 400,
-    ): { scrollTop: number; scrollHeight: number; clientHeight: number } {
-      const mockEl = { scrollTop: 0, scrollHeight: initialHeight, clientHeight };
-      (component as any).scrollContainer = { nativeElement: mockEl };
-      (component as any).lastScrollHeight = initialHeight;
-      return mockEl;
-    }
+  describe('scroll behavior (anchor-on-send + follow)', () => {
+    // Most scroll tests assume a RUNNING process (so "Auto scrolling" can show).
+    beforeEach(() => {
+      TestBed.inject(ContextService).currentTeamRunning$.next(true);
+    });
 
-    function sendUserTurn(id: string, ts = '2026-06-14T10:00:00Z') {
-      const sent = makeSentMessage(
+    function humanTurn(id: string): SentMessage {
+      return makeSentMessage(
         { name: '@Human', role: 'Human' },
         { name: '@Manager', role: 'Manager' },
         'user turn',
         id,
       );
-      sent.timestamp = ts;
-      sent.message.timestamp = ts;
-      return sent;
     }
-
-    // --- AC #1: no-jump-while-streaming / idle ---------------------------------
-    it('AC #1: in idle, repeated growth does NOT move scrollTop (no autoscroll)', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 200; // user parked somewhere, not at bottom
-      // Latch the mount scroll so it does not fire (we test pure idle growth).
-      (component as any).hasDoneInitialScroll = true;
-      expect((component as any).scrollMode).toBe('idle');
-
-      // Several emissions grow the content.
-      for (const h of [1200, 1500, 1800]) {
-        mockEl.scrollHeight = h;
-        component.ngAfterViewChecked();
-      }
-      // Idle never moves the view on its own.
-      expect(mockEl.scrollTop).toBe(200);
-    });
-
-    // --- AC #4: one-shot mount scroll + latch ---------------------------------
-    it('AC #4: mount fires exactly ONE instant scroll-to-bottom, then never again', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      expect((component as any).hasDoneInitialScroll).toBe(false);
-
-      component.ngAfterViewChecked();
-      // Instant jump to bottom on the first laid-out view-settle.
-      expect(mockEl.scrollTop).toBe(1000);
-      expect((component as any).hasDoneInitialScroll).toBe(true);
-      // After mount the panel is idle (does not keep tailing).
-      expect((component as any).scrollMode).toBe('idle');
-
-      // Subsequent growth / view-checks must NOT re-fire the mount scroll.
-      mockEl.scrollTop = 300; // user scrolled up
-      mockEl.scrollHeight = 1600;
-      component.ngAfterViewChecked();
-      component.ngAfterViewChecked();
-      expect(mockEl.scrollTop).toBe(300);
-    });
-
-    it('AC #4: mount scroll does not fire while scrollHeight is 0 (not laid out)', () => {
-      const mockEl = installMockScrollContainer(0, 400);
-      component.ngAfterViewChecked();
-      expect((component as any).hasDoneInitialScroll).toBe(false);
-      expect(mockEl.scrollTop).toBe(0);
-
-      // Once content lays out, it fires once.
-      mockEl.scrollHeight = 900;
-      component.ngAfterViewChecked();
-      expect((component as any).hasDoneInitialScroll).toBe(true);
-      expect(mockEl.scrollTop).toBe(900);
-    });
-
-    it('AC #4: anchor precedence — mount scroll is skipped when a turn is anchored', () => {
-      const mockEl = installMockScrollContainer(1000, 400) as any;
-      // The anchor path runs first in ngAfterViewChecked; give the container a
-      // querySelector (anchor not yet rendered → null) so it no-ops cleanly.
-      mockEl.querySelector = (_sel: string) => null;
-      // A send arrived before mount settled.
-      (component as any).anchorMessageId = 'pending-anchor';
-      component.ngAfterViewChecked();
-      // Mount scroll did not fire (anchor owns the first frame).
-      expect((component as any).hasDoneInitialScroll).toBe(false);
-      expect(mockEl.scrollTop).toBe(0);
-    });
-
-    // --- AC #5: programmatic-vs-user scroll discrimination --------------------
-    it('AC #5: a programmatic write does NOT release the anchor', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-1';
-      // Simulate the bracket a programmatic write opens.
-      (component as any).isProgrammaticScroll = true;
-      // The write moved us above the near-bottom threshold...
-      mockEl.scrollTop = 0;
-      component.onScroll();
-      // ...but the guard suppresses the release.
-      expect((component as any).scrollMode).toBe('anchored');
-      expect((component as any).anchorMessageId).toBe('a-1');
-    });
-
-    it('AC #5: a genuine user scroll past the threshold DOES release the anchor', () => {
-      const mockEl = installMockScrollContainer(2000, 400);
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-2';
-      (component as any).anchorScrollDone = true;
-      (component as any).lastAnchorOffsetTop = 600;
-      component.spacerHeight = 300;
-      (component as any).isProgrammaticScroll = false;
-      // User scrolled to the top — far above the near-bottom threshold
-      // (distanceFromBottom = 2000 - 0 - 400 = 1600 > 100).
-      mockEl.scrollTop = 0;
-
-      component.onScroll();
-
-      expect((component as any).scrollMode).toBe('idle');
-      expect((component as any).anchorMessageId).toBeNull();
-      expect((component as any).anchorScrollDone).toBe(false);
-      expect((component as any).lastAnchorOffsetTop).toBeNull();
-      expect(component.spacerHeight).toBe(0);
-    });
-
-    it('AC #5: a user scroll that stays near the bottom does NOT release', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-3';
-      (component as any).isProgrammaticScroll = false;
-      // distanceFromBottom = 1000 - 550 - 400 = 50 <= 100 (near bottom).
-      mockEl.scrollTop = 550;
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('anchored');
-    });
-
-    it('AC #5: the programmatic guard clears on the trailing debounce so a later user scroll releases', fakeAsync(() => {
-      const mockEl = installMockScrollContainer(2000, 400);
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-4';
-      // Open the guard window the way scrollToBottom()/applyAnchorScroll() do.
-      (component as any).beginProgrammaticScroll();
-      expect((component as any).isProgrammaticScroll).toBe(true);
-
-      // The guard outlasts a microtask checkpoint (a smooth scrollTo dispatches
-      // its `scroll` events across later frames, not the current microtask).
-      flushMicrotasks();
-      expect((component as any).isProgrammaticScroll).toBe(true);
-
-      // Once the settle window elapses with no further scroll events, it drops.
-      tick((component as any).programmaticScrollSettleMs);
-      expect((component as any).isProgrammaticScroll).toBe(false);
-
-      // A genuine user scroll in a later tick now releases.
-      mockEl.scrollTop = 0;
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('idle');
-    }));
-
-    it('AC #5: the anchor does NOT release itself when its own async programmatic scroll events fire', fakeAsync(() => {
-      const mockEl = installMockScrollContainer(2000, 400);
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-5';
-      // Open the guard the way a smooth anchor write does.
-      (component as any).beginProgrammaticScroll();
-
-      // The smooth scroll parks the view near the TOP — its own `scroll` frames
-      // arrive across several later ticks, each below the near-bottom threshold.
-      // These are the animation's frames, not a user exit: the anchor must hold.
-      for (let i = 0; i < 4; i++) {
-        mockEl.scrollTop = i * 10; // still far above near-bottom (distance > 100)
-        component.onScroll();
-        tick(50); // less than the settle window — guard stays armed
-      }
-      expect((component as any).scrollMode).toBe('anchored');
-      expect((component as any).anchorMessageId).toBe('a-5');
-
-      // After the events stop for the full settle window, the guard drops and a
-      // genuine later user scroll releases.
-      tick((component as any).programmaticScrollSettleMs);
-      expect((component as any).isProgrammaticScroll).toBe(false);
-      mockEl.scrollTop = 0;
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('idle');
-    }));
-
-    // --- AC #6: typed hover owed-action --------------------------------------
-    it('AC #6: a new message during hover (turn anchored) owes a top-anchor', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 850;
-      (component as any).anchorMessageId = 'hov-anchor';
-
-      component.onMouseEnter();
-      messagesSubject.next([sendUserTurn('hov-1')]);
-      // anchorMessageId stays non-null (already set) — owed kind is top-anchor.
-      expect((component as any).owedScroll).toBe('top-anchor');
-    });
-
-    it('AC #6: a new message during hover (no anchor, near bottom) owes a mount-bottom', () => {
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 850; // near bottom (distanceFromBottom = 1000-850-400 < 0)
-      (component as any).anchorMessageId = null;
-
-      component.onMouseEnter();
-      const sent = makeSentMessage(
-        { name: '@Manager', role: 'Manager' },
-        { name: '@Human', role: 'Human' },
-        'arrival',
-        'mb-1',
-      );
-      messagesSubject.next([sent]);
-      expect((component as any).owedScroll).toBe('mount-bottom');
-    });
-
-    it('AC #6: mouseleave replays a top-anchor owed action via the anchor scroll', fakeAsync(() => {
-      const mockEl = installMockScrollContainer(1200, 500) as any;
-      // Give the container a resolvable anchor element + scrollTo recorder.
-      mockEl.scrollTop = 0;
-      mockEl.lastScrollTo = null;
-      mockEl.scrollTo = (opts: { top: number; behavior: string }) => {
-        mockEl.lastScrollTo = opts;
-        mockEl.scrollTop = opts.top;
-      };
-      mockEl.querySelector = (_sel: string) => ({ offsetTop: 600 });
-      (component as any).anchorMessageId = 'owed-anchor';
-      (component as any).owedScroll = 'top-anchor';
-      spyOn(window, 'matchMedia').and.returnValue({ matches: true } as any);
-
-      component.onMouseLeave();
-      flushMicrotasks();
-
-      // The anchor scroll replayed (offsetTop 600 - padding 8 = 592).
-      expect(mockEl.lastScrollTo?.top).toBe(592);
-      expect((component as any).owedScroll).toBeNull();
-      flush(); // drain the programmatic-scroll settle timer the replay armed
-    }));
-
-    it('AC #6: mouseleave replays a mount-bottom owed action via scrollToBottom', fakeAsync(() => {
-      const mockEl = installMockScrollContainer(1300, 400);
-      mockEl.scrollTop = 0;
-      (component as any).owedScroll = 'mount-bottom';
-
-      component.onMouseLeave();
-      flushMicrotasks();
-
-      expect(mockEl.scrollTop).toBe(1300);
-      expect((component as any).owedScroll).toBeNull();
-      flush(); // drain the programmatic-scroll settle timer the replay armed
-    }));
-
-    it('AC #6: collapse toggle during hover does NOT queue an owed scroll', fakeAsync(() => {
-      const r4 = makeSentMessage(
-        { name: '@Worker', role: 'Worker' },
-        { name: '@Manager', role: 'Manager' },
-        'ai msg',
-        'r4-hover',
-      );
-      messagesSubject.next([r4]);
-      fixture.detectChanges();
-
-      const mockEl = installMockScrollContainer(1000, 400);
-      mockEl.scrollTop = 850;
-      (component as any).hasDoneInitialScroll = true;
-
-      component.onMouseEnter();
-      // A collapse toggle changes DOM height but is NOT a message-arrival event.
-      component.onToggleCollapse(component.chatMessages[0]);
-      mockEl.scrollHeight = 1100;
-      component.ngAfterViewChecked();
-
-      // No owed scroll queued for a collapse toggle; view unmoved.
-      expect((component as any).owedScroll).toBeNull();
-      expect(mockEl.scrollTop).toBe(850);
-
-      component.onMouseLeave();
-      flushMicrotasks();
-      expect(mockEl.scrollTop).toBe(850);
-    }));
-  });
-
-  // -------------------------------------------------------------------------
-  // Story 19-1 (ADR-016) — top-anchor primitive
-  // -------------------------------------------------------------------------
-  describe('top-anchor primitive (Story 19-1)', () => {
-    // A mock scroll container whose querySelector returns a controllable
-    // anchor element (data-message-id lookup), with controllable client/scroll
-    // heights and a recording scrollTo.
-    interface MockAnchorEl {
-      offsetTop: number;
-    }
-    interface MockContainer {
-      clientHeight: number;
-      scrollHeight: number;
-      scrollTop: number;
-      lastScrollTo: { top: number; behavior: string } | null;
-      scrollToCalls: number;
-      querySelectorCalls: string[];
-      _anchor: MockAnchorEl | null;
-      querySelector(sel: string): MockAnchorEl | null;
-      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
-    }
-
-    function installContainer(
-      anchor: MockAnchorEl | null,
-      clientHeight = 500,
-      scrollHeight = 1200,
-    ): MockContainer {
-      const container: MockContainer = {
-        clientHeight,
-        scrollHeight,
-        scrollTop: 0,
-        lastScrollTo: null,
-        scrollToCalls: 0,
-        querySelectorCalls: [],
-        _anchor: anchor,
-        querySelector(sel: string) {
-          this.querySelectorCalls.push(sel);
-          return this._anchor;
-        },
-        scrollTo(opts) {
-          this.scrollToCalls += 1;
-          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
-          this.scrollTop = opts.top;
-        },
-      };
-      (component as any).scrollContainer = { nativeElement: container };
-      return container;
-    }
-
-    function mockReducedMotion(matches: boolean): void {
-      spyOn(window, 'matchMedia').and.returnValue({
-        matches,
-        media: '(prefers-reduced-motion: reduce)',
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      } as any);
-    }
-
-    function sendUserMessage(id: string, ts = '2026-06-14T10:00:00Z') {
-      const sent = makeSentMessage(
-        { name: '@Human', role: 'Human' },
-        { name: '@Manager', role: 'Manager' },
-        'user turn',
-        id,
-      );
-      sent.timestamp = ts;
-      sent.message.timestamp = ts;
-      return sent;
-    }
-
-    // Seed a turn WITHOUT change detection: emit the just-sent key, push the
-    // user message through the log (the BehaviorSubject pipe runs synchronously,
-    // so `chatMessages`/`displayItems` update and the anchor id resolves), then
-    // install the controllable mock container. We deliberately avoid
-    // `fixture.detectChanges()` here so Angular's lifecycle does not run
-    // `ngAfterViewChecked` against the real @ViewChild('scrollContainer') and
-    // fire the anchor before the mock is in place — the test drives the
-    // post-layout pass explicitly via `component.ngAfterViewChecked()`.
-    function seedTurn(
-      msgs: AkgenticMessage[],
-      key: string,
-      anchor: MockAnchorEl | null,
-      clientHeight = 500,
-      scrollHeight = 1200,
-    ): MockContainer {
-      (component.chatService as any).emitJustSent(key);
-      messagesSubject.next(msgs);
-      return installContainer(anchor, clientHeight, scrollHeight);
-    }
-
-    it('AC #2: first id-matched emission fires a single top-anchor, no re-fire on same turn', () => {
-      mockReducedMotion(false);
-      const container = seedTurn([sendUserMessage('u-1')], '1000', {
-        offsetTop: 600,
-      });
-
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-      // offsetTop(600) - topPadding(8) = 592
-      expect(container.lastScrollTo?.top).toBe(592);
-
-      // A subsequent same-turn emission (more streamed content) must NOT re-anchor.
-      component.ngAfterViewChecked();
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-    });
-
-    it('AC #2: latch resets on a new just-sent so the next turn can anchor', () => {
-      mockReducedMotion(false);
-      const container = seedTurn([sendUserMessage('turn-1')], '1000', {
-        offsetTop: 600,
-      });
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-
-      // New turn: the latch resets; spacer resets to 0 on the new just-sent.
-      // Key the new send AFTER turn-1's timestamp so the matcher picks turn-2.
-      const turn2Key = String(Date.parse('2026-06-14T10:00:01Z'));
-      (component.chatService as any).emitJustSent(turn2Key);
-      expect(component.spacerHeight).toBe(0);
-      messagesSubject.next([
-        sendUserMessage('turn-1', '2026-06-14T10:00:00Z'),
-        sendUserMessage('turn-2', '2026-06-14T10:05:00Z'),
-      ]);
-      // The matcher must have resolved turn-2 (first Rule-1 at/after the key).
-      expect((component as any).anchorMessageId).toBe('turn-2');
-      const container2 = installContainer({ offsetTop: 800 });
-      component.ngAfterViewChecked();
-      expect(container2.scrollToCalls).toBe(1);
-      expect(container2.lastScrollTo?.top).toBe(792);
-    });
-
-    it('AC #4: resolves via data-message-id and is a no-op when not yet rendered', () => {
-      mockReducedMotion(false);
-      // No anchor element resolvable yet (querySelector returns null).
-      const container = seedTurn([sendUserMessage('late-1')], '1000', null);
-      component.ngAfterViewChecked();
-
-      expect(container.scrollToCalls).toBe(0);
-      expect((component as any).anchorScrollDone).toBe(false);
-      expect(container.querySelectorCalls.some((s) => s.includes('late-1'))).toBe(
-        true,
-      );
-
-      // Element renders on the next pass → first-match latch fires.
-      container._anchor = { offsetTop: 300 };
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-      expect(container.lastScrollTo?.top).toBe(292);
-    });
-
-    it('AC #3: spacer is 0 when not anchored and max(0, viewport-content) when anchored, capped at viewport', () => {
-      mockReducedMotion(false);
-      // Before any send → spacer stays 0.
-      expect(component.spacerHeight).toBe(0);
-
-      // viewport 500, scrollHeight 600, offsetTop 550 →
-      // heightOfAnchoredTurnAndBelow = 600 - 0 - 550 = 50 → spacer = 450.
-      const container = seedTurn(
-        [sendUserMessage('sp-1')],
-        '1000',
-        { offsetTop: 550 },
-        500,
-        600,
-      );
-      component.ngAfterViewChecked();
-      expect(component.spacerHeight).toBe(450);
-      // Capped at the viewport (never exceeds clientHeight).
-      expect(component.spacerHeight).toBeLessThanOrEqual(container.clientHeight);
-    });
-
-    it('AC #3: spacer collapses toward 0 as the answer fills the viewport', () => {
-      mockReducedMotion(false);
-      // viewport 500, scrollHeight 2000, offsetTop 10 →
-      // heightOfAnchoredTurnAndBelow = 2000 - 0 - 10 = 1990 → max(0, 500-1990)=0.
-      seedTurn([sendUserMessage('fill-1')], '1000', { offsetTop: 10 }, 500, 2000);
-      component.ngAfterViewChecked();
-
-      expect(component.spacerHeight).toBe(0);
-    });
-
-    it('AC #5: re-pins on the anchor element\'s OWN offset change; answer-below growth does not', () => {
-      mockReducedMotion(false);
-      const anchorEl = { offsetTop: 600 };
-      const container = seedTurn(
-        [sendUserMessage('st-1')],
-        '1000',
-        anchorEl,
-        500,
-        1200,
-      );
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-
-      // Answer grows BELOW the anchor: scrollHeight changes, offsetTop does not.
-      container.scrollHeight = 1800;
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1); // no re-pin
-
-      // The anchor's OWN height changes (late image load) → offsetTop shifts.
-      anchorEl.offsetTop = 640;
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(2); // re-pinned
-      expect(container.lastScrollTo?.top).toBe(632);
-    });
-
-    it('AC #6: instant jump when reduced motion is requested', () => {
-      mockReducedMotion(true);
-      const container = seedTurn([sendUserMessage('rm-1')], '1000', {
-        offsetTop: 600,
-      });
-      component.ngAfterViewChecked();
-
-      expect(container.lastScrollTo?.behavior).toBe('auto');
-    });
-
-    it('AC #6: behavior is smooth when reduced motion is NOT requested', () => {
-      mockReducedMotion(false);
-      const container = seedTurn([sendUserMessage('rm-2')], '1000', {
-        offsetTop: 600,
-      });
-      component.ngAfterViewChecked();
-
-      expect(container.lastScrollTo?.behavior).toBe('smooth');
-    });
-
-    it('renders the trailing spacer bound to spacerHeight, excluded from displayItems', () => {
-      mockReducedMotion(false);
-      messagesSubject.next([sendUserMessage('dom-1')]);
-      fixture.detectChanges();
-
-      const el: HTMLElement = fixture.nativeElement;
-      const list = el.querySelector('.message-list');
-      const spacer = list!.querySelector('.message-spacer');
-      expect(spacer).not.toBeNull();
-      // The spacer is the LAST child of the message list.
-      expect(list!.lastElementChild).toBe(spacer);
-      // It is not a DisplayItem — only the message is.
-      expect(component.displayItems.length).toBe(1);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Story 19-2 (ADR-016) — anchored-holds / release / re-anchor state
-  // transitions (driven through the anchor mock container, like 19-1).
-  // -------------------------------------------------------------------------
-  describe('Story 19-2: anchored-holds, release, re-anchor transitions', () => {
-    interface MockAnchorEl {
-      offsetTop: number;
-    }
-    interface MockContainer {
-      clientHeight: number;
-      scrollHeight: number;
-      scrollTop: number;
-      lastScrollTo: { top: number; behavior: string } | null;
-      scrollToCalls: number;
-      _anchor: MockAnchorEl | null;
-      querySelector(sel: string): MockAnchorEl | null;
-      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
-    }
-
-    function installContainer(
-      anchor: MockAnchorEl | null,
-      clientHeight = 500,
-      scrollHeight = 1200,
-    ): MockContainer {
-      const container: MockContainer = {
-        clientHeight,
-        scrollHeight,
-        scrollTop: 0,
-        lastScrollTo: null,
-        scrollToCalls: 0,
-        _anchor: anchor,
-        querySelector() {
-          return this._anchor;
-        },
-        scrollTo(opts) {
-          this.scrollToCalls += 1;
-          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
-          this.scrollTop = opts.top;
-        },
-      };
-      (component as any).scrollContainer = { nativeElement: container };
-      return container;
-    }
-
-    function mockReducedMotion(matches: boolean): void {
-      spyOn(window, 'matchMedia').and.returnValue({ matches } as any);
-    }
-
-    function sendUserMessage(id: string, ts = '2026-06-14T10:00:00Z') {
-      const sent = makeSentMessage(
-        { name: '@Human', role: 'Human' },
-        { name: '@Manager', role: 'Manager' },
-        'user turn',
-        id,
-      );
-      sent.timestamp = ts;
-      sent.message.timestamp = ts;
-      return sent;
-    }
-
-    function seedTurn(
-      id: string,
-      key: string,
-      anchor: MockAnchorEl | null,
-      clientHeight = 500,
-      scrollHeight = 1200,
-    ): MockContainer {
-      (component.chatService as any).emitJustSent(key);
-      messagesSubject.next([sendUserMessage(id)]);
-      return installContainer(anchor, clientHeight, scrollHeight);
-    }
-
-    it('AC #2: first anchor sets scrollMode = anchored', () => {
-      mockReducedMotion(false);
-      seedTurn('a-1', '1000', { offsetTop: 600 });
-      expect((component as any).scrollMode).toBe('idle');
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-    });
-
-    it('AC #1/#2: anchored holds — answer-below growth does not move the scroll', () => {
-      mockReducedMotion(false);
-      const anchorEl = { offsetTop: 600 };
-      const container = seedTurn('hold-1', '1000', anchorEl, 500, 1200);
-      component.ngAfterViewChecked();
-      expect(container.scrollToCalls).toBe(1);
-      const parkedTop = container.scrollTop;
-
-      // Several downstream growths (streamed tokens) — offsetTop unchanged.
-      for (const h of [1600, 2000, 2400]) {
-        container.scrollHeight = h;
-        component.ngAfterViewChecked();
-      }
-      expect(container.scrollToCalls).toBe(1); // no extra scroll writes
-      expect(container.scrollTop).toBe(parkedTop);
-      expect((component as any).scrollMode).toBe('anchored');
-    });
-
-    it('AC #3: a user scroll event past the threshold releases the anchor to idle', () => {
-      mockReducedMotion(false);
-      const container = seedTurn('rel-1', '1000', { offsetTop: 600 }, 500, 2000);
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-
-      // Let the programmatic-guard window close, then simulate a genuine user
-      // scroll to the top (distanceFromBottom = 2000 - 0 - 500 = 1500 > 100).
-      (component as any).isProgrammaticScroll = false;
-      container.scrollTop = 0;
-      component.onScroll();
-
-      expect((component as any).scrollMode).toBe('idle');
-      expect((component as any).anchorMessageId).toBeNull();
-      expect(component.spacerHeight).toBe(0);
-    });
-
-    it('AC #3: natural scroll-off (anchor pushed above the fold) releases to idle', () => {
-      mockReducedMotion(false);
-      const anchorEl = { offsetTop: 600 };
-      const container = seedTurn('off-1', '1000', anchorEl, 500, 1200);
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-
-      // The answer grew so the anchor scrolled above the top of the viewport:
-      // offsetTop - scrollTop < topPadding (8). With scrollTop parked at 592,
-      // an anchor offsetTop of 595 means 595 - 592 = 3 < 8 → scrolled off.
-      anchorEl.offsetTop = 595;
-      component.ngAfterViewChecked();
-
-      expect((component as any).scrollMode).toBe('idle');
-      expect((component as any).anchorMessageId).toBeNull();
-      expect(container.scrollToCalls).toBe(1); // released, NOT re-pinned
-    });
-
-    it('AC #3: re-anchor on send — idle → (send) → anchored', () => {
-      mockReducedMotion(false);
-      const container = seedTurn('re-1', '1000', { offsetTop: 600 }, 500, 2000);
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-
-      // Release via user scroll.
-      (component as any).isProgrammaticScroll = false;
-      container.scrollTop = 0;
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('idle');
-
-      // A new turn is sent → latch resets, scrollMode returns to idle-intent,
-      // and the next matching emission re-anchors.
-      const key2 = String(Date.parse('2026-06-14T10:05:01Z'));
-      (component.chatService as any).emitJustSent(key2);
-      expect((component as any).scrollMode).toBe('idle');
-      messagesSubject.next([
-        sendUserMessage('re-1', '2026-06-14T10:00:00Z'),
-        sendUserMessage('re-2', '2026-06-14T10:06:00Z'),
-      ]);
-      expect((component as any).anchorMessageId).toBe('re-2');
-      const container2 = installContainer({ offsetTop: 800 }, 500, 2000);
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-      expect(container2.scrollToCalls).toBe(1);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Story 19-3 (ADR-016 §Decision 4/6) — jump-to-latest indicator + opt-in
-  // follow mode. Completes the state machine: `following` is now ENTERED (it
-  // was a reachable-but-unentered placeholder in 19-2).
-  // -------------------------------------------------------------------------
-  describe('Story 19-3: jump-to-latest indicator + follow mode', () => {
-    // Mock container with a recording scrollTo + controllable geometry. The
-    // follow tail writes via `scrollTo`; geometry drives isNearBottom().
-    interface MockContainer {
-      scrollTop: number;
-      scrollHeight: number;
-      clientHeight: number;
-      lastScrollTo: { top: number; behavior: string } | null;
-      scrollToCalls: number;
-      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
-    }
-
-    function installMockScrollContainer(
-      scrollHeight = 2000,
-      clientHeight = 400,
-    ): MockContainer {
-      const container: MockContainer = {
-        scrollTop: 0,
-        scrollHeight,
-        clientHeight,
-        lastScrollTo: null,
-        scrollToCalls: 0,
-        scrollTo(opts) {
-          this.scrollToCalls += 1;
-          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
-          this.scrollTop = opts.top;
-        },
-      };
-      (component as any).scrollContainer = { nativeElement: container };
-      (component as any).lastScrollHeight = scrollHeight;
-      // Mount scroll is irrelevant to these tests — latch it off.
-      (component as any).hasDoneInitialScroll = true;
-      return container;
-    }
-
-    function mockReducedMotion(matches: boolean): void {
-      spyOn(window, 'matchMedia').and.returnValue({ matches } as any);
-    }
-
-    function aiMessage(id: string, content = 'answer') {
+    function agentMsg(id: string): SentMessage {
       return makeSentMessage(
         { name: '@Manager', role: 'Manager' },
         { name: '@Human', role: 'Human' },
-        content,
+        'reply',
         id,
       );
     }
 
-    function sendUserTurn(id: string, ts = '2026-06-14T10:00:00Z') {
-      const sent = makeSentMessage(
-        { name: '@Human', role: 'Human' },
-        { name: '@Manager', role: 'Manager' },
-        'user turn',
-        id,
-      );
-      sent.timestamp = ts;
-      sent.message.timestamp = ts;
-      return sent;
+    // Clamp-aware container with a single anchor message + spacer.
+    // `spacerEl.offsetTop` is the end of real content; mutate it to simulate the
+    // reply growing.
+    function installClamping(
+      anchorOffsetTop: number,
+      anchorHeight: number,
+      clientHeight: number,
+      containerOffsetTop = 0,
+    ) {
+      let spacerMin = 0;
+      const spacerEl = {
+        offsetTop: anchorOffsetTop + anchorHeight,
+        style: {
+          set minHeight(v: string) {
+            spacerMin = parseInt(v, 10) || 0;
+          },
+          get minHeight() {
+            return spacerMin + 'px';
+          },
+        },
+      };
+      const anchorEl = { offsetTop: anchorOffsetTop };
+      const container = {
+        offsetTop: containerOffsetTop,
+        clientHeight,
+        get scrollHeight() {
+          return Math.max(clientHeight, spacerEl.offsetTop + spacerMin); // CLAMP UP
+        },
+        scrollTop: 0,
+        lastScrollTo: null as null | { top: number; behavior: string },
+        querySelector(sel: string) {
+          return sel.includes('message-spacer') ? null : anchorEl;
+        },
+        scrollTo(o: { top: number; behavior: ScrollBehavior }) {
+          this.lastScrollTo = { top: o.top, behavior: o.behavior };
+          const max = Math.max(0, this.scrollHeight - this.clientHeight);
+          this.scrollTop = Math.max(0, Math.min(o.top, max)); // CLAMP, like a browser
+        },
+      };
+      container.scrollTop = Math.max(0, container.scrollHeight - clientHeight); // parked bottom
+      (component as any).scrollContainer = { nativeElement: container };
+      (component as any).spacerRef = { nativeElement: spacerEl };
+      return { container, spacerEl, anchorEl, getSpacerMin: () => spacerMin };
     }
 
-    // --- AC #1: indicator visibility ----------------------------------------
-    it('AC #1: indicator SHOWN when not following, not at bottom, unseen content', () => {
-      const el = installMockScrollContainer(2000, 400);
-      el.scrollTop = 0; // distanceFromBottom = 2000 - 0 - 400 = 1600 > 100
-      (component as any).scrollMode = 'idle';
-      (component as any).unseenContent = true;
+    // Simple container for follow / indicator tests (no anchor element).
+    function installSimple(scrollHeight: number, clientHeight: number, scrollTop = 0) {
+      const container = {
+        offsetTop: 0,
+        clientHeight,
+        scrollHeight,
+        scrollTop,
+        lastScrollTo: null as null | { top: number; behavior: string },
+        querySelector: () => null,
+        scrollTo(o: { top: number; behavior: ScrollBehavior }) {
+          this.lastScrollTo = { top: o.top, behavior: o.behavior };
+          this.scrollTop = o.top;
+        },
+      };
+      (component as any).scrollContainer = { nativeElement: container };
+      // Spacer marks the end of the messages (= scrollHeight here; no reserved gap).
+      (component as any).spacerRef = {
+        nativeElement: { offsetTop: scrollHeight, style: { minHeight: '' } },
+      };
+      return container;
+    }
 
-      expect(component.showJumpToLatest).toBe(true);
+    // --- anchor on send ------------------------------------------------------
 
-      // The *ngIf control renders.
-      fixture.detectChanges();
-      const btn = (fixture.nativeElement as HTMLElement).querySelector(
-        '.jump-to-latest',
-      );
-      expect(btn).not.toBeNull();
-    });
+    it('pins the just-sent message to the top on a SHORT conversation', () => {
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      expect((component as any).anchorId).toBe('u1');
 
-    it('AC #1: indicator HIDDEN at bottom (and unseenContent cleared on reaching bottom)', () => {
-      const el = installMockScrollContainer(1000, 400);
-      el.scrollTop = 600; // distanceFromBottom = 1000 - 600 - 400 = 0 <= 100
-      (component as any).scrollMode = 'idle';
-      (component as any).unseenContent = true;
+      const { container, getSpacerMin } = installClamping(84, 36, 356);
+      expect(container.scrollTop).toBe(0); // content < viewport → parked at 0
 
-      // At bottom → getter false regardless of the flag.
-      expect(component.showJumpToLatest).toBe(false);
-
-      // Reaching the bottom via a scroll event clears the flag (AC #1).
-      component.onScroll();
-      expect((component as any).unseenContent).toBe(false);
-    });
-
-    it('AC #1: indicator HIDDEN while following even if not at bottom', () => {
-      const el = installMockScrollContainer(2000, 400);
-      el.scrollTop = 0; // not near bottom
-      (component as any).scrollMode = 'following';
-      (component as any).unseenContent = true;
-
-      expect(component.showJumpToLatest).toBe(false);
-    });
-
-    it('AC #1: unseenContent SET on growth while not at bottom + not following', () => {
-      const el = installMockScrollContainer(2000, 400);
-      el.scrollTop = 0; // below the fold
-      (component as any).scrollMode = 'idle';
-
-      messagesSubject.next([aiMessage('grow-1')]);
-      expect((component as any).unseenContent).toBe(true);
-    });
-
-    it('AC #1: unseenContent NOT set on growth while at bottom', () => {
-      const el = installMockScrollContainer(800, 400);
-      el.scrollTop = 400; // distanceFromBottom = 800 - 400 - 400 = 0 (at bottom)
-      (component as any).scrollMode = 'idle';
-
-      messagesSubject.next([aiMessage('grow-2')]);
-      expect((component as any).unseenContent).toBe(false);
-    });
-
-    // --- AC #2: enter follow on click ---------------------------------------
-    it('AC #2: onJumpToLatest enters following, smooth scroll, clears anchor + unseen', () => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2000, 400);
-      el.scrollTop = 0;
-      (component as any).scrollMode = 'anchored';
-      (component as any).anchorMessageId = 'a-1';
-      (component as any).anchorScrollDone = true;
-      (component as any).lastAnchorOffsetTop = 600;
-      component.spacerHeight = 300;
-      (component as any).unseenContent = true;
-
-      component.onJumpToLatest();
-
-      expect((component as any).scrollMode).toBe('following');
-      expect(el.scrollToCalls).toBe(1);
-      expect(el.lastScrollTo?.top).toBe(2000);
-      expect(el.lastScrollTo?.behavior).toBe('smooth');
-      // Anchor bookkeeping cleared.
-      expect((component as any).anchorMessageId).toBeNull();
-      expect(component.spacerHeight).toBe(0);
-      // Unseen flag cleared.
-      expect((component as any).unseenContent).toBe(false);
-    });
-
-    it('AC #2: onJumpToLatest uses instant behavior under prefers-reduced-motion', () => {
-      mockReducedMotion(true);
-      const el = installMockScrollContainer(2000, 400);
-      component.onJumpToLatest();
-      expect(el.lastScrollTo?.behavior).toBe('auto');
-    });
-
-    // --- AC #2: stay pinned while following ----------------------------------
-    it('AC #2: follow tails on EACH subsequent growth (continuous tail)', () => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2000, 400);
-      component.onJumpToLatest();
-      expect((component as any).scrollMode).toBe('following');
-      expect(el.scrollToCalls).toBe(1); // the click's own scroll
-
-      // First growth → tail armed by subscription, fired by post-layout pass.
-      el.scrollHeight = 2400;
-      messagesSubject.next([aiMessage('t-1')]);
-      component.ngAfterViewChecked();
-      expect(el.scrollToCalls).toBe(2);
-      expect(el.lastScrollTo?.top).toBe(2400);
-
-      // Second growth → tails again (not a one-shot).
-      el.scrollHeight = 2800;
-      messagesSubject.next([aiMessage('t-1'), aiMessage('t-2')]);
-      component.ngAfterViewChecked();
-      expect(el.scrollToCalls).toBe(3);
-      expect(el.lastScrollTo?.top).toBe(2800);
-    });
-
-    it('AC #2: follow tail routes through the programmatic guard (does not self-release)', () => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2000, 400);
-      component.onJumpToLatest();
-      // The programmatic guard is armed by the follow write.
-      expect((component as any).isProgrammaticScroll).toBe(true);
-      // The follow write's own `scroll` frame arrives near the top — but the
-      // guard suppresses any exit (re-arms the debounce, returns early).
-      el.scrollTop = 0;
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('following');
-    });
-
-    // --- AC #3: exit follow on scroll up ------------------------------------
-    it('AC #3: a genuine user scroll-up exits following → idle, indicator reappears', () => {
-      const el = installMockScrollContainer(2000, 400);
-      (component as any).scrollMode = 'following';
-      (component as any).isProgrammaticScroll = false;
-      el.scrollTop = 0; // distanceFromBottom = 1600 > 100 (scrolled up)
-
-      component.onScroll();
-
-      expect((component as any).scrollMode).toBe('idle');
-      // The affordance is immediately available (Open Question 5): unseen set.
-      expect((component as any).unseenContent).toBe(true);
-      expect(component.showJumpToLatest).toBe(true);
-    });
-
-    it('AC #3: a near-bottom scroll while following does NOT exit', () => {
-      const el = installMockScrollContainer(1000, 400);
-      (component as any).scrollMode = 'following';
-      (component as any).isProgrammaticScroll = false;
-      el.scrollTop = 550; // distanceFromBottom = 50 <= 100 (still near bottom)
-
-      component.onScroll();
-      expect((component as any).scrollMode).toBe('following');
-    });
-
-    // --- AC #3: exit follow on send -----------------------------------------
-    it('AC #3: a send while following re-anchors (following → anchored)', () => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2000, 500) as any;
-      el.querySelector = (_sel: string) => ({ offsetTop: 800 });
-      component.onJumpToLatest();
-      expect((component as any).scrollMode).toBe('following');
-
-      // A new send: the justSent$ handler resets to idle-intent (supersedes
-      // following), the next matching emission resolves the anchor, and the
-      // post-layout pass sets `anchored`.
-      const key = String(Date.parse('2026-06-14T10:00:01Z'));
-      (component.chatService as any).emitJustSent(key);
-      expect((component as any).scrollMode).toBe('idle');
-      messagesSubject.next([sendUserTurn('snd-1', '2026-06-14T10:05:00Z')]);
-      expect((component as any).anchorMessageId).toBe('snd-1');
-      component.ngAfterViewChecked();
-      expect((component as any).scrollMode).toBe('anchored');
-    });
-
-    // --- AC #4: follow-tail hover defer -------------------------------------
-    it('AC #4: growth while following + hovered owes a follow-tail (no scroll)', () => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2000, 400);
-      component.onJumpToLatest();
-      const callsAfterClick = el.scrollToCalls;
-
-      component.onMouseEnter();
-      el.scrollHeight = 2400;
-      messagesSubject.next([aiMessage('hov-tail-1')]);
       component.ngAfterViewChecked();
 
-      // Deferred — no scroll fired; the owed kind is the typed follow-tail.
-      expect(el.scrollToCalls).toBe(callsAfterClick);
-      expect((component as any).owedScroll).toBe('follow-tail');
+      // realBelow = spacer.offsetTop(120) - anchor.offsetTop(84) = 36 → spacer 320.
+      expect(getSpacerMin()).toBe(320);
+      // target = 84 - containerOffsetTop(0) - pad(8) = 76 → message at the top.
+      expect(container.scrollTop).toBe(76);
+      expect(84 - container.scrollTop).toBe(8);
     });
 
-    it('AC #4: mouseleave replays the follow-tail as a smooth bottom scroll', fakeAsync(() => {
-      mockReducedMotion(false);
-      const el = installMockScrollContainer(2400, 400);
-      (component as any).scrollMode = 'following';
-      (component as any).owedScroll = 'follow-tail';
+    it('pins to the top regardless of the prior scroll position', () => {
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      const { container } = installClamping(520, 40, 356);
+      container.scrollTop = 999; // user was scrolled elsewhere
 
-      component.onMouseLeave();
+      component.ngAfterViewChecked();
+
+      expect(container.scrollTop).toBe(512); // 520 - 8, independent of 999
+    });
+
+    it('uses a clean container frame: subtracts container.offsetTop', () => {
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      // container is inset 16px inside its positioned parent.
+      const { container } = installClamping(100, 40, 356, 16);
+      component.ngAfterViewChecked();
+      expect(container.scrollTop).toBe(76); // 100 - 16 - 8
+    });
+
+    it('anchors the newly-sent message, not a pre-existing one (baseline)', () => {
+      messagesSubject.next([humanTurn('old')]); // restored history, no send
+      (component.chatService as any).emitJustSent('k'); // baseline = 'old'
+      messagesSubject.next([humanTurn('old'), humanTurn('new')]);
+      expect((component as any).anchorId).toBe('new');
+    });
+
+    it('does NOT anchor messages that arrive without a send (history load)', () => {
+      messagesSubject.next([humanTurn('h1'), agentMsg('a1')]);
+      const { container } = installClamping(84, 36, 356);
+      const before = container.scrollTop;
+      component.ngAfterViewChecked();
+      expect((component as any).anchorId).toBeNull();
+      expect(container.scrollTop).toBe(before); // viewport untouched
+    });
+
+    it('the spacer shrinks as the reply grows, keeping scrollHeight constant (shift-free)', () => {
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      const { container, spacerEl, getSpacerMin } = installClamping(84, 36, 356);
+      component.ngAfterViewChecked();
+      expect(getSpacerMin()).toBe(320);
+      const scrollHeightAfterPin = container.scrollHeight; // 120 + 320 = 440
+
+      // The reply adds 100px of content below the anchor.
+      spacerEl.offsetTop += 100; // content end moves down
+      component.ngAfterViewChecked();
+
+      expect(getSpacerMin()).toBe(220); // shrank by exactly 100
+      expect(container.scrollHeight).toBe(scrollHeightAfterPin); // constant → no shift
+    });
+
+    // --- status pill: New messages / Messages / Auto scrolling --------
+
+    it('shows "New messages" when a NEW reply arrives below the fold', fakeAsync(() => {
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      const { spacerEl } = installClamping(20, 40, 500); // small user message
+      component.ngAfterViewChecked(); // pin to top
       flushMicrotasks();
+      expect(component.indicatorLabel).toBeNull(); // only the user message, visible
 
-      expect(el.scrollToCalls).toBe(1);
-      expect(el.lastScrollTo?.top).toBe(2400);
-      expect(el.lastScrollTo?.behavior).toBe('smooth');
-      expect((component as any).owedScroll).toBeNull();
-      flush(); // drain the programmatic-scroll settle timer the replay armed
+      // A NEW reply arrives (count grows → "unseen") and extends below the fold.
+      spacerEl.offsetTop += 800;
+      messagesSubject.next([humanTurn('u1'), agentMsg('a1')]);
+      component.ngAfterViewChecked();
+      flushMicrotasks(); // the pill update is deferred to a microtask
+      expect(component.indicatorLabel).toBe('New messages');
     }));
+
+    it('shows "Messages" when merely scrolled up (nothing new)', () => {
+      installSimple(2000, 500, 1500); // spacer.offsetTop = 2000
+      const c = (component as any).scrollContainer.nativeElement;
+      c.scrollTop = 200; // user scrolled up, no new message
+      component.onScroll();
+      expect(component.indicatorLabel).toBe('Messages');
+    });
+
+    it('treats the initial history load as "Messages", not "New messages"', () => {
+      // First non-empty emission = the loaded backlog — it is NOT "new".
+      messagesSubject.next([agentMsg('h1'), agentMsg('h2')]);
+      const container = installSimple(2000, 500, 0); // at top, backlog below the fold
+      container.scrollTop = 0;
+      component.onScroll();
+      expect((component as any).unseen).toBe(false);
+      expect(component.indicatorLabel).toBe('Messages');
+    });
+
+    it('shows "Auto scrolling" while following', () => {
+      installSimple(2000, 500, 1500);
+      (component as any).following = true;
+      component.onScroll();
+      expect(component.indicatorLabel).toBe('Auto scrolling');
+    });
+
+    it('does NOT show "Auto scrolling" when the process is stopped', () => {
+      TestBed.inject(ContextService).currentTeamRunning$.next(false);
+      installSimple(2000, 500, 1500); // at bottom
+      (component as any).following = true;
+      component.onScroll();
+      expect(component.indicatorLabel).not.toBe('Auto scrolling');
+    });
+
+    it('reaching the bottom hides the pill and clears "unseen"', () => {
+      const container = installSimple(2000, 500, 200);
+      (component as any).unseen = true;
+      component.indicatorLabel = 'New messages';
+      container.scrollTop = 1500; // distance 2000-1500-500 = 0 → at bottom
+      component.onScroll();
+      expect(component.indicatorLabel).toBeNull();
+      expect((component as any).unseen).toBe(false);
+    });
+
+    // --- follow mode ---------------------------------------------------------
+
+    it('clicking the pill enters follow mode, scrolls to bottom, shows "Auto scrolling"', () => {
+      const container = installSimple(2000, 500, 100);
+      component.onJumpToLatest();
+      expect((component as any).following).toBe(true);
+      expect(component.indicatorLabel).toBe('Auto scrolling');
+      expect(container.scrollTop).toBe(container.scrollHeight); // jumped to bottom
+    });
+
+    it('in follow mode, a new message tails to the bottom', () => {
+      const container = installSimple(1000, 500, 500);
+      (component as any).following = true;
+      (component as any).lastScrollHeight = 1000;
+      container.scrollHeight = 1400; // new message grew content
+      component.ngAfterViewChecked();
+      expect(container.scrollTop).toBe(1400); // tailed
+    });
+
+    it('the smooth follow tail (moving DOWN) does not exit follow mode', () => {
+      installSimple(2000, 500, 1500); // at bottom
+      (component as any).following = true;
+      (component as any).lastScrollTop = 1000; // tail animated down the page
+      component.onScroll(); // a frame of our own smooth tail (moved down, not up)
+      expect((component as any).following).toBe(true);
+      expect(component.indicatorLabel).toBe('Auto scrolling');
+    });
+
+    it('a manual upward scroll exits follow mode → "Messages"', () => {
+      const container = installSimple(2000, 500, 1500);
+      (component as any).following = true;
+      (component as any).lastScrollTop = 1500; // was at the bottom
+      container.scrollTop = 200; // user scrolled UP (distance 1300 > 100)
+      component.onScroll();
+      expect((component as any).following).toBe(false);
+      expect(component.indicatorLabel).toBe('Messages'); // no new msg since
+    });
+
+    // --- smooth scrolling ----------------------------------------------------
+
+    it('scrolls SMOOTHLY to the top on send (instant only under reduced motion)', () => {
+      spyOn(window, 'matchMedia').and.returnValue({ matches: false } as any);
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      const { container } = installClamping(84, 36, 356);
+      component.ngAfterViewChecked();
+      expect(container.lastScrollTo?.behavior).toBe('smooth');
+    });
+
+    it('respects reduced motion (instant) for the top anchor', () => {
+      spyOn(window, 'matchMedia').and.returnValue({ matches: true } as any);
+      (component.chatService as any).emitJustSent('k');
+      messagesSubject.next([humanTurn('u1')]);
+      const { container } = installClamping(84, 36, 356);
+      component.ngAfterViewChecked();
+      expect(container.lastScrollTo?.behavior).toBe('auto');
+    });
+
+    it('the "New messages" jump scrolls SMOOTHLY to the bottom', () => {
+      spyOn(window, 'matchMedia').and.returnValue({ matches: false } as any);
+      const container = installSimple(2000, 500, 100);
+      component.onJumpToLatest();
+      expect(container.lastScrollTo?.behavior).toBe('smooth');
+      expect(container.lastScrollTo?.top).toBe(2000);
+    });
+
+    it('a new send exits follow mode and re-anchors', () => {
+      (component as any).following = true;
+      (component.chatService as any).emitJustSent('k');
+      expect((component as any).following).toBe(false);
+      messagesSubject.next([humanTurn('u2')]);
+      expect((component as any).anchorId).toBe('u2');
+    });
+
+    // --- REAL layout (actual component + real CSS in ChromeHeadless) ----------
+    // No mocked container: the component renders into the live DOM with its own
+    // stylesheet, so this exercises the true layout engine (offsetParent frame,
+    // scrollHeight clamping, spacer) that the unit mocks can only approximate.
+    it('REAL layout: the just-sent message is scrolled to the top of the panel', () => {
+      // Force reduced-motion so the real scrollTo is INSTANT and the end position
+      // can be asserted synchronously (smooth would animate over real time).
+      spyOn(window, 'matchMedia').and.returnValue({ matches: true } as any);
+      const host = fixture.nativeElement as HTMLElement;
+      host.style.display = 'block';
+      host.style.height = '400px';
+      document.body.appendChild(host);
+      try {
+        // A short conversation (the case that used to fail): two replies already
+        // shown, then the user sends — the sent message must jump to the top.
+        messagesSubject.next([agentMsg('a0'), agentMsg('a1')]);
+        fixture.detectChanges();
+
+        (component.chatService as any).emitJustSent('k');
+        messagesSubject.next([agentMsg('a0'), agentMsg('a1'), humanTurn('u1')]);
+        fixture.detectChanges(); // render + ngAfterViewChecked → pin
+        fixture.detectChanges(); // settle spacer/geometry
+
+        const list = host.querySelector('.message-list') as HTMLElement;
+        const anchor = host.querySelector('[data-message-id="u1"]') as HTMLElement;
+        expect(anchor).toBeTruthy();
+
+        const delta =
+          anchor.getBoundingClientRect().top - list.getBoundingClientRect().top;
+        // The sent message sits at the top of the scroll viewport (within the
+        // small top inset), NOT pushed down the panel.
+        expect(delta).toBeGreaterThanOrEqual(0);
+        expect(delta).toBeLessThanOrEqual(16);
+      } finally {
+        document.body.removeChild(host);
+      }
+    });
   });
+
 });

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { provideMarkdown } from 'ngx-markdown';
 
@@ -70,9 +70,12 @@ describe('ChatPanelComponent', () => {
   let component: ChatPanelComponent;
   let fixture: ComponentFixture<ChatPanelComponent>;
   let messagesSubject: BehaviorSubject<AkgenticMessage[]>;
+  // Story 19-1 (ADR-016): just-sent side channel feed.
+  let justSentSubject: Subject<string>;
 
   beforeEach(async () => {
     messagesSubject = new BehaviorSubject<AkgenticMessage[]>([]);
+    justSentSubject = new Subject<string>();
 
     // Story 6.4 (AC3): `ChatPanelComponent` no longer injects
     // `IngestionService`. The spec feeds SentMessages via
@@ -95,6 +98,8 @@ describe('ChatPanelComponent', () => {
         map(computePendingNotifications),
       ),
       thinkingAgents$: thinkingAgentsSubj,
+      justSent$: justSentSubject.asObservable(),
+      emitJustSent: (key: string) => justSentSubject.next(key),
     };
 
     const selectionService = jasmine.createSpyObj('SelectionService', [
@@ -1090,5 +1095,251 @@ describe('ChatPanelComponent', () => {
       // No catch-up fired — scrollTop still at 850.
       expect(mockEl.scrollTop).toBe(850);
     }));
+  });
+
+  // -------------------------------------------------------------------------
+  // Story 19-1 (ADR-016) — top-anchor primitive
+  // -------------------------------------------------------------------------
+  describe('top-anchor primitive (Story 19-1)', () => {
+    // A mock scroll container whose querySelector returns a controllable
+    // anchor element (data-message-id lookup), with controllable client/scroll
+    // heights and a recording scrollTo.
+    interface MockAnchorEl {
+      offsetTop: number;
+    }
+    interface MockContainer {
+      clientHeight: number;
+      scrollHeight: number;
+      scrollTop: number;
+      lastScrollTo: { top: number; behavior: string } | null;
+      scrollToCalls: number;
+      querySelectorCalls: string[];
+      _anchor: MockAnchorEl | null;
+      querySelector(sel: string): MockAnchorEl | null;
+      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
+    }
+
+    function installContainer(
+      anchor: MockAnchorEl | null,
+      clientHeight = 500,
+      scrollHeight = 1200,
+    ): MockContainer {
+      const container: MockContainer = {
+        clientHeight,
+        scrollHeight,
+        scrollTop: 0,
+        lastScrollTo: null,
+        scrollToCalls: 0,
+        querySelectorCalls: [],
+        _anchor: anchor,
+        querySelector(sel: string) {
+          this.querySelectorCalls.push(sel);
+          return this._anchor;
+        },
+        scrollTo(opts) {
+          this.scrollToCalls += 1;
+          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
+          this.scrollTop = opts.top;
+        },
+      };
+      (component as any).scrollContainer = { nativeElement: container };
+      return container;
+    }
+
+    function mockReducedMotion(matches: boolean): void {
+      spyOn(window, 'matchMedia').and.returnValue({
+        matches,
+        media: '(prefers-reduced-motion: reduce)',
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      } as any);
+    }
+
+    function sendUserMessage(id: string, ts = '2026-06-14T10:00:00Z') {
+      const sent = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'user turn',
+        id,
+      );
+      sent.timestamp = ts;
+      sent.message.timestamp = ts;
+      return sent;
+    }
+
+    // Seed a turn WITHOUT change detection: emit the just-sent key, push the
+    // user message through the log (the BehaviorSubject pipe runs synchronously,
+    // so `chatMessages`/`displayItems` update and the anchor id resolves), then
+    // install the controllable mock container. We deliberately avoid
+    // `fixture.detectChanges()` here so Angular's lifecycle does not run
+    // `ngAfterViewChecked` against the real @ViewChild('scrollContainer') and
+    // fire the anchor before the mock is in place — the test drives the
+    // post-layout pass explicitly via `component.ngAfterViewChecked()`.
+    function seedTurn(
+      msgs: AkgenticMessage[],
+      key: string,
+      anchor: MockAnchorEl | null,
+      clientHeight = 500,
+      scrollHeight = 1200,
+    ): MockContainer {
+      (component.chatService as any).emitJustSent(key);
+      messagesSubject.next(msgs);
+      return installContainer(anchor, clientHeight, scrollHeight);
+    }
+
+    it('AC #2: first id-matched emission fires a single top-anchor, no re-fire on same turn', () => {
+      mockReducedMotion(false);
+      const container = seedTurn([sendUserMessage('u-1')], '1000', {
+        offsetTop: 600,
+      });
+
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+      // offsetTop(600) - topPadding(8) = 592
+      expect(container.lastScrollTo?.top).toBe(592);
+
+      // A subsequent same-turn emission (more streamed content) must NOT re-anchor.
+      component.ngAfterViewChecked();
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+    });
+
+    it('AC #2: latch resets on a new just-sent so the next turn can anchor', () => {
+      mockReducedMotion(false);
+      const container = seedTurn([sendUserMessage('turn-1')], '1000', {
+        offsetTop: 600,
+      });
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+
+      // New turn: the latch resets; spacer resets to 0 on the new just-sent.
+      // Key the new send AFTER turn-1's timestamp so the matcher picks turn-2.
+      const turn2Key = String(Date.parse('2026-06-14T10:00:01Z'));
+      (component.chatService as any).emitJustSent(turn2Key);
+      expect(component.spacerHeight).toBe(0);
+      messagesSubject.next([
+        sendUserMessage('turn-1', '2026-06-14T10:00:00Z'),
+        sendUserMessage('turn-2', '2026-06-14T10:05:00Z'),
+      ]);
+      // The matcher must have resolved turn-2 (first Rule-1 at/after the key).
+      expect((component as any).anchorMessageId).toBe('turn-2');
+      const container2 = installContainer({ offsetTop: 800 });
+      component.ngAfterViewChecked();
+      expect(container2.scrollToCalls).toBe(1);
+      expect(container2.lastScrollTo?.top).toBe(792);
+    });
+
+    it('AC #4: resolves via data-message-id and is a no-op when not yet rendered', () => {
+      mockReducedMotion(false);
+      // No anchor element resolvable yet (querySelector returns null).
+      const container = seedTurn([sendUserMessage('late-1')], '1000', null);
+      component.ngAfterViewChecked();
+
+      expect(container.scrollToCalls).toBe(0);
+      expect((component as any).anchorScrollDone).toBe(false);
+      expect(container.querySelectorCalls.some((s) => s.includes('late-1'))).toBe(
+        true,
+      );
+
+      // Element renders on the next pass → first-match latch fires.
+      container._anchor = { offsetTop: 300 };
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+      expect(container.lastScrollTo?.top).toBe(292);
+    });
+
+    it('AC #3: spacer is 0 when not anchored and max(0, viewport-content) when anchored, capped at viewport', () => {
+      mockReducedMotion(false);
+      // Before any send → spacer stays 0.
+      expect(component.spacerHeight).toBe(0);
+
+      // viewport 500, scrollHeight 600, offsetTop 550 →
+      // heightOfAnchoredTurnAndBelow = 600 - 0 - 550 = 50 → spacer = 450.
+      const container = seedTurn(
+        [sendUserMessage('sp-1')],
+        '1000',
+        { offsetTop: 550 },
+        500,
+        600,
+      );
+      component.ngAfterViewChecked();
+      expect(component.spacerHeight).toBe(450);
+      // Capped at the viewport (never exceeds clientHeight).
+      expect(component.spacerHeight).toBeLessThanOrEqual(container.clientHeight);
+    });
+
+    it('AC #3: spacer collapses toward 0 as the answer fills the viewport', () => {
+      mockReducedMotion(false);
+      // viewport 500, scrollHeight 2000, offsetTop 10 →
+      // heightOfAnchoredTurnAndBelow = 2000 - 0 - 10 = 1990 → max(0, 500-1990)=0.
+      seedTurn([sendUserMessage('fill-1')], '1000', { offsetTop: 10 }, 500, 2000);
+      component.ngAfterViewChecked();
+
+      expect(component.spacerHeight).toBe(0);
+    });
+
+    it('AC #5: re-pins on the anchor element\'s OWN offset change; answer-below growth does not', () => {
+      mockReducedMotion(false);
+      const anchorEl = { offsetTop: 600 };
+      const container = seedTurn(
+        [sendUserMessage('st-1')],
+        '1000',
+        anchorEl,
+        500,
+        1200,
+      );
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1);
+
+      // Answer grows BELOW the anchor: scrollHeight changes, offsetTop does not.
+      container.scrollHeight = 1800;
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(1); // no re-pin
+
+      // The anchor's OWN height changes (late image load) → offsetTop shifts.
+      anchorEl.offsetTop = 640;
+      component.ngAfterViewChecked();
+      expect(container.scrollToCalls).toBe(2); // re-pinned
+      expect(container.lastScrollTo?.top).toBe(632);
+    });
+
+    it('AC #6: instant jump when reduced motion is requested', () => {
+      mockReducedMotion(true);
+      const container = seedTurn([sendUserMessage('rm-1')], '1000', {
+        offsetTop: 600,
+      });
+      component.ngAfterViewChecked();
+
+      expect(container.lastScrollTo?.behavior).toBe('auto');
+    });
+
+    it('AC #6: behavior is smooth when reduced motion is NOT requested', () => {
+      mockReducedMotion(false);
+      const container = seedTurn([sendUserMessage('rm-2')], '1000', {
+        offsetTop: 600,
+      });
+      component.ngAfterViewChecked();
+
+      expect(container.lastScrollTo?.behavior).toBe('smooth');
+    });
+
+    it('renders the trailing spacer bound to spacerHeight, excluded from displayItems', () => {
+      mockReducedMotion(false);
+      messagesSubject.next([sendUserMessage('dom-1')]);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const list = el.querySelector('.message-list');
+      const spacer = list!.querySelector('.message-spacer');
+      expect(spacer).not.toBeNull();
+      // The spacer is the LAST child of the message list.
+      expect(list!.lastElementChild).toBe(spacer);
+      // It is not a DisplayItem — only the message is.
+      expect(component.displayItems.length).toBe(1);
+    });
   });
 });

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -1199,13 +1199,13 @@ describe('ChatPanelComponent', () => {
       expect(component.indicatorLabel).not.toBe('Auto scrolling');
     });
 
-    it('reaching the bottom hides the pill and clears "unseen"', () => {
+    it('reaching the bottom activates follow ("Auto scrolling") and clears "unseen"', () => {
       const container = installSimple(2000, 500, 200);
       (component as any).unseen = true;
-      component.indicatorLabel = 'New messages';
       container.scrollTop = 1500; // distance 2000-1500-500 = 0 → at bottom
       component.onScroll();
-      expect(component.indicatorLabel).toBeNull();
+      expect((component as any).following).toBe(true);
+      expect(component.indicatorLabel).toBe('Auto scrolling');
       expect((component as any).unseen).toBe(false);
     });
 

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -1674,4 +1674,274 @@ describe('ChatPanelComponent', () => {
       expect(container2.scrollToCalls).toBe(1);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Story 19-3 (ADR-016 §Decision 4/6) — jump-to-latest indicator + opt-in
+  // follow mode. Completes the state machine: `following` is now ENTERED (it
+  // was a reachable-but-unentered placeholder in 19-2).
+  // -------------------------------------------------------------------------
+  describe('Story 19-3: jump-to-latest indicator + follow mode', () => {
+    // Mock container with a recording scrollTo + controllable geometry. The
+    // follow tail writes via `scrollTo`; geometry drives isNearBottom().
+    interface MockContainer {
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+      lastScrollTo: { top: number; behavior: string } | null;
+      scrollToCalls: number;
+      scrollTo(opts: { top: number; behavior: ScrollBehavior }): void;
+    }
+
+    function installMockScrollContainer(
+      scrollHeight = 2000,
+      clientHeight = 400,
+    ): MockContainer {
+      const container: MockContainer = {
+        scrollTop: 0,
+        scrollHeight,
+        clientHeight,
+        lastScrollTo: null,
+        scrollToCalls: 0,
+        scrollTo(opts) {
+          this.scrollToCalls += 1;
+          this.lastScrollTo = { top: opts.top, behavior: opts.behavior };
+          this.scrollTop = opts.top;
+        },
+      };
+      (component as any).scrollContainer = { nativeElement: container };
+      (component as any).lastScrollHeight = scrollHeight;
+      // Mount scroll is irrelevant to these tests — latch it off.
+      (component as any).hasDoneInitialScroll = true;
+      return container;
+    }
+
+    function mockReducedMotion(matches: boolean): void {
+      spyOn(window, 'matchMedia').and.returnValue({ matches } as any);
+    }
+
+    function aiMessage(id: string, content = 'answer') {
+      return makeSentMessage(
+        { name: '@Manager', role: 'Manager' },
+        { name: '@Human', role: 'Human' },
+        content,
+        id,
+      );
+    }
+
+    function sendUserTurn(id: string, ts = '2026-06-14T10:00:00Z') {
+      const sent = makeSentMessage(
+        { name: '@Human', role: 'Human' },
+        { name: '@Manager', role: 'Manager' },
+        'user turn',
+        id,
+      );
+      sent.timestamp = ts;
+      sent.message.timestamp = ts;
+      return sent;
+    }
+
+    // --- AC #1: indicator visibility ----------------------------------------
+    it('AC #1: indicator SHOWN when not following, not at bottom, unseen content', () => {
+      const el = installMockScrollContainer(2000, 400);
+      el.scrollTop = 0; // distanceFromBottom = 2000 - 0 - 400 = 1600 > 100
+      (component as any).scrollMode = 'idle';
+      (component as any).unseenContent = true;
+
+      expect(component.showJumpToLatest).toBe(true);
+
+      // The *ngIf control renders.
+      fixture.detectChanges();
+      const btn = (fixture.nativeElement as HTMLElement).querySelector(
+        '.jump-to-latest',
+      );
+      expect(btn).not.toBeNull();
+    });
+
+    it('AC #1: indicator HIDDEN at bottom (and unseenContent cleared on reaching bottom)', () => {
+      const el = installMockScrollContainer(1000, 400);
+      el.scrollTop = 600; // distanceFromBottom = 1000 - 600 - 400 = 0 <= 100
+      (component as any).scrollMode = 'idle';
+      (component as any).unseenContent = true;
+
+      // At bottom → getter false regardless of the flag.
+      expect(component.showJumpToLatest).toBe(false);
+
+      // Reaching the bottom via a scroll event clears the flag (AC #1).
+      component.onScroll();
+      expect((component as any).unseenContent).toBe(false);
+    });
+
+    it('AC #1: indicator HIDDEN while following even if not at bottom', () => {
+      const el = installMockScrollContainer(2000, 400);
+      el.scrollTop = 0; // not near bottom
+      (component as any).scrollMode = 'following';
+      (component as any).unseenContent = true;
+
+      expect(component.showJumpToLatest).toBe(false);
+    });
+
+    it('AC #1: unseenContent SET on growth while not at bottom + not following', () => {
+      const el = installMockScrollContainer(2000, 400);
+      el.scrollTop = 0; // below the fold
+      (component as any).scrollMode = 'idle';
+
+      messagesSubject.next([aiMessage('grow-1')]);
+      expect((component as any).unseenContent).toBe(true);
+    });
+
+    it('AC #1: unseenContent NOT set on growth while at bottom', () => {
+      const el = installMockScrollContainer(800, 400);
+      el.scrollTop = 400; // distanceFromBottom = 800 - 400 - 400 = 0 (at bottom)
+      (component as any).scrollMode = 'idle';
+
+      messagesSubject.next([aiMessage('grow-2')]);
+      expect((component as any).unseenContent).toBe(false);
+    });
+
+    // --- AC #2: enter follow on click ---------------------------------------
+    it('AC #2: onJumpToLatest enters following, smooth scroll, clears anchor + unseen', () => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2000, 400);
+      el.scrollTop = 0;
+      (component as any).scrollMode = 'anchored';
+      (component as any).anchorMessageId = 'a-1';
+      (component as any).anchorScrollDone = true;
+      (component as any).lastAnchorOffsetTop = 600;
+      component.spacerHeight = 300;
+      (component as any).unseenContent = true;
+
+      component.onJumpToLatest();
+
+      expect((component as any).scrollMode).toBe('following');
+      expect(el.scrollToCalls).toBe(1);
+      expect(el.lastScrollTo?.top).toBe(2000);
+      expect(el.lastScrollTo?.behavior).toBe('smooth');
+      // Anchor bookkeeping cleared.
+      expect((component as any).anchorMessageId).toBeNull();
+      expect(component.spacerHeight).toBe(0);
+      // Unseen flag cleared.
+      expect((component as any).unseenContent).toBe(false);
+    });
+
+    it('AC #2: onJumpToLatest uses instant behavior under prefers-reduced-motion', () => {
+      mockReducedMotion(true);
+      const el = installMockScrollContainer(2000, 400);
+      component.onJumpToLatest();
+      expect(el.lastScrollTo?.behavior).toBe('auto');
+    });
+
+    // --- AC #2: stay pinned while following ----------------------------------
+    it('AC #2: follow tails on EACH subsequent growth (continuous tail)', () => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2000, 400);
+      component.onJumpToLatest();
+      expect((component as any).scrollMode).toBe('following');
+      expect(el.scrollToCalls).toBe(1); // the click's own scroll
+
+      // First growth → tail armed by subscription, fired by post-layout pass.
+      el.scrollHeight = 2400;
+      messagesSubject.next([aiMessage('t-1')]);
+      component.ngAfterViewChecked();
+      expect(el.scrollToCalls).toBe(2);
+      expect(el.lastScrollTo?.top).toBe(2400);
+
+      // Second growth → tails again (not a one-shot).
+      el.scrollHeight = 2800;
+      messagesSubject.next([aiMessage('t-1'), aiMessage('t-2')]);
+      component.ngAfterViewChecked();
+      expect(el.scrollToCalls).toBe(3);
+      expect(el.lastScrollTo?.top).toBe(2800);
+    });
+
+    it('AC #2: follow tail routes through the programmatic guard (does not self-release)', () => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2000, 400);
+      component.onJumpToLatest();
+      // The programmatic guard is armed by the follow write.
+      expect((component as any).isProgrammaticScroll).toBe(true);
+      // The follow write's own `scroll` frame arrives near the top — but the
+      // guard suppresses any exit (re-arms the debounce, returns early).
+      el.scrollTop = 0;
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('following');
+    });
+
+    // --- AC #3: exit follow on scroll up ------------------------------------
+    it('AC #3: a genuine user scroll-up exits following → idle, indicator reappears', () => {
+      const el = installMockScrollContainer(2000, 400);
+      (component as any).scrollMode = 'following';
+      (component as any).isProgrammaticScroll = false;
+      el.scrollTop = 0; // distanceFromBottom = 1600 > 100 (scrolled up)
+
+      component.onScroll();
+
+      expect((component as any).scrollMode).toBe('idle');
+      // The affordance is immediately available (Open Question 5): unseen set.
+      expect((component as any).unseenContent).toBe(true);
+      expect(component.showJumpToLatest).toBe(true);
+    });
+
+    it('AC #3: a near-bottom scroll while following does NOT exit', () => {
+      const el = installMockScrollContainer(1000, 400);
+      (component as any).scrollMode = 'following';
+      (component as any).isProgrammaticScroll = false;
+      el.scrollTop = 550; // distanceFromBottom = 50 <= 100 (still near bottom)
+
+      component.onScroll();
+      expect((component as any).scrollMode).toBe('following');
+    });
+
+    // --- AC #3: exit follow on send -----------------------------------------
+    it('AC #3: a send while following re-anchors (following → anchored)', () => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2000, 500) as any;
+      el.querySelector = (_sel: string) => ({ offsetTop: 800 });
+      component.onJumpToLatest();
+      expect((component as any).scrollMode).toBe('following');
+
+      // A new send: the justSent$ handler resets to idle-intent (supersedes
+      // following), the next matching emission resolves the anchor, and the
+      // post-layout pass sets `anchored`.
+      const key = String(Date.parse('2026-06-14T10:00:01Z'));
+      (component.chatService as any).emitJustSent(key);
+      expect((component as any).scrollMode).toBe('idle');
+      messagesSubject.next([sendUserTurn('snd-1', '2026-06-14T10:05:00Z')]);
+      expect((component as any).anchorMessageId).toBe('snd-1');
+      component.ngAfterViewChecked();
+      expect((component as any).scrollMode).toBe('anchored');
+    });
+
+    // --- AC #4: follow-tail hover defer -------------------------------------
+    it('AC #4: growth while following + hovered owes a follow-tail (no scroll)', () => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2000, 400);
+      component.onJumpToLatest();
+      const callsAfterClick = el.scrollToCalls;
+
+      component.onMouseEnter();
+      el.scrollHeight = 2400;
+      messagesSubject.next([aiMessage('hov-tail-1')]);
+      component.ngAfterViewChecked();
+
+      // Deferred — no scroll fired; the owed kind is the typed follow-tail.
+      expect(el.scrollToCalls).toBe(callsAfterClick);
+      expect((component as any).owedScroll).toBe('follow-tail');
+    });
+
+    it('AC #4: mouseleave replays the follow-tail as a smooth bottom scroll', fakeAsync(() => {
+      mockReducedMotion(false);
+      const el = installMockScrollContainer(2400, 400);
+      (component as any).scrollMode = 'following';
+      (component as any).owedScroll = 'follow-tail';
+
+      component.onMouseLeave();
+      flushMicrotasks();
+
+      expect(el.scrollToCalls).toBe(1);
+      expect(el.lastScrollTo?.top).toBe(2400);
+      expect(el.lastScrollTo?.behavior).toBe('smooth');
+      expect((component as any).owedScroll).toBeNull();
+      flush(); // drain the programmatic-scroll settle timer the replay armed
+    }));
+  });
 });

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -346,7 +346,15 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    *  is the last child, so its offsetTop marks the end of the messages). This is
    *  immune to `scrollHeight` being clamped up to `clientHeight` on short
    *  conversations — the case where a scrollHeight-based formula under-reserves
-   *  and the message can never reach the top. */
+   *  and the message can never reach the top.
+   *
+   *  We reserve only enough that the PINNED position (anchor at `TOP_PAD`) is the
+   *  bottom-most scroll: subtracting the `TOP_PAD` inset and the list's own
+   *  bottom padding makes `maxScrollTop === anchorTop - TOP_PAD` exactly, so
+   *  scrolling down can't push the anchored bubble above its top inset and no
+   *  surplus empty space is left below the reply. The flex gap before the spacer
+   *  is part of `realBelow` and cancels out, so the inset is exact regardless of
+   *  the gap/padding values. */
   private reserveSpacer(anchorEl: HTMLElement): void {
     const c = this.scrollContainer?.nativeElement;
     const spacer = this.spacerRef?.nativeElement;
@@ -355,7 +363,9 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       return;
     }
     const realBelow = spacer.offsetTop - anchorEl.offsetTop;
-    this.spacerHeight = Math.max(0, Math.min(c.clientHeight, c.clientHeight - realBelow));
+    const padBottom = parseFloat(getComputedStyle(c).paddingBottom) || 0;
+    const reserve = c.clientHeight - realBelow - this.TOP_PAD - padBottom;
+    this.spacerHeight = Math.max(0, Math.min(c.clientHeight, reserve));
     spacer.style.minHeight = this.spacerHeight + 'px';
   }
 

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
 
-import { ChatMessage } from '../../selectors/chat-message.model';
+import { ChatMessage, ENTRY_POINT_NAME } from '../../selectors/chat-message.model';
 import { ActorAddress } from '../../../../protocol/message.types';
 import { ApiService } from '../../../../core/http/api.service';
 import { ChatService, ThinkingState } from '../../selectors/chat.selector';
@@ -86,6 +86,26 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private notificationSubscription!: Subscription;
   pendingNotifications: Set<string> = new Set();
 
+  // ---------------------------------------------------------------------------
+  // Story 19-1 (ADR-016) — top-anchor primitive.
+  // `justSentKey` is the send-origin timestamp emitted by user-input on send;
+  // `anchorMessageId` is the OUTER `ChatMessage.id` of the matched user message
+  // (the `data-message-id` lookup key). `anchorScrollDone` latches the single
+  // top-anchor per turn (AC #2). `spacerHeight` drives the trailing spacer that
+  // reserves room to park the turn at top (AC #3). `lastAnchorOffsetTop` caches
+  // the anchored element's own geometry to discriminate its own height changes
+  // (re-pin, AC #5) from answer-below growth (must NOT move the view).
+  // ---------------------------------------------------------------------------
+  private justSentSubscription!: Subscription;
+  private justSentKey: string | null = null;
+  private anchorMessageId: string | null = null;
+  private anchorScrollDone = false;
+  spacerHeight = 0;
+  private lastAnchorOffsetTop: number | null = null;
+  /** Small top inset (px) so the parked message isn't flush to the edge —
+   *  echoes the `.message-list` 0.5rem/1rem padding rhythm (ADR-016 §Decision 3). */
+  private readonly anchorTopPadding = 8;
+
   ngOnInit(): void {
     this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
       (pending) => {
@@ -93,6 +113,17 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
         this.recomputeModalInputs();
       }
     );
+    // Story 19-1 (AC #1/#2): a new just-sent signal starts a fresh turn —
+    // record the send-origin key and reset the per-anchor latch so the next
+    // matching emission can fire exactly one top-anchor.
+    this.justSentSubscription = this.chatService.justSent$.subscribe((key) => {
+      this.justSentKey = key;
+      this.anchorMessageId = null;
+      this.anchorScrollDone = false;
+      this.lastAnchorOffsetTop = null;
+      // AC #3: spacer is 0 until the new turn is actually anchored.
+      this.spacerHeight = 0;
+    });
     // Story 4-8: merge chat messages + thinking states into a single sorted
     // displayItems array. Either stream re-triggers rebuild.
     // Story 6.4 (AC3): subscription migrated from the deleted
@@ -118,6 +149,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       this.chatMessages = classified;
       this.thinkingStates = thinkingStates;
       this.displayItems = this.buildDisplayItems(classified, thinkingStates);
+      // Story 19-1 (AC #2): resolve the anchor id from the first user-originated
+      // message at/after the send time. Once resolved, the actual scroll runs
+      // post-layout in ngAfterViewChecked (offsetTop must be read post-layout).
+      this.resolveAnchorMessageId();
       // Story 4.4: if a new message arrived while the user is hovering the
       // panel, remember that a catch-up scroll is owed on mouseleave.
       if (this.isHovered && classified.length > previousLength) {
@@ -142,6 +177,11 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     // even while hovered — otherwise a collapse/expand during hover would
     // leave a stale lastScrollHeight that spuriously fires a scroll later.
     const contentChanged = this.hasContentChanged();
+    // Story 19-1: the top-anchor is independent of the hover lock and the
+    // legacy autoscroll — it runs once per turn (AC #2) and then re-pins only
+    // on the anchor element's own height change (AC #5). It coexists with the
+    // legacy stick-to-bottom until Story 19-2 retires the latter.
+    this.maybeAnchorTurn();
     if (this.isHovered) return; // Story 4.4: suspended while hovering
     if (this.shouldScrollToBottom && contentChanged) {
       this.scrollToBottom();
@@ -180,6 +220,9 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
     if (this.notificationSubscription) {
       this.notificationSubscription.unsubscribe();
+    }
+    if (this.justSentSubscription) {
+      this.justSentSubscription.unsubscribe();
     }
   }
 
@@ -385,5 +428,115 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     } catch (err) {
       console.warn('Could not scroll to bottom:', err);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Story 19-1 (ADR-016) — top-anchor primitive helpers.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * AC #2 — resolve `anchorMessageId` (the OUTER `ChatMessage.id`, the
+   * `data-message-id` lookup key) from the first user-originated (Rule 1)
+   * message at/after the send time. Keyed by send ORIGIN (timestamp), not by
+   * content (ADR-016 §Decision 1). No-op once an id is resolved for the turn so
+   * frame-batched / de-dup re-emits do not re-resolve. The actual scroll is
+   * latched separately by `anchorScrollDone` in `maybeAnchorTurn()`.
+   */
+  private resolveAnchorMessageId(): void {
+    if (this.justSentKey === null || this.anchorMessageId !== null) return;
+    const sentAt = Number(this.justSentKey);
+    const match = this.chatMessages.find(
+      (m) =>
+        m.sender.name === ENTRY_POINT_NAME &&
+        (Number.isNaN(sentAt) || m.timestamp.getTime() >= sentAt),
+    );
+    if (match) {
+      this.anchorMessageId = match.id;
+    }
+  }
+
+  /**
+   * AC #2/#4/#5 — drive the top-anchor from the post-layout `ngAfterViewChecked`
+   * pass. Fires the single first-anchor once the matched element renders, then
+   * re-pins only when the anchored element's OWN offset changes (late layout:
+   * image/code-block/late-expanding bubble). Downstream answer growth does not
+   * move the view because it does not change the anchor element's `offsetTop`.
+   */
+  private maybeAnchorTurn(): void {
+    if (this.anchorMessageId === null) return;
+    const anchorEl = this.resolveAnchorElement(this.anchorMessageId);
+    if (!anchorEl) return; // not yet rendered — retry on next emission (AC #4)
+
+    if (!this.anchorScrollDone) {
+      this.applyAnchorScroll(anchorEl);
+      this.anchorScrollDone = true;
+      return;
+    }
+    // Anchor stability (AC #5): re-pin only on the anchor's OWN geometry change.
+    if (anchorEl.offsetTop !== this.lastAnchorOffsetTop) {
+      this.applyAnchorScroll(anchorEl);
+    }
+  }
+
+  /** Resolve the anchored element inside the scroll container via
+   *  `data-message-id` (ADR-016 §Decision 3). Returns null if not yet rendered. */
+  private resolveAnchorElement(id: string): HTMLElement | null {
+    if (!this.scrollContainer) return null;
+    return (
+      this.scrollContainer.nativeElement.querySelector(
+        '[data-message-id="' + id + '"]',
+      ) ?? null
+    );
+  }
+
+  /**
+   * AC #3/#4/#6 — single post-layout read→write task. Reads `offsetTop` /
+   * `clientHeight` / `scrollHeight` first, derives the trailing spacer height,
+   * writes the spacer height, then writes `scrollTop` (smooth unless reduced
+   * motion is requested). No read after the writes — no thrash (NFR2).
+   */
+  private applyAnchorScroll(anchorEl: HTMLElement): void {
+    if (!this.scrollContainer) return;
+    const container = this.scrollContainer.nativeElement;
+    // --- reads (post-layout) ---
+    const offsetTop: number = anchorEl.offsetTop;
+    // --- derive + write spacer (AC #3) ---
+    this.recomputeSpacerHeight(offsetTop);
+    // --- write scroll (AC #4/#6) ---
+    const top = offsetTop - this.anchorTopPadding;
+    container.scrollTo({
+      top,
+      behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
+    });
+    this.lastAnchorOffsetTop = offsetTop;
+  }
+
+  /**
+   * AC #3 — trailing spacer height. `0` when no turn is anchored; otherwise
+   * `max(0, min(viewport, viewport − heightOfAnchoredTurnAndBelow))`, where the
+   * "below" term is measured against the spacer-excluded content
+   * (`scrollHeight − spacerHeight − offsetTop`, Open Question 3 option (a)).
+   * Collapses toward `0` as the answer fills the viewport; capped at the
+   * viewport so short conversations show no dead space.
+   */
+  private recomputeSpacerHeight(anchorOffsetTop: number): void {
+    if (!this.scrollContainer || this.anchorMessageId === null) {
+      this.spacerHeight = 0;
+      return;
+    }
+    const container = this.scrollContainer.nativeElement;
+    const viewportHeight: number = container.clientHeight;
+    const scrollHeight: number = container.scrollHeight;
+    const heightOfAnchoredTurnAndBelow =
+      scrollHeight - this.spacerHeight - anchorOffsetTop;
+    this.spacerHeight = Math.max(
+      0,
+      Math.min(viewportHeight, viewportHeight - heightOfAnchoredTurnAndBelow),
+    );
+  }
+
+  /** AC #6 — true when the user has requested reduced motion. */
+  private prefersReducedMotion(): boolean {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 }

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -17,6 +17,7 @@ import { ActorAddress } from '../../../../protocol/message.types';
 import { ApiService } from '../../../../core/http/api.service';
 import { ChatService, ThinkingState } from '../../selectors/chat.selector';
 import { IngestionService } from '../../event/ingestion.service';
+import { ContextService } from '../../../../core/context/context.service';
 import { Selectable, SelectionService } from '../../ui-state/selection.service';
 import {
   AnsweredRequest,
@@ -32,6 +33,35 @@ export type DisplayItem =
   | { kind: 'message'; data: ChatMessage }
   | { kind: 'thinking'; data: ThinkingState };
 
+/**
+ * Chat panel scroll model (ADR-016, simplified rewrite).
+ *
+ * Two behaviors, kept deliberately small and position-based (no programmatic
+ * scroll flags, no hover lock, no state-machine enum):
+ *
+ *  1. ANCHOR ON SEND — when the user submits a message, the panel pins THAT
+ *     message to the top of the viewport (regardless of the prior scroll
+ *     position) and reserves a trailing spacer so the agent's reply streams into
+ *     the space below it. The submit is signalled by `chatService.justSent$`; the
+ *     echoed message is matched by identity (the newest human-authored message
+ *     that appeared after the send). The spacer shrinks as the reply grows, so
+ *     the message holds its top position without any further scrolling.
+ *
+ *  2. FOLLOW ON DEMAND — while a reply streams in below the fold, a
+ *     "New messages" indicator is shown. Clicking it scrolls to the bottom and
+ *     enters FOLLOW mode (auto-scroll to the bottom on every new message). Any
+ *     manual upward scroll exits follow mode. A new send also exits follow and
+ *     re-anchors.
+ *
+ * Programmatic scrolls are INSTANT, so a scroll event is never confused with a
+ * user scroll: follow mode exits only when the position moves measurably away
+ * from the bottom, which a "scroll to bottom" write never does.
+ *
+ * Entry-to-page (mount) scrolling is intentionally OUT of scope here.
+ *
+ * The per-agent `akgent-chat` trace keeps its own stick-to-bottom autoscroll —
+ * the two surfaces diverge on purpose (see `akgent-chat.component.ts#scroll()`).
+ */
 @Component({
   selector: 'app-chat-panel',
   standalone: true,
@@ -49,12 +79,17 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   @Input() processId!: string;
 
   @ViewChild('scrollContainer', { static: false })
-  private scrollContainer!: ElementRef;
+  private scrollContainer!: ElementRef<HTMLElement>;
+
+  /** The trailing spacer element that reserves room below the anchored message. */
+  @ViewChild('spacer', { static: false })
+  private spacerRef?: ElementRef<HTMLElement>;
 
   chatService: ChatService = inject(ChatService);
   ingestionService: IngestionService = inject(IngestionService);
   selectionService: SelectionService = inject(SelectionService);
   apiService: ApiService = inject(ApiService);
+  private contextService: ContextService = inject(ContextService);
 
   chatMessages: ChatMessage[] = [];
   thinkingStates: ThinkingState[] = [];
@@ -69,175 +104,331 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   modalAnsweredMessages: AnsweredRequest[] = [];
 
   private subscription!: Subscription;
-  private lastScrollHeight = 0;
-  // Story 4.4: hover-aware auto-scroll lock. `isHovered` short-circuits the
-  // scroll in ngAfterViewChecked while the user's pointer is over the panel.
-  // `owedScroll` is set ONLY from the messages$ / mount / anchor paths (a
-  // programmatic scroll suppressed by hover) — never from ngAfterViewChecked
-  // height changes — so collapse/expand toggles during hover do NOT queue a
-  // spurious catch-up.
-  private isHovered = false;
-  // Story 19-2 (ADR-016 §Decision 4 item 4): typed hover owed-action. Records
-  // WHICH programmatic scroll was deferred by the hover lock so `mouseleave`
-  // replays the correct one (the boolean `pendingCatchUpScroll` is retired).
-  // Story 19-3 adds `'follow-tail'` — a deferred follow-mode tail scroll.
-  private owedScroll: 'top-anchor' | 'mount-bottom' | 'follow-tail' | null = null;
+  private notificationSubscription!: Subscription;
+  private justSentSubscription!: Subscription;
+  private runningSubscription!: Subscription;
+
   private expandedMessageIds = new Set<string>();
-  /** Story 4-8: per-bubble expansion state (mirrors expandedMessageIds
-   *  pattern; persists across thinkingAgents$ re-emissions). */
+  /** Story 4-8: per-bubble expansion state. */
   private thinkingExpanded = new Set<string>();
   selectedMessageId: string | null = null;
-  private notificationSubscription!: Subscription;
   pendingNotifications: Set<string> = new Set();
 
-  // ---------------------------------------------------------------------------
-  // Story 19-1 (ADR-016) — top-anchor primitive.
-  // `justSentKey` is the send-origin timestamp emitted by user-input on send;
-  // `anchorMessageId` is the OUTER `ChatMessage.id` of the matched user message
-  // (the `data-message-id` lookup key). `anchorScrollDone` latches the single
-  // top-anchor per turn (AC #2). `spacerHeight` drives the trailing spacer that
-  // reserves room to park the turn at top (AC #3). `lastAnchorOffsetTop` caches
-  // the anchored element's own geometry to discriminate its own height changes
-  // (re-pin, AC #5) from answer-below growth (must NOT move the view).
-  // ---------------------------------------------------------------------------
-  private justSentSubscription!: Subscription;
-  private justSentKey: string | null = null;
-  private anchorMessageId: string | null = null;
-  private anchorScrollDone = false;
+  // --- scroll state -----------------------------------------------------------
+  /** Reserved height (px) of the trailing spacer; bound imperatively. */
   spacerHeight = 0;
-  private lastAnchorOffsetTop: number | null = null;
-  /** Small top inset (px) so the parked message isn't flush to the edge —
-   *  echoes the `.message-list` 0.5rem/1rem padding rhythm (ADR-016 §Decision 3). */
-  private readonly anchorTopPadding = 8;
+  /** Status-pill label above the input (template-bound), or null when hidden.
+   *  One of: 'Auto scrolling' | 'New messages' | 'Messages'. */
+  indicatorLabel: string | null = null;
+  /** FOLLOW mode: auto-scroll to the bottom on every new message. */
+  private following = false;
+  /** A new message arrived that the user hasn't caught up to yet — the only
+   *  difference between "New messages" and "Messages". Set on growth while
+   *  not following; cleared once the newest message is back on screen. */
+  private unseen = false;
+  /** Message count last seen, to detect a genuinely new message. */
+  private prevCount = 0;
+  /** True once the initial history has loaded — so the first batch isn't counted
+   *  as "new" (it's pre-existing, hence "Messages", not "New messages"). */
+  private loaded = false;
 
-  // ---------------------------------------------------------------------------
-  // Story 19-2 (ADR-016 §Decision 4) — explicit scroll-mode state machine.
-  // `scrollMode` is the SINGLE source of truth for "what the viewport is
-  // allowed to do", replacing the implicit `shouldScrollToBottom` boolean:
-  //   - `idle`      : the view never moves on its own (no autoscroll).
-  //   - `anchored`  : a turn is parked at top; turn-triggered growth fills the
-  //                   space below the anchor without moving the scroll.
-  //   - `following` : Story 19-3 — opt-in tail. Entered ONLY by clicking the
-  //                   jump-to-latest indicator (`onJumpToLatest`); pins to the
-  //                   bottom on every `messages$` growth. A manual upward scroll
-  //                   exits to `idle`; a send exits to `anchored` (re-anchor).
-  //
-  // FR12 trace divergence (ADR-016 §Consequences): the main chat panel is now
-  // top-anchored (idle/anchored/following) while the per-agent `akgent-chat`
-  // trace (process/components/agent-tabs/akgent-chat/) deliberately keeps its
-  // own stick-to-bottom autoscroll. The two surfaces diverge intentionally —
-  // see `akgent-chat.component.ts#scroll()`. This is a human navigation note,
-  // not a runtime invariant.
-  // ---------------------------------------------------------------------------
-  private scrollMode: 'idle' | 'anchored' | 'following' = 'idle';
-  /** Story 19-3 (ADR-016 §Decision 6) — true when content grew while the user
-   *  was below the fold and not following, so the jump-to-latest indicator is
-   *  offered. Set on `messages$` growth while `!isNearBottom()` and not
-   *  following; cleared once the user reaches the bottom (`onScroll`) or enters
-   *  follow mode (`onJumpToLatest`). Drives the `showJumpToLatest` getter. */
-  private unseenContent = false;
-  /** Story 19-3 (AC #2) — set on `messages$` growth while `following` so the
-   *  post-layout pass (`maybeFollowTail` in `ngAfterViewChecked`) tails to the
-   *  bottom AFTER layout settles (reading `scrollHeight` post-layout). Keeping
-   *  the write in `ngAfterViewChecked` co-locates all programmatic scroll writes
-   *  (NFR2) and naturally coalesces frame-batched emissions. */
-  private followTailPending = false;
-  /** ADR-016 §Decision 7 — one-shot instant scroll-to-bottom on mount, latched
-   *  so it never re-fires on subsequent emissions / view-checks / growth. */
-  private hasDoneInitialScroll = false;
-  /** ADR-016 §Decision 4 "critical" — set around every programmatic `scrollTop`/
-   *  `scrollTo` write so the resulting `scroll` event is not mistaken for the
-   *  user scrolling away. A smooth `scrollTo` dispatches `scroll` events across
-   *  many animation frames (macrotasks) — long after a microtask checkpoint —
-   *  so the flag is cleared on a TRAILING debounce: each programmatic-origin
-   *  `scroll` re-arms the timer and the flag only drops once the events stop
-   *  arriving (the animation has settled). This is the documented top regression
-   *  risk (§Consequences): a microtask clear would close the window before the
-   *  async `scroll` fired and the anchor would release itself on its own write. */
-  private isProgrammaticScroll = false;
-  /** Trailing-debounce handle that clears `isProgrammaticScroll` once the
-   *  programmatic `scroll` events stop arriving. */
-  private programmaticScrollTimer: ReturnType<typeof setTimeout> | null = null;
-  /** ms of `scroll`-event silence after which a programmatic write is considered
-   *  settled — comfortably outlasts the smooth-scroll animation's frame cadence
-   *  while staying short enough that a genuine user scroll is not swallowed. */
-  private readonly programmaticScrollSettleMs = 150;
-  /** Reused near-bottom threshold (px) — the constant from the retired
-   *  `checkShouldAutoScroll`. Drives anchor-release classification (and, in
-   *  19-3, the indicator + follow-exit) so they stay consistent. */
-  private readonly nearBottomThreshold = 100;
+  /** Outer id of the message currently pinned to the top (null when none). */
+  private anchorId: string | null = null;
+  /** Whether the one-time scroll-to-top for `anchorId` has run. */
+  private anchorPinned = false;
+
+  /** Between a send and the arrival of its echo. */
+  private awaitingEcho = false;
+  /** Newest entry-point (@Human) message id at send time — tells the echo from a
+   *  pre-existing one. */
+  private sendBaselineId: string | null = null;
+
+  private lastScrollHeight = 0;
+  /** Last observed scrollTop — used to tell a user scroll-UP from our own smooth
+   *  scroll (which only ever moves DOWN toward the bottom). */
+  private lastScrollTop = 0;
+
+  /** Small top inset so the pinned message isn't flush against the edge. */
+  private readonly TOP_PAD = 8;
 
   ngOnInit(): void {
     this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
       (pending) => {
         this.pendingNotifications = pending;
         this.recomputeModalInputs();
-      }
+      },
     );
-    // Story 19-1 (AC #1/#2): a new just-sent signal starts a fresh turn —
-    // record the send-origin key and reset the per-anchor latch so the next
-    // matching emission can fire exactly one top-anchor.
-    this.justSentSubscription = this.chatService.justSent$.subscribe((key) => {
-      this.justSentKey = key;
-      this.anchorMessageId = null;
-      this.anchorScrollDone = false;
-      this.lastAnchorOffsetTop = null;
-      // AC #3: spacer is 0 until the new turn is actually anchored.
-      this.spacerHeight = 0;
-      // Story 19-2 (AC #3): re-anchor on send. The latch reset above is the
-      // anchor's own bookkeeping; routing it through the state field makes the
-      // transition read as `anchored/idle → (send) → anchored`. The actual
-      // `anchored` set happens when `applyAnchorScroll` fires in
-      // `maybeAnchorTurn()` once the matched element renders.
-      // Story 19-3 (AC #3): a send while `following` ALSO routes here — setting
-      // `idle` here supersedes `following`, so the next matching emission
-      // re-anchors (`following → (send) → anchored`). Drop any pending tail.
-      this.scrollMode = 'idle';
-      this.followTailPending = false;
+
+    // A submit arms anchoring and exits follow mode. The echo is matched on the
+    // next emission (see onMessages); the baseline distinguishes it from a
+    // pre-existing human message (e.g. restored history).
+    this.justSentSubscription = this.chatService.justSent$.subscribe(() => {
+      this.sendBaselineId = this.latestEntryPointId();
+      this.awaitingEcho = true;
+      this.following = false;
+      this.anchorId = null;
+      this.anchorPinned = false;
+      this.unseen = false;
+      this.indicatorLabel = null;
+      this.clearSpacer();
     });
-    // Story 4-8: merge chat messages + thinking states into a single sorted
-    // displayItems array. Either stream re-triggers rebuild.
-    // Story 6.4 (AC3): subscription migrated from the deleted
-    // `messageService.messages$` onto `chatService.messages$` — classification
-    // is owned by `chatFold` (Story 6.3); the component is a presenter.
+
+    // "Auto scrolling" only applies to a RUNNING process — a stopped team
+    // produces no messages to follow. Exit follow + refresh the pill on change.
+    this.runningSubscription = this.contextService.currentTeamRunning$.subscribe(
+      (running) => {
+        if (!running) this.following = false;
+        this.updateIndicator();
+      },
+    );
+
     this.subscription = combineLatest([
       this.chatService.messages$,
       this.chatService.thinkingAgents$,
-    ]).subscribe(([classified, thinkingStates]) => {
-      const previousLength = this.chatMessages.length;
-      // Preserve per-user expand state across re-emissions (Rule 3 / Rule 4).
-      for (const chatMsg of classified) {
-        if (
-          (chatMsg.rule === 3 || chatMsg.rule === 4) &&
-          this.expandedMessageIds.has(chatMsg.id)
-        ) {
-          chatMsg.collapsed = false;
-        }
-      }
-
-      this.chatMessages = classified;
-      this.thinkingStates = thinkingStates;
-      this.displayItems = this.buildDisplayItems(classified, thinkingStates);
-      // Story 19-1 (AC #2): resolve the anchor id from the first user-originated
-      // message at/after the send time. Once resolved, the actual scroll runs
-      // post-layout in ngAfterViewChecked (offsetTop must be read post-layout).
-      this.resolveAnchorMessageId();
-      // Story 19-2 (AC #6): if a new message arrived while the user is hovering
-      // the panel, remember WHICH scroll is owed on mouseleave (typed). The
-      // `mount-bottom` catch-up preserves the pre-existing "only catch up if
-      // the user was near the bottom at arrival time" intent.
-      if (this.isHovered && classified.length > previousLength) {
-        this.recordOwedScrollDuringHover();
-      }
-      // Story 19-3 (AC #1/#2): react to content growth for the follow-mode tail
-      // and the unseen-content indicator flag. Both key off `displayItems`
-      // growth only (no ingestion change, ADR-005).
-      if (classified.length > previousLength) {
-        this.onContentGrew();
-      }
-      this.recomputeModalInputs();
-    });
+    ]).subscribe(([classified, thinking]) => this.onMessages(classified, thinking));
   }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    this.notificationSubscription?.unsubscribe();
+    this.justSentSubscription?.unsubscribe();
+    this.runningSubscription?.unsubscribe();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Message stream
+  // ---------------------------------------------------------------------------
+
+  private onMessages(classified: ChatMessage[], thinking: ThinkingState[]): void {
+    const grew = classified.length > this.prevCount;
+    this.prevCount = classified.length;
+
+    // Preserve per-user expand state across re-emissions (Rule 3 / Rule 4).
+    for (const chatMsg of classified) {
+      if (
+        (chatMsg.rule === 3 || chatMsg.rule === 4) &&
+        this.expandedMessageIds.has(chatMsg.id)
+      ) {
+        chatMsg.collapsed = false;
+      }
+    }
+
+    this.chatMessages = classified;
+    this.thinkingStates = thinking;
+    this.displayItems = this.buildDisplayItems(classified, thinking);
+
+    // The user's just-sent message arrived → pin it to the top (done in
+    // ngAfterViewChecked once it has rendered). The baseline distinguishes the
+    // echo from a pre-existing @Human message (restored history).
+    if (this.awaitingEcho) {
+      const echoId = this.latestEntryPointId(classified);
+      if (echoId && echoId !== this.sendBaselineId) {
+        this.anchorId = echoId;
+        this.anchorPinned = false;
+        this.awaitingEcho = false;
+        this.following = false;
+        this.unseen = false;
+        this.indicatorLabel = null;
+      }
+    }
+
+    // A genuinely new message the user isn't watching live ⇒ "New messages"
+    // (vs "Messages" when merely scrolled up). The initial history load
+    // does not count as "new". The label itself is derived from layout and
+    // applied in ngAfterViewChecked.
+    if (grew && this.loaded && !this.following) this.unseen = true;
+    this.loaded = this.loaded || classified.length > 0;
+    this.recomputeModalInputs();
+  }
+
+  /**
+   * Post-layout scrolling. Runs after the view is updated so `offsetTop` /
+   * `scrollHeight` are measured against the rendered DOM.
+   */
+  ngAfterViewChecked(): void {
+    if (this.anchorId && !this.anchorPinned) {
+      // First chance to pin the just-sent message to the top. Wait until BOTH the
+      // message element and the spacer have rendered — pinning without the spacer
+      // would reserve no room and the scroll would clamp short.
+      const el = this.findMessageEl(this.anchorId);
+      if (el && this.spacerRef) {
+        this.pinToTop(el);
+        this.anchorPinned = true;
+      }
+    } else if (this.anchorId && this.anchorPinned) {
+      // Keep the reserved room accurate as the reply streams in. The spacer
+      // shrinks by exactly what the reply grows, so scrollHeight stays constant
+      // and the pinned message holds its top position with no further scrolling.
+      const el = this.findMessageEl(this.anchorId);
+      if (el) this.reserveSpacer(el);
+      // Once the reply fills the viewport the spacer is gone — stop managing.
+      if (this.spacerHeight === 0) this.anchorId = null;
+    }
+
+    // FOLLOW mode: tail to the bottom whenever new content arrived.
+    if (this.following && this.contentGrewSinceLastCheck()) {
+      this.scrollToBottom();
+    }
+
+    // Refresh the status pill from post-layout geometry (this is what makes it
+    // appear as replies stream in below an anchored turn, when no scroll event
+    // fires). Deferred to a microtask, and only when it would actually change, so
+    // it can't trip Angular's "expression changed after it was checked" guard or
+    // loop.
+    if (this.computeIndicatorLabel() !== this.indicatorLabel) {
+      queueMicrotask(() => this.updateIndicator());
+    }
+  }
+
+  /** Scroll handler (template `(scroll)` binding). Pure position logic — no
+   *  programmatic-scroll flag needed: our smooth scrolls only ever move DOWN
+   *  toward the bottom, so a measurable UPWARD move is unambiguously the user. */
+  onScroll(): void {
+    const c = this.scrollContainer?.nativeElement;
+    if (!c) return;
+    const movedUp = c.scrollTop < this.lastScrollTop - 2;
+    this.lastScrollTop = c.scrollTop;
+    // The user scrolled up → stop auto-scrolling ("follow until the user scrolls").
+    if (this.following && movedUp) {
+      this.following = false;
+    }
+    // Re-derive the pill from the new position (safe directly — outside CD).
+    this.updateIndicator();
+  }
+
+  /** Pill click — jump to the bottom and start auto-scrolling. */
+  onJumpToLatest(): void {
+    this.following = true;
+    this.unseen = false;
+    this.indicatorLabel = 'Auto scrolling';
+    this.anchorId = null;
+    this.clearSpacer();
+    this.scrollToBottom();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scroll primitives (all INSTANT — see class docstring)
+  // ---------------------------------------------------------------------------
+
+  /** Pin `anchorEl` to the top: reserve the spacer (synchronously, so the
+   *  container has room) then scroll the message's top to the viewport top. */
+  private pinToTop(anchorEl: HTMLElement): void {
+    const c = this.scrollContainer?.nativeElement;
+    if (!c) return;
+    this.reserveSpacer(anchorEl);
+    // `offsetTop` is relative to the nearest positioned ancestor (`.chat-container`),
+    // which the message and the scroll container (`.message-list`) share — so
+    // subtract the container's own `offsetTop` to get a position within the
+    // scroll content.
+    const top = Math.max(0, anchorEl.offsetTop - (c.offsetTop ?? 0) - this.TOP_PAD);
+    c.scrollTo({ top, behavior: this.scrollBehavior() });
+  }
+
+  private scrollToBottom(): void {
+    const c = this.scrollContainer?.nativeElement;
+    if (c) c.scrollTo({ top: c.scrollHeight, behavior: this.scrollBehavior() });
+  }
+
+  /** Smooth by default; instant only when the user requests reduced motion. */
+  private scrollBehavior(): ScrollBehavior {
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+      ? 'auto'
+      : 'smooth';
+  }
+
+  /** Recompute + write the spacer min-height to the DOM synchronously. Real
+   *  content below the anchor = `spacer.offsetTop - anchor.offsetTop` (the spacer
+   *  is the last child, so its offsetTop marks the end of the messages). This is
+   *  immune to `scrollHeight` being clamped up to `clientHeight` on short
+   *  conversations — the case where a scrollHeight-based formula under-reserves
+   *  and the message can never reach the top. */
+  private reserveSpacer(anchorEl: HTMLElement): void {
+    const c = this.scrollContainer?.nativeElement;
+    const spacer = this.spacerRef?.nativeElement;
+    if (!c || !spacer) {
+      this.spacerHeight = 0;
+      return;
+    }
+    const realBelow = spacer.offsetTop - anchorEl.offsetTop;
+    this.spacerHeight = Math.max(0, Math.min(c.clientHeight, c.clientHeight - realBelow));
+    spacer.style.minHeight = this.spacerHeight + 'px';
+  }
+
+  private clearSpacer(): void {
+    this.spacerHeight = 0;
+    const spacer = this.spacerRef?.nativeElement;
+    if (spacer) spacer.style.minHeight = '0px';
+  }
+
+  private findMessageEl(id: string): HTMLElement | null {
+    return (
+      this.scrollContainer?.nativeElement.querySelector<HTMLElement>(
+        '[data-message-id="' + id + '"]',
+      ) ?? null
+    );
+  }
+
+  /**
+   * The "is there a new message to show?" criterion (the indicator's trigger):
+   * the END of the message list is below the visible viewport — i.e. the newest
+   * message is not on screen. The spacer is the list's last child, so its
+   * POSITION (`offsetTop`, not its reserved height) marks where the messages end;
+   * using it keeps the check correct even while a turn is anchored (the reserved
+   * spacer height would otherwise make a scrollHeight-based check think we're at
+   * the bottom).
+   */
+  private newestMessageBelowFold(): boolean {
+    const c = this.scrollContainer?.nativeElement;
+    const spacer = this.spacerRef?.nativeElement;
+    if (!c || !spacer) return false;
+    const messagesBottom = spacer.offsetTop - (c.offsetTop ?? 0);
+    return messagesBottom > c.scrollTop + c.clientHeight + 4;
+  }
+
+  /** The status-pill label for the current state (pure). */
+  private computeIndicatorLabel(): string | null {
+    // "Auto scrolling" only while the process is RUNNING — a stopped team has
+    // nothing to follow.
+    if (this.following && this.contextService.currentTeamRunning$.value) {
+      return 'Auto scrolling';
+    }
+    if (!this.newestMessageBelowFold()) return null;
+    return this.unseen ? 'New messages' : 'Messages';
+  }
+
+  /** Icon class for the status pill — a "following" glyph while auto scrolling,
+   *  a down-arrow for the jump-to-latest states (keyed off the shown label). */
+  get indicatorIcon(): string {
+    return this.indicatorLabel === 'Auto scrolling' ? 'pi-sync' : 'pi-arrow-down';
+  }
+
+  /** Apply the pill label; clears `unseen` once the user is caught up. */
+  private updateIndicator(): void {
+    const label = this.computeIndicatorLabel();
+    if (label === null) this.unseen = false; // newest message back on screen
+    this.indicatorLabel = label;
+  }
+
+  /** True when scrollHeight changed since the last check (new content / spacer). */
+  private contentGrewSinceLastCheck(): boolean {
+    const c = this.scrollContainer?.nativeElement;
+    if (!c) return false;
+    const changed = c.scrollHeight !== this.lastScrollHeight;
+    this.lastScrollHeight = c.scrollHeight;
+    return changed;
+  }
+
+  /** Newest entry-point (@Human) message id — the user's own send — or null. */
+  private latestEntryPointId(msgs: ChatMessage[] = this.chatMessages): string | null {
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].sender.name === ENTRY_POINT_NAME) return msgs[i].id;
+    }
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Presentation helpers (unchanged behavior)
+  // ---------------------------------------------------------------------------
 
   onToggleCollapse(chatMsg: ChatMessage): void {
     if (chatMsg.rule !== 3 && chatMsg.rule !== 4) return;
@@ -249,188 +440,22 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
   }
 
-  /**
-   * Post-layout orchestrator (Story 19-2). Public method coordinates; private
-   * helpers implement. Order: keep `lastScrollHeight` fresh → drive the anchor
-   * (Story 19-1, AC #2/#5) and detect natural scroll-off release (AC #3) →
-   * one-shot mount scroll (AC #4). NO default autoscroll — the legacy
-   * per-emission bottom re-pin is retired (AC #1).
-   */
-  ngAfterViewChecked(): void {
-    // Always evaluate hasContentChanged() so lastScrollHeight stays fresh —
-    // even while hovered — otherwise a collapse/expand during hover would
-    // leave a stale lastScrollHeight that spuriously fires a scroll later. The
-    // return value no longer gates an autoscroll (AC #1) but keeps the
-    // discrimination geometry current.
-    this.hasContentChanged();
-    // Story 19-1/19-2: the top-anchor runs once per turn (AC #2) and re-pins
-    // only on the anchor element's own height change (AC #5); 19-2 also
-    // releases to idle on natural scroll-off (AC #3) and sets `scrollMode`.
-    this.maybeAnchorTurn();
-    this.maybeMountScroll();
-    // Story 19-3 (AC #2): when following, tail to the bottom on each growth.
-    // Runs LAST — `following` is mutually exclusive with an active anchor
-    // (entering follow clears it) and the mount scroll is latched, so this
-    // never fights them.
-    this.maybeFollowTail();
-  }
-
-  /**
-   * AC #4 — one-shot INSTANT scroll-to-bottom on the first view-settle with a
-   * laid-out, non-empty backlog. Latched by `hasDoneInitialScroll` so it never
-   * re-fires. Anchor precedence: if a turn is already anchored (a send arrived
-   * before mount settled), the anchor owns the first frame and the mount scroll
-   * is skipped. After mount the panel stays `idle` (it does not start tailing).
-   */
-  private maybeMountScroll(): void {
-    if (this.hasDoneInitialScroll || this.anchorMessageId !== null) return;
-    if (!this.scrollContainer) return;
-    const el = this.scrollContainer.nativeElement;
-    if (el.scrollHeight <= 0) return; // not laid out yet — retry next pass
-    this.hasDoneInitialScroll = true;
-    if (this.isHovered) {
-      // Story 4.4: defer the programmatic mount scroll until mouseleave.
-      this.owedScroll = 'mount-bottom';
-      return;
-    }
-    this.scrollToBottom();
-  }
-
-  onMouseEnter(): void {
-    this.isHovered = true;
-  }
-
-  onMouseLeave(): void {
-    this.isHovered = false;
-    // Story 19-2 (AC #6): replay the typed owed scroll, then clear it.
-    const owed = this.owedScroll;
-    this.owedScroll = null;
-    if (owed === 'top-anchor') {
-      // Re-run the anchor scroll once layout settles. `maybeAnchorTurn()` is
-      // idempotent (latched) so it re-pins via the resolved element.
-      queueMicrotask(() => this.maybeAnchorTurn());
-    } else if (owed === 'mount-bottom') {
-      // queueMicrotask defers the scroll until after the current event-loop
-      // tick so Angular can finish any change detection triggered by the
-      // isHovered = false assignment before we read scrollHeight.
-      queueMicrotask(() => this.scrollToBottom());
-    } else if (owed === 'follow-tail') {
-      // Story 19-3 (AC #4): replay the deferred follow-mode tail as a smooth
-      // bottom scroll, routed through the programmatic guard.
-      queueMicrotask(() => this.followScrollToBottom());
-    }
-  }
-
-  /**
-   * AC #6 — record WHICH programmatic scroll the hover lock deferred. A
-   * `top-anchor` is owed whenever an active turn's anchor scroll is suppressed
-   * by hover; a `mount-bottom` is owed for the deferred mount catch-up, gated
-   * by the pre-existing "user was near the bottom at arrival" intent. The
-   * `top-anchor` kind wins because parking the turn at top is the dominant
-   * behavior (mirrors 19-1).
-   */
-  private recordOwedScrollDuringHover(): void {
-    // Story 19-3 (AC #4): a follow-mode tail deferred by hover owes a
-    // `follow-tail`. `following` is mutually exclusive with an active anchor
-    // (entering follow clears the anchor), so this branch and `top-anchor`
-    // cannot both apply — check `following` first.
-    if (this.scrollMode === 'following') {
-      this.owedScroll = 'follow-tail';
-      return;
-    }
-    if (this.anchorMessageId !== null) {
-      this.owedScroll = 'top-anchor';
-      return;
-    }
-    if (this.isNearBottom()) {
-      this.owedScroll = 'mount-bottom';
-    }
-  }
-
-  /**
-   * AC #3/#5 — `scroll` event handler bound via the template `(scroll)`
-   * binding (Open Question 2: template binding chosen — smaller, testable
-   * surface, no manual teardown). Programmatic writes (the anchor write, the
-   * mount-bottom write) are ignored via `isProgrammaticScroll` (primary guard);
-   * the near-bottom threshold is the secondary safety net. A GENUINE user
-   * scroll that moves the position measurably above the near-bottom frame while
-   * anchored releases the anchor to `idle`.
-   */
-  onScroll(): void {
-    if (this.isProgrammaticScroll) {
-      // Still settling a programmatic write: this `scroll` is one of the
-      // animation's own frames. Re-arm the trailing debounce and ignore it —
-      // do NOT classify it as a user exit (the anchor must not release itself,
-      // and the follow tail must not self-cancel `following`).
-      this.armProgrammaticScrollSettle();
-      return;
-    }
-    // Story 19-3 (AC #1): reaching the bottom clears the unseen-content flag so
-    // the indicator hides — regardless of the active mode.
-    if (this.isNearBottom()) {
-      this.unseenContent = false;
-    }
-    // Story 19-3 (AC #3): a genuine upward scroll past the threshold while
-    // following exits to `idle` (tailing stops); the indicator re-evaluates
-    // (`showJumpToLatest` shows again if there is unseen content below).
-    if (this.scrollMode === 'following') {
-      if (!this.isNearBottom()) {
-        this.scrollMode = 'idle';
-        this.followTailPending = false;
-        // The user is now below the fold with content beyond the bottom — make
-        // the affordance immediately available (Open Question 5).
-        this.unseenContent = true;
-      }
-      return;
-    }
-    if (this.scrollMode !== 'anchored') return;
-    if (!this.isNearBottom()) {
-      this.releaseAnchor();
-    }
-  }
-
   hasNotification(chatMsg: ChatMessage): boolean {
     // `pendingNotifications` holds inner `BaseMessage.id` values so that
-    // `reply.parent_id` (also inner) clears the correct entry. Using the
-    // outer envelope `chatMsg.id` here would never match, which was the
-    // root cause of the "hand icon never disappears in chat" regression.
+    // `reply.parent_id` (also inner) clears the correct entry.
     return chatMsg.rule === 3 && this.pendingNotifications.has(chatMsg.message_id);
   }
 
-  ngOnDestroy(): void {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
-    if (this.notificationSubscription) {
-      this.notificationSubscription.unsubscribe();
-    }
-    if (this.justSentSubscription) {
-      this.justSentSubscription.unsubscribe();
-    }
-    if (this.programmaticScrollTimer !== null) {
-      clearTimeout(this.programmaticScrollTimer);
-      this.programmaticScrollTimer = null;
-    }
-  }
-
   /**
-   * Bubble click updates the visual selection highlight only. Routing is
-   * driven exclusively by the Send-to dropdown in `user-input.component`
-   * (see Story 4-11 / ADR-002 Revision Log 2026-04-13 — Decision 3
-   * superseded). The former `chatService.setReplyContext(...)` call was
-   * retired because it silently overrode the dropdown selection.
+   * Bubble click updates the visual selection highlight only. Routing is driven
+   * exclusively by the Send-to dropdown in `user-input.component` (Story 4-11).
    */
   onBubbleClicked(chatMsg: ChatMessage): void {
     this.selectedMessageId = chatMsg.id;
   }
 
-  /**
-   * Open the Rule 3 modal with every still-unanswered message from the same
-   * agent pair as the clicked bubble. Story 4-7 will replace the
-   * last-message fallback (modal emits one reply per send) with per-request
-   * reply inputs; this story only changes the notification tracking data
-   * model from `Map<pairKey, ChatMessage[]>` to `Set<id>`.
-   */
+  /** Open the Rule 3 modal with every still-unanswered message from the clicked
+   *  bubble's agent pair. */
   onRule3Clicked(chatMsg: ChatMessage): void {
     const pair = { sender: chatMsg.sender, recipient: chatMsg.recipient };
     const pendingForPair = this.computePendingForPair(pair);
@@ -445,8 +470,6 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   onModalReply(reply: HumanModalReply): void {
-    // Modal stays open across replies (Story 4-7 AC3) — the next messages$
-    // emission will reclassify pending/answered via recomputeModalInputs().
     this.apiService
       .processHumanInput(this.processId, reply.content, reply.messageId)
       .catch((err) => console.error('Failed to send human input:', err));
@@ -461,11 +484,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
   }
 
-  /**
-   * Re-derive modalPendingMessages and modalAnsweredMessages from the current
-   * chatMessages + pendingNotifications when the modal is open. Auto-closes
-   * the modal when both lists become empty (clean-exit condition).
-   */
+  /** Re-derive modal pending/answered lists; auto-close when both empty. */
   private recomputeModalInputs(): void {
     if (this.modalAgentPair === null) return;
     const pendingForPair = this.computePendingForPair(this.modalAgentPair);
@@ -502,8 +521,6 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
           !this.pendingNotifications.has(m.message_id),
       )
       .map((request) => {
-        // Reply's `parent_id` is the original's INNER id (`message_id`),
-        // not its outer envelope `id`.
         const reply =
           this.chatMessages.find((r) => r.parent_id === request.message_id) ?? null;
         return reply ? { request, reply } : null;
@@ -535,11 +552,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     return item.id;
   }
 
-  /**
-   * Story 4-8: Stable tracking key for the mixed display list — preserves
-   * DOM nodes across ephemeral → persistent transitions of a thinking
-   * bubble (the `anchor_message_id` is constant across the finalise flip).
-   */
+  /** Stable tracking key for the mixed display list. */
   trackByDisplayItem(_: number, item: DisplayItem): string {
     return (
       item.kind +
@@ -560,13 +573,7 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
   }
 
-  /**
-   * Story 4-8 (AC5): Merge chat messages and thinking states into a single
-   * chronologically sorted list.
-   *   - Primary key: timestamp / start_time (ms).
-   *   - Tie-break (same ms): message BEFORE thinking (so the triggering
-   *     ReceivedMessage visually precedes its own bubble).
-   */
+  /** Merge chat messages + thinking states into one chronologically sorted list. */
   private buildDisplayItems(
     messages: ChatMessage[],
     thinking: ThinkingState[],
@@ -585,333 +592,5 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       return a.kind === 'message' ? -1 : 1;
     });
     return items;
-  }
-
-  /**
-   * Story 19-2 — distance (px) from the bottom of the scroll container. The
-   * 100px near-bottom threshold from the retired `checkShouldAutoScroll` lives
-   * in `isNearBottom()` below; both reuse this single geometry read.
-   */
-  private distanceFromBottom(): number {
-    if (!this.scrollContainer) return 0;
-    const el = this.scrollContainer.nativeElement;
-    return el.scrollHeight - el.scrollTop - el.clientHeight;
-  }
-
-  /**
-   * Story 19-2 (AC #3/#5) — true when the viewport is within the reused
-   * near-bottom threshold of the bottom. Anchor-release, the mount catch-up
-   * intent, and (19-3) the indicator/follow-exit all key off this constant so
-   * they stay consistent.
-   */
-  private isNearBottom(): boolean {
-    if (!this.scrollContainer) return true;
-    return this.distanceFromBottom() <= this.nearBottomThreshold;
-  }
-
-  private hasContentChanged(): boolean {
-    if (!this.scrollContainer) return false;
-    const currentScrollHeight = this.scrollContainer.nativeElement.scrollHeight;
-    const changed = currentScrollHeight !== this.lastScrollHeight;
-    this.lastScrollHeight = currentScrollHeight;
-    return changed;
-  }
-
-  /**
-   * Instant jump to the bottom. Used by the one-shot mount scroll (AC #4) and,
-   * in 19-3, by follow mode. The write is PROGRAMMATIC: it is bracketed by the
-   * `isProgrammaticScroll` guard (AC #5) so the resulting `scroll` event is not
-   * mistaken for a user scroll-away. Mount is instant regardless (FR8).
-   */
-  private scrollToBottom(): void {
-    if (!this.scrollContainer) return;
-    try {
-      const el = this.scrollContainer.nativeElement;
-      this.beginProgrammaticScroll();
-      el.scrollTop = el.scrollHeight;
-    } catch (err) {
-      console.warn('Could not scroll to bottom:', err);
-    }
-  }
-
-  /**
-   * Story 19-3 (AC #2/#4, Open Question 2) — SMOOTH bottom scroll for follow
-   * mode (honoring reduced motion). A sibling to the instant `scrollToBottom()`
-   * so the mount path stays byte-stable instant (FR8). The write is
-   * PROGRAMMATIC — bracketed by `beginProgrammaticScroll()` so its async smooth
-   * `scroll` frames do not self-cancel `following` via `onScroll` (AC #2).
-   */
-  private followScrollToBottom(): void {
-    if (!this.scrollContainer) return;
-    try {
-      const el = this.scrollContainer.nativeElement;
-      this.beginProgrammaticScroll();
-      el.scrollTo({
-        top: el.scrollHeight,
-        behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
-      });
-    } catch (err) {
-      console.warn('Could not follow-scroll to bottom:', err);
-    }
-  }
-
-  /**
-   * AC #5 — open the programmatic-scroll guard window around a `scrollTop`/
-   * `scrollTo` write. A smooth `scrollTo` dispatches its `scroll` events across
-   * many later animation frames, so the flag is NOT cleared on a microtask
-   * (that window closes before the first async `scroll` fires, letting the
-   * anchor release itself — §Consequences top regression risk). Instead the
-   * flag is cleared on a TRAILING debounce: it is armed here and re-armed by
-   * every programmatic-origin `scroll` in `onScroll`, dropping only once the
-   * events stop (the animation has settled). A genuine user scroll arriving
-   * after settle is then classified normally.
-   */
-  private beginProgrammaticScroll(): void {
-    this.isProgrammaticScroll = true;
-    this.armProgrammaticScrollSettle();
-  }
-
-  /** Re-arm the trailing debounce that clears the programmatic-scroll guard
-   *  once `scroll` events stop arriving (the programmatic animation settled). */
-  private armProgrammaticScrollSettle(): void {
-    if (this.programmaticScrollTimer !== null) {
-      clearTimeout(this.programmaticScrollTimer);
-    }
-    this.programmaticScrollTimer = setTimeout(() => {
-      this.isProgrammaticScroll = false;
-      this.programmaticScrollTimer = null;
-    }, this.programmaticScrollSettleMs);
-  }
-
-  /**
-   * AC #3 — release the anchor to `idle`: stop re-pinning and clear ALL anchor
-   * bookkeeping so `maybeAnchorTurn()` no longer fires until the next send.
-   */
-  private releaseAnchor(): void {
-    this.scrollMode = 'idle';
-    this.anchorMessageId = null;
-    this.anchorScrollDone = false;
-    this.lastAnchorOffsetTop = null;
-    this.spacerHeight = 0;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Story 19-3 (ADR-016 §Decision 4/6) — opt-in follow mode + jump-to-latest.
-  // ---------------------------------------------------------------------------
-
-  /**
-   * AC #1/#2 — react to `displayItems` growth (called only when the list grew).
-   * In `following`, arm the post-layout tail (`maybeFollowTail`). Otherwise, if
-   * the user is below the fold, flag unseen content so the indicator is offered.
-   */
-  private onContentGrew(): void {
-    if (this.scrollMode === 'following') {
-      this.followTailPending = true;
-      return;
-    }
-    if (!this.isNearBottom()) {
-      this.unseenContent = true;
-    }
-  }
-
-  /**
-   * AC #2 — post-layout follow tail. Runs from `ngAfterViewChecked` after the
-   * mount/anchor passes. Pins to the bottom on every growth while `following`.
-   * Honors the hover lock (defers a `follow-tail` owed action) and routes the
-   * write through the programmatic guard so it does not self-release (AC #2).
-   */
-  private maybeFollowTail(): void {
-    if (this.scrollMode !== 'following' || !this.followTailPending) return;
-    this.followTailPending = false;
-    if (this.isHovered) {
-      // Story 4.4 hover lock: defer the tail until mouseleave (AC #4).
-      this.owedScroll = 'follow-tail';
-      return;
-    }
-    this.followScrollToBottom();
-  }
-
-  /**
-   * AC #2 — enter `following`. Clears any active anchor bookkeeping (follow
-   * supersedes `anchored`) then sets the state. Extracted so the click handler
-   * stays an orchestrator. `releaseAnchor()` would set `idle`, so the order is:
-   * clear anchor fields, THEN set `following`.
-   */
-  private enterFollowMode(): void {
-    this.anchorMessageId = null;
-    this.anchorScrollDone = false;
-    this.lastAnchorOffsetTop = null;
-    this.spacerHeight = 0;
-    this.scrollMode = 'following';
-  }
-
-  /**
-   * AC #1 — derived indicator visibility (cheap, side-effect-free; reads
-   * geometry only, no writes — OnPush/CD safe, NFR3). Shown when NOT following,
-   * NOT at the bottom, and there is unseen content below the fold. The
-   * `!== 'following'` and `!isNearBottom()` terms give "hidden while following"
-   * and "hidden at bottom" for free.
-   */
-  get showJumpToLatest(): boolean {
-    return (
-      this.scrollMode !== 'following' &&
-      !this.isNearBottom() &&
-      this.unseenContent
-    );
-  }
-
-  /**
-   * AC #2 — the indicator's click handler: the ONLY entry into `following`.
-   * Enters follow mode, smooth-scrolls to the newest message (reduced-motion
-   * aware), and clears the unseen-content flag.
-   */
-  onJumpToLatest(): void {
-    this.enterFollowMode();
-    this.unseenContent = false;
-    this.followScrollToBottom();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Story 19-1 (ADR-016) — top-anchor primitive helpers.
-  // ---------------------------------------------------------------------------
-
-  /**
-   * AC #2 — resolve `anchorMessageId` (the OUTER `ChatMessage.id`, the
-   * `data-message-id` lookup key) from the first user-originated (Rule 1)
-   * message at/after the send time. Keyed by send ORIGIN (timestamp), not by
-   * content (ADR-016 §Decision 1). No-op once an id is resolved for the turn so
-   * frame-batched / de-dup re-emits do not re-resolve. The actual scroll is
-   * latched separately by `anchorScrollDone` in `maybeAnchorTurn()`.
-   */
-  private resolveAnchorMessageId(): void {
-    if (this.justSentKey === null || this.anchorMessageId !== null) return;
-    const sentAt = Number(this.justSentKey);
-    const match = this.chatMessages.find(
-      (m) =>
-        m.sender.name === ENTRY_POINT_NAME &&
-        (Number.isNaN(sentAt) || m.timestamp.getTime() >= sentAt),
-    );
-    if (match) {
-      this.anchorMessageId = match.id;
-    }
-  }
-
-  /**
-   * AC #2/#4/#5 (19-1) + AC #3 (19-2) — drive the top-anchor from the
-   * post-layout pass. Fires the single first-anchor once the matched element
-   * renders (sets `scrollMode = 'anchored'`), then re-pins only on the anchored
-   * element's OWN offset change (late layout). 19-2 additions: a hover defer
-   * (owe a `top-anchor` replay), and natural scroll-off release to `idle` when
-   * answer growth pushes the anchor above the fold. Downstream answer growth
-   * does not move the view (it does not change the anchor's `offsetTop`).
-   */
-  private maybeAnchorTurn(): void {
-    if (this.anchorMessageId === null) return;
-    const anchorEl = this.resolveAnchorElement(this.anchorMessageId);
-    if (!anchorEl) return; // not yet rendered — retry on next emission (AC #4)
-
-    // Story 4.4 hover lock: defer the programmatic anchor write until mouseleave.
-    if (this.isHovered) {
-      this.owedScroll = 'top-anchor';
-      return;
-    }
-
-    if (!this.anchorScrollDone) {
-      this.applyAnchorScroll(anchorEl);
-      this.anchorScrollDone = true;
-      this.scrollMode = 'anchored';
-      return;
-    }
-    // Natural scroll-off (AC #3): the answer grew tall enough that the anchored
-    // message scrolled above the top of the viewport — release, do NOT re-pin.
-    // Disjoint from the AC #5 re-pin below (Open Question 4): scroll-off is
-    // "anchor above the fold" (offsetTop − scrollTop < topPadding), re-pin is
-    // "anchor's OWN offsetTop changed".
-    if (this.isAnchorScrolledOff(anchorEl)) {
-      this.releaseAnchor();
-      return;
-    }
-    // Anchor stability (AC #5): re-pin only on the anchor's OWN geometry change.
-    if (anchorEl.offsetTop !== this.lastAnchorOffsetTop) {
-      this.applyAnchorScroll(anchorEl);
-    }
-  }
-
-  /**
-   * AC #3 (Open Question 4) — true when the anchored element has scrolled above
-   * the top of the viewport (answer growth pushed it off the fold). Uses the
-   * cached geometry vs the live container `scrollTop`, not a brittle per-frame
-   * heuristic. Distinct from the AC #5 re-pin (which keys off the anchor's OWN
-   * `offsetTop` change, not its position relative to the scroll position).
-   */
-  private isAnchorScrolledOff(anchorEl: HTMLElement): boolean {
-    if (!this.scrollContainer) return false;
-    const container = this.scrollContainer.nativeElement;
-    return anchorEl.offsetTop - container.scrollTop < this.anchorTopPadding;
-  }
-
-  /** Resolve the anchored element inside the scroll container via
-   *  `data-message-id` (ADR-016 §Decision 3). Returns null if not yet rendered. */
-  private resolveAnchorElement(id: string): HTMLElement | null {
-    if (!this.scrollContainer) return null;
-    return (
-      this.scrollContainer.nativeElement.querySelector(
-        '[data-message-id="' + id + '"]',
-      ) ?? null
-    );
-  }
-
-  /**
-   * AC #3/#4/#6 — single post-layout read→write task. Reads `offsetTop` /
-   * `clientHeight` / `scrollHeight` first, derives the trailing spacer height,
-   * writes the spacer height, then writes `scrollTop` (smooth unless reduced
-   * motion is requested). No read after the writes — no thrash (NFR2).
-   */
-  private applyAnchorScroll(anchorEl: HTMLElement): void {
-    if (!this.scrollContainer) return;
-    const container = this.scrollContainer.nativeElement;
-    // --- reads (post-layout) ---
-    const offsetTop: number = anchorEl.offsetTop;
-    // --- derive + write spacer (AC #3) ---
-    this.recomputeSpacerHeight(offsetTop);
-    // --- write scroll (AC #4/#6) ---
-    // Story 19-2 (AC #5): the anchor write is PROGRAMMATIC — bracket it so the
-    // resulting `scroll` event does not release the anchor as a user-exit.
-    const top = offsetTop - this.anchorTopPadding;
-    this.beginProgrammaticScroll();
-    container.scrollTo({
-      top,
-      behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
-    });
-    this.lastAnchorOffsetTop = offsetTop;
-  }
-
-  /**
-   * AC #3 — trailing spacer height. `0` when no turn is anchored; otherwise
-   * `max(0, min(viewport, viewport − heightOfAnchoredTurnAndBelow))`, where the
-   * "below" term is measured against the spacer-excluded content
-   * (`scrollHeight − spacerHeight − offsetTop`, Open Question 3 option (a)).
-   * Collapses toward `0` as the answer fills the viewport; capped at the
-   * viewport so short conversations show no dead space.
-   */
-  private recomputeSpacerHeight(anchorOffsetTop: number): void {
-    if (!this.scrollContainer || this.anchorMessageId === null) {
-      this.spacerHeight = 0;
-      return;
-    }
-    const container = this.scrollContainer.nativeElement;
-    const viewportHeight: number = container.clientHeight;
-    const scrollHeight: number = container.scrollHeight;
-    const heightOfAnchoredTurnAndBelow =
-      scrollHeight - this.spacerHeight - anchorOffsetTop;
-    this.spacerHeight = Math.max(
-      0,
-      Math.min(viewportHeight, viewportHeight - heightOfAnchoredTurnAndBelow),
-    );
-  }
-
-  /** AC #6 — true when the user has requested reduced motion. */
-  private prefersReducedMotion(): boolean {
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 }

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -80,8 +80,8 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   // Story 19-2 (ADR-016 §Decision 4 item 4): typed hover owed-action. Records
   // WHICH programmatic scroll was deferred by the hover lock so `mouseleave`
   // replays the correct one (the boolean `pendingCatchUpScroll` is retired).
-  // The `'follow-tail'` member is added in Story 19-3.
-  private owedScroll: 'top-anchor' | 'mount-bottom' | null = null;
+  // Story 19-3 adds `'follow-tail'` — a deferred follow-mode tail scroll.
+  private owedScroll: 'top-anchor' | 'mount-bottom' | 'follow-tail' | null = null;
   private expandedMessageIds = new Set<string>();
   /** Story 4-8: per-bubble expansion state (mirrors expandedMessageIds
    *  pattern; persists across thinkingAgents$ re-emissions). */
@@ -117,10 +117,31 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   //   - `idle`      : the view never moves on its own (no autoscroll).
   //   - `anchored`  : a turn is parked at top; turn-triggered growth fills the
   //                   space below the anchor without moving the scroll.
-  //   - `following` : 19-3 placeholder — the transitions can target it but
-  //                   NOTHING enters it in this story (tail/indicator are 19-3).
+  //   - `following` : Story 19-3 — opt-in tail. Entered ONLY by clicking the
+  //                   jump-to-latest indicator (`onJumpToLatest`); pins to the
+  //                   bottom on every `messages$` growth. A manual upward scroll
+  //                   exits to `idle`; a send exits to `anchored` (re-anchor).
+  //
+  // FR12 trace divergence (ADR-016 §Consequences): the main chat panel is now
+  // top-anchored (idle/anchored/following) while the per-agent `akgent-chat`
+  // trace (process/components/agent-tabs/akgent-chat/) deliberately keeps its
+  // own stick-to-bottom autoscroll. The two surfaces diverge intentionally —
+  // see `akgent-chat.component.ts#scroll()`. This is a human navigation note,
+  // not a runtime invariant.
   // ---------------------------------------------------------------------------
   private scrollMode: 'idle' | 'anchored' | 'following' = 'idle';
+  /** Story 19-3 (ADR-016 §Decision 6) — true when content grew while the user
+   *  was below the fold and not following, so the jump-to-latest indicator is
+   *  offered. Set on `messages$` growth while `!isNearBottom()` and not
+   *  following; cleared once the user reaches the bottom (`onScroll`) or enters
+   *  follow mode (`onJumpToLatest`). Drives the `showJumpToLatest` getter. */
+  private unseenContent = false;
+  /** Story 19-3 (AC #2) — set on `messages$` growth while `following` so the
+   *  post-layout pass (`maybeFollowTail` in `ngAfterViewChecked`) tails to the
+   *  bottom AFTER layout settles (reading `scrollHeight` post-layout). Keeping
+   *  the write in `ngAfterViewChecked` co-locates all programmatic scroll writes
+   *  (NFR2) and naturally coalesces frame-batched emissions. */
+  private followTailPending = false;
   /** ADR-016 §Decision 7 — one-shot instant scroll-to-bottom on mount, latched
    *  so it never re-fires on subsequent emissions / view-checks / growth. */
   private hasDoneInitialScroll = false;
@@ -168,7 +189,11 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       // transition read as `anchored/idle → (send) → anchored`. The actual
       // `anchored` set happens when `applyAnchorScroll` fires in
       // `maybeAnchorTurn()` once the matched element renders.
+      // Story 19-3 (AC #3): a send while `following` ALSO routes here — setting
+      // `idle` here supersedes `following`, so the next matching emission
+      // re-anchors (`following → (send) → anchored`). Drop any pending tail.
       this.scrollMode = 'idle';
+      this.followTailPending = false;
     });
     // Story 4-8: merge chat messages + thinking states into a single sorted
     // displayItems array. Either stream re-triggers rebuild.
@@ -204,6 +229,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       if (this.isHovered && classified.length > previousLength) {
         this.recordOwedScrollDuringHover();
       }
+      // Story 19-3 (AC #1/#2): react to content growth for the follow-mode tail
+      // and the unseen-content indicator flag. Both key off `displayItems`
+      // growth only (no ingestion change, ADR-005).
+      if (classified.length > previousLength) {
+        this.onContentGrew();
+      }
       this.recomputeModalInputs();
     });
   }
@@ -237,6 +268,11 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     // releases to idle on natural scroll-off (AC #3) and sets `scrollMode`.
     this.maybeAnchorTurn();
     this.maybeMountScroll();
+    // Story 19-3 (AC #2): when following, tail to the bottom on each growth.
+    // Runs LAST — `following` is mutually exclusive with an active anchor
+    // (entering follow clears it) and the mount scroll is latched, so this
+    // never fights them.
+    this.maybeFollowTail();
   }
 
   /**
@@ -278,6 +314,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       // tick so Angular can finish any change detection triggered by the
       // isHovered = false assignment before we read scrollHeight.
       queueMicrotask(() => this.scrollToBottom());
+    } else if (owed === 'follow-tail') {
+      // Story 19-3 (AC #4): replay the deferred follow-mode tail as a smooth
+      // bottom scroll, routed through the programmatic guard.
+      queueMicrotask(() => this.followScrollToBottom());
     }
   }
 
@@ -290,6 +330,14 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    * behavior (mirrors 19-1).
    */
   private recordOwedScrollDuringHover(): void {
+    // Story 19-3 (AC #4): a follow-mode tail deferred by hover owes a
+    // `follow-tail`. `following` is mutually exclusive with an active anchor
+    // (entering follow clears the anchor), so this branch and `top-anchor`
+    // cannot both apply — check `following` first.
+    if (this.scrollMode === 'following') {
+      this.owedScroll = 'follow-tail';
+      return;
+    }
     if (this.anchorMessageId !== null) {
       this.owedScroll = 'top-anchor';
       return;
@@ -312,8 +360,27 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (this.isProgrammaticScroll) {
       // Still settling a programmatic write: this `scroll` is one of the
       // animation's own frames. Re-arm the trailing debounce and ignore it —
-      // do NOT classify it as a user exit (the anchor must not release itself).
+      // do NOT classify it as a user exit (the anchor must not release itself,
+      // and the follow tail must not self-cancel `following`).
       this.armProgrammaticScrollSettle();
+      return;
+    }
+    // Story 19-3 (AC #1): reaching the bottom clears the unseen-content flag so
+    // the indicator hides — regardless of the active mode.
+    if (this.isNearBottom()) {
+      this.unseenContent = false;
+    }
+    // Story 19-3 (AC #3): a genuine upward scroll past the threshold while
+    // following exits to `idle` (tailing stops); the indicator re-evaluates
+    // (`showJumpToLatest` shows again if there is unseen content below).
+    if (this.scrollMode === 'following') {
+      if (!this.isNearBottom()) {
+        this.scrollMode = 'idle';
+        this.followTailPending = false;
+        // The user is now below the fold with content beyond the bottom — make
+        // the affordance immediately available (Open Question 5).
+        this.unseenContent = true;
+      }
       return;
     }
     if (this.scrollMode !== 'anchored') return;
@@ -568,6 +635,27 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   /**
+   * Story 19-3 (AC #2/#4, Open Question 2) — SMOOTH bottom scroll for follow
+   * mode (honoring reduced motion). A sibling to the instant `scrollToBottom()`
+   * so the mount path stays byte-stable instant (FR8). The write is
+   * PROGRAMMATIC — bracketed by `beginProgrammaticScroll()` so its async smooth
+   * `scroll` frames do not self-cancel `following` via `onScroll` (AC #2).
+   */
+  private followScrollToBottom(): void {
+    if (!this.scrollContainer) return;
+    try {
+      const el = this.scrollContainer.nativeElement;
+      this.beginProgrammaticScroll();
+      el.scrollTo({
+        top: el.scrollHeight,
+        behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
+      });
+    } catch (err) {
+      console.warn('Could not follow-scroll to bottom:', err);
+    }
+  }
+
+  /**
    * AC #5 — open the programmatic-scroll guard window around a `scrollTop`/
    * `scrollTo` write. A smooth `scrollTo` dispatches its `scroll` events across
    * many later animation frames, so the flag is NOT cleared on a microtask
@@ -605,6 +693,82 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     this.anchorScrollDone = false;
     this.lastAnchorOffsetTop = null;
     this.spacerHeight = 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Story 19-3 (ADR-016 §Decision 4/6) — opt-in follow mode + jump-to-latest.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * AC #1/#2 — react to `displayItems` growth (called only when the list grew).
+   * In `following`, arm the post-layout tail (`maybeFollowTail`). Otherwise, if
+   * the user is below the fold, flag unseen content so the indicator is offered.
+   */
+  private onContentGrew(): void {
+    if (this.scrollMode === 'following') {
+      this.followTailPending = true;
+      return;
+    }
+    if (!this.isNearBottom()) {
+      this.unseenContent = true;
+    }
+  }
+
+  /**
+   * AC #2 — post-layout follow tail. Runs from `ngAfterViewChecked` after the
+   * mount/anchor passes. Pins to the bottom on every growth while `following`.
+   * Honors the hover lock (defers a `follow-tail` owed action) and routes the
+   * write through the programmatic guard so it does not self-release (AC #2).
+   */
+  private maybeFollowTail(): void {
+    if (this.scrollMode !== 'following' || !this.followTailPending) return;
+    this.followTailPending = false;
+    if (this.isHovered) {
+      // Story 4.4 hover lock: defer the tail until mouseleave (AC #4).
+      this.owedScroll = 'follow-tail';
+      return;
+    }
+    this.followScrollToBottom();
+  }
+
+  /**
+   * AC #2 — enter `following`. Clears any active anchor bookkeeping (follow
+   * supersedes `anchored`) then sets the state. Extracted so the click handler
+   * stays an orchestrator. `releaseAnchor()` would set `idle`, so the order is:
+   * clear anchor fields, THEN set `following`.
+   */
+  private enterFollowMode(): void {
+    this.anchorMessageId = null;
+    this.anchorScrollDone = false;
+    this.lastAnchorOffsetTop = null;
+    this.spacerHeight = 0;
+    this.scrollMode = 'following';
+  }
+
+  /**
+   * AC #1 — derived indicator visibility (cheap, side-effect-free; reads
+   * geometry only, no writes — OnPush/CD safe, NFR3). Shown when NOT following,
+   * NOT at the bottom, and there is unseen content below the fold. The
+   * `!== 'following'` and `!isNearBottom()` terms give "hidden while following"
+   * and "hidden at bottom" for free.
+   */
+  get showJumpToLatest(): boolean {
+    return (
+      this.scrollMode !== 'following' &&
+      !this.isNearBottom() &&
+      this.unseenContent
+    );
+  }
+
+  /**
+   * AC #2 — the indicator's click handler: the ONLY entry into `following`.
+   * Enters follow mode, smooth-scrolls to the newest message (reduced-motion
+   * aware), and clears the unseen-content flag.
+   */
+  onJumpToLatest(): void {
+    this.enterFollowMode();
+    this.unseenContent = false;
+    this.followScrollToBottom();
   }
 
   // ---------------------------------------------------------------------------

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -115,8 +115,8 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   pendingNotifications: Set<string> = new Set();
 
   // --- scroll state -----------------------------------------------------------
-  /** Reserved height (px) of the trailing spacer; bound imperatively. */
-  spacerHeight = 0;
+  /** Reserved height (px) of the trailing spacer; written to the DOM imperatively. */
+  private spacerHeight = 0;
   /** Status-pill label above the input (template-bound), or null when hidden.
    *  One of: 'Auto scrolling' | 'New messages' | 'Messages'. */
   indicatorLabel: string | null = null;
@@ -288,8 +288,13 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     if (!c) return;
     const movedUp = c.scrollTop < this.lastScrollTop - 2;
     this.lastScrollTop = c.scrollTop;
-    // The user scrolled up → stop auto-scrolling ("follow until the user scrolls").
-    if (this.following && movedUp) {
+    // Reaching the bottom turns auto-scroll ON; scrolling up turns it off
+    // ("follow until the user scrolls"). The `anchorId` guard keeps a just-sent
+    // anchored turn (message parked at top, spacer below) from counting as
+    // "at the bottom".
+    if (this.anchorId === null && !this.newestMessageBelowFold()) {
+      this.following = true;
+    } else if (this.following && movedUp) {
       this.following = false;
     }
     // Re-derive the pill from the new position (safe directly — outside CD).
@@ -386,13 +391,13 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   /** The status-pill label for the current state (pure). */
-  private computeIndicatorLabel(): string | null {
+  private computeIndicatorLabel(belowFold = this.newestMessageBelowFold()): string | null {
     // "Auto scrolling" only while the process is RUNNING — a stopped team has
     // nothing to follow.
     if (this.following && this.contextService.currentTeamRunning$.value) {
       return 'Auto scrolling';
     }
-    if (!this.newestMessageBelowFold()) return null;
+    if (!belowFold) return null;
     return this.unseen ? 'New messages' : 'Messages';
   }
 
@@ -402,11 +407,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     return this.indicatorLabel === 'Auto scrolling' ? 'pi-sync' : 'pi-arrow-down';
   }
 
-  /** Apply the pill label; clears `unseen` once the user is caught up. */
+  /** Apply the pill label; clears `unseen` once the user is at the bottom
+   *  (caught up), whether following or not. */
   private updateIndicator(): void {
-    const label = this.computeIndicatorLabel();
-    if (label === null) this.unseen = false; // newest message back on screen
-    this.indicatorLabel = label;
+    const belowFold = this.newestMessageBelowFold();
+    if (!belowFold) this.unseen = false; // at the bottom → caught up
+    this.indicatorLabel = this.computeIndicatorLabel(belowFold);
   }
 
   /** True when scrollHeight changed since the last check (new content / spacer). */

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -69,15 +69,19 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   modalAnsweredMessages: AnsweredRequest[] = [];
 
   private subscription!: Subscription;
-  private shouldScrollToBottom = true;
   private lastScrollHeight = 0;
   // Story 4.4: hover-aware auto-scroll lock. `isHovered` short-circuits the
   // scroll in ngAfterViewChecked while the user's pointer is over the panel.
-  // `pendingCatchUpScroll` is set ONLY from the messages$ subscription path
-  // (new-message arrival) — never from ngAfterViewChecked height changes —
-  // so collapse/expand toggles during hover do NOT queue a spurious catch-up.
+  // `owedScroll` is set ONLY from the messages$ / mount / anchor paths (a
+  // programmatic scroll suppressed by hover) — never from ngAfterViewChecked
+  // height changes — so collapse/expand toggles during hover do NOT queue a
+  // spurious catch-up.
   private isHovered = false;
-  private pendingCatchUpScroll = false;
+  // Story 19-2 (ADR-016 §Decision 4 item 4): typed hover owed-action. Records
+  // WHICH programmatic scroll was deferred by the hover lock so `mouseleave`
+  // replays the correct one (the boolean `pendingCatchUpScroll` is retired).
+  // The `'follow-tail'` member is added in Story 19-3.
+  private owedScroll: 'top-anchor' | 'mount-bottom' | null = null;
   private expandedMessageIds = new Set<string>();
   /** Story 4-8: per-bubble expansion state (mirrors expandedMessageIds
    *  pattern; persists across thinkingAgents$ re-emissions). */
@@ -106,6 +110,29 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    *  echoes the `.message-list` 0.5rem/1rem padding rhythm (ADR-016 §Decision 3). */
   private readonly anchorTopPadding = 8;
 
+  // ---------------------------------------------------------------------------
+  // Story 19-2 (ADR-016 §Decision 4) — explicit scroll-mode state machine.
+  // `scrollMode` is the SINGLE source of truth for "what the viewport is
+  // allowed to do", replacing the implicit `shouldScrollToBottom` boolean:
+  //   - `idle`      : the view never moves on its own (no autoscroll).
+  //   - `anchored`  : a turn is parked at top; turn-triggered growth fills the
+  //                   space below the anchor without moving the scroll.
+  //   - `following` : 19-3 placeholder — the transitions can target it but
+  //                   NOTHING enters it in this story (tail/indicator are 19-3).
+  // ---------------------------------------------------------------------------
+  private scrollMode: 'idle' | 'anchored' | 'following' = 'idle';
+  /** ADR-016 §Decision 7 — one-shot instant scroll-to-bottom on mount, latched
+   *  so it never re-fires on subsequent emissions / view-checks / growth. */
+  private hasDoneInitialScroll = false;
+  /** ADR-016 §Decision 4 "critical" — set around every programmatic `scrollTop`/
+   *  `scrollTo` write so the resulting `scroll` event is not mistaken for the
+   *  user scrolling away. Cleared after the event settles (queueMicrotask). */
+  private isProgrammaticScroll = false;
+  /** Reused near-bottom threshold (px) — the constant from the retired
+   *  `checkShouldAutoScroll`. Drives anchor-release classification (and, in
+   *  19-3, the indicator + follow-exit) so they stay consistent. */
+  private readonly nearBottomThreshold = 100;
+
   ngOnInit(): void {
     this.notificationSubscription = this.chatService.pendingNotifications$.subscribe(
       (pending) => {
@@ -123,6 +150,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       this.lastAnchorOffsetTop = null;
       // AC #3: spacer is 0 until the new turn is actually anchored.
       this.spacerHeight = 0;
+      // Story 19-2 (AC #3): re-anchor on send. The latch reset above is the
+      // anchor's own bookkeeping; routing it through the state field makes the
+      // transition read as `anchored/idle → (send) → anchored`. The actual
+      // `anchored` set happens when `applyAnchorScroll` fires in
+      // `maybeAnchorTurn()` once the matched element renders.
+      this.scrollMode = 'idle';
     });
     // Story 4-8: merge chat messages + thinking states into a single sorted
     // displayItems array. Either stream re-triggers rebuild.
@@ -133,8 +166,6 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       this.chatService.messages$,
       this.chatService.thinkingAgents$,
     ]).subscribe(([classified, thinkingStates]) => {
-      this.checkShouldAutoScroll();
-
       const previousLength = this.chatMessages.length;
       // Preserve per-user expand state across re-emissions (Rule 3 / Rule 4).
       for (const chatMsg of classified) {
@@ -153,10 +184,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
       // message at/after the send time. Once resolved, the actual scroll runs
       // post-layout in ngAfterViewChecked (offsetTop must be read post-layout).
       this.resolveAnchorMessageId();
-      // Story 4.4: if a new message arrived while the user is hovering the
-      // panel, remember that a catch-up scroll is owed on mouseleave.
+      // Story 19-2 (AC #6): if a new message arrived while the user is hovering
+      // the panel, remember WHICH scroll is owed on mouseleave (typed). The
+      // `mount-bottom` catch-up preserves the pre-existing "only catch up if
+      // the user was near the bottom at arrival time" intent.
       if (this.isHovered && classified.length > previousLength) {
-        this.pendingCatchUpScroll = true;
+        this.recordOwedScrollDuringHover();
       }
       this.recomputeModalInputs();
     });
@@ -172,20 +205,46 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
   }
 
+  /**
+   * Post-layout orchestrator (Story 19-2). Public method coordinates; private
+   * helpers implement. Order: keep `lastScrollHeight` fresh → drive the anchor
+   * (Story 19-1, AC #2/#5) and detect natural scroll-off release (AC #3) →
+   * one-shot mount scroll (AC #4). NO default autoscroll — the legacy
+   * per-emission bottom re-pin is retired (AC #1).
+   */
   ngAfterViewChecked(): void {
     // Always evaluate hasContentChanged() so lastScrollHeight stays fresh —
     // even while hovered — otherwise a collapse/expand during hover would
-    // leave a stale lastScrollHeight that spuriously fires a scroll later.
-    const contentChanged = this.hasContentChanged();
-    // Story 19-1: the top-anchor is independent of the hover lock and the
-    // legacy autoscroll — it runs once per turn (AC #2) and then re-pins only
-    // on the anchor element's own height change (AC #5). It coexists with the
-    // legacy stick-to-bottom until Story 19-2 retires the latter.
+    // leave a stale lastScrollHeight that spuriously fires a scroll later. The
+    // return value no longer gates an autoscroll (AC #1) but keeps the
+    // discrimination geometry current.
+    this.hasContentChanged();
+    // Story 19-1/19-2: the top-anchor runs once per turn (AC #2) and re-pins
+    // only on the anchor element's own height change (AC #5); 19-2 also
+    // releases to idle on natural scroll-off (AC #3) and sets `scrollMode`.
     this.maybeAnchorTurn();
-    if (this.isHovered) return; // Story 4.4: suspended while hovering
-    if (this.shouldScrollToBottom && contentChanged) {
-      this.scrollToBottom();
+    this.maybeMountScroll();
+  }
+
+  /**
+   * AC #4 — one-shot INSTANT scroll-to-bottom on the first view-settle with a
+   * laid-out, non-empty backlog. Latched by `hasDoneInitialScroll` so it never
+   * re-fires. Anchor precedence: if a turn is already anchored (a send arrived
+   * before mount settled), the anchor owns the first frame and the mount scroll
+   * is skipped. After mount the panel stays `idle` (it does not start tailing).
+   */
+  private maybeMountScroll(): void {
+    if (this.hasDoneInitialScroll || this.anchorMessageId !== null) return;
+    if (!this.scrollContainer) return;
+    const el = this.scrollContainer.nativeElement;
+    if (el.scrollHeight <= 0) return; // not laid out yet — retry next pass
+    this.hasDoneInitialScroll = true;
+    if (this.isHovered) {
+      // Story 4.4: defer the programmatic mount scroll until mouseleave.
+      this.owedScroll = 'mount-bottom';
+      return;
     }
+    this.scrollToBottom();
   }
 
   onMouseEnter(): void {
@@ -194,15 +253,53 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   onMouseLeave(): void {
     this.isHovered = false;
-    // Catch-up only if a new message arrived during hover AND the user was
-    // near the bottom at arrival time (preserve pre-existing user-intent).
-    const shouldCatchUp = this.pendingCatchUpScroll && this.shouldScrollToBottom;
-    this.pendingCatchUpScroll = false;
-    if (shouldCatchUp) {
+    // Story 19-2 (AC #6): replay the typed owed scroll, then clear it.
+    const owed = this.owedScroll;
+    this.owedScroll = null;
+    if (owed === 'top-anchor') {
+      // Re-run the anchor scroll once layout settles. `maybeAnchorTurn()` is
+      // idempotent (latched) so it re-pins via the resolved element.
+      queueMicrotask(() => this.maybeAnchorTurn());
+    } else if (owed === 'mount-bottom') {
       // queueMicrotask defers the scroll until after the current event-loop
       // tick so Angular can finish any change detection triggered by the
       // isHovered = false assignment before we read scrollHeight.
       queueMicrotask(() => this.scrollToBottom());
+    }
+  }
+
+  /**
+   * AC #6 — record WHICH programmatic scroll the hover lock deferred. A
+   * `top-anchor` is owed whenever an active turn's anchor scroll is suppressed
+   * by hover; a `mount-bottom` is owed for the deferred mount catch-up, gated
+   * by the pre-existing "user was near the bottom at arrival" intent. The
+   * `top-anchor` kind wins because parking the turn at top is the dominant
+   * behavior (mirrors 19-1).
+   */
+  private recordOwedScrollDuringHover(): void {
+    if (this.anchorMessageId !== null) {
+      this.owedScroll = 'top-anchor';
+      return;
+    }
+    if (this.isNearBottom()) {
+      this.owedScroll = 'mount-bottom';
+    }
+  }
+
+  /**
+   * AC #3/#5 — `scroll` event handler bound via the template `(scroll)`
+   * binding (Open Question 2: template binding chosen — smaller, testable
+   * surface, no manual teardown). Programmatic writes (the anchor write, the
+   * mount-bottom write) are ignored via `isProgrammaticScroll` (primary guard);
+   * the near-bottom threshold is the secondary safety net. A GENUINE user
+   * scroll that moves the position measurably above the near-bottom frame while
+   * anchored releases the anchor to `idle`.
+   */
+  onScroll(): void {
+    if (this.isProgrammaticScroll) return; // programmatic write — not a user exit
+    if (this.scrollMode !== 'anchored') return;
+    if (!this.isNearBottom()) {
+      this.releaseAnchor();
     }
   }
 
@@ -400,16 +497,26 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     return items;
   }
 
-  private checkShouldAutoScroll(): void {
-    if (!this.scrollContainer) {
-      this.shouldScrollToBottom = true;
-      return;
-    }
+  /**
+   * Story 19-2 — distance (px) from the bottom of the scroll container. The
+   * 100px near-bottom threshold from the retired `checkShouldAutoScroll` lives
+   * in `isNearBottom()` below; both reuse this single geometry read.
+   */
+  private distanceFromBottom(): number {
+    if (!this.scrollContainer) return 0;
     const el = this.scrollContainer.nativeElement;
-    const threshold = 100;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    this.shouldScrollToBottom =
-      distanceFromBottom <= threshold || this.lastScrollHeight === 0;
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  }
+
+  /**
+   * Story 19-2 (AC #3/#5) — true when the viewport is within the reused
+   * near-bottom threshold of the bottom. Anchor-release, the mount catch-up
+   * intent, and (19-3) the indicator/follow-exit all key off this constant so
+   * they stay consistent.
+   */
+  private isNearBottom(): boolean {
+    if (!this.scrollContainer) return true;
+    return this.distanceFromBottom() <= this.nearBottomThreshold;
   }
 
   private hasContentChanged(): boolean {
@@ -420,14 +527,47 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     return changed;
   }
 
+  /**
+   * Instant jump to the bottom. Used by the one-shot mount scroll (AC #4) and,
+   * in 19-3, by follow mode. The write is PROGRAMMATIC: it is bracketed by the
+   * `isProgrammaticScroll` guard (AC #5) so the resulting `scroll` event is not
+   * mistaken for a user scroll-away. Mount is instant regardless (FR8).
+   */
   private scrollToBottom(): void {
     if (!this.scrollContainer) return;
     try {
       const el = this.scrollContainer.nativeElement;
+      this.beginProgrammaticScroll();
       el.scrollTop = el.scrollHeight;
     } catch (err) {
       console.warn('Could not scroll to bottom:', err);
     }
+  }
+
+  /**
+   * AC #5 — open the programmatic-scroll guard window around a `scrollTop`/
+   * `scrollTo` write. The `scroll` event fires asynchronously, so the flag is
+   * cleared via `queueMicrotask` after the write (mirroring Story 4.4's
+   * discipline) — long enough to bracket the programmatic `scroll` event,
+   * short enough that a genuine user scroll in a later tick still releases.
+   */
+  private beginProgrammaticScroll(): void {
+    this.isProgrammaticScroll = true;
+    queueMicrotask(() => {
+      this.isProgrammaticScroll = false;
+    });
+  }
+
+  /**
+   * AC #3 — release the anchor to `idle`: stop re-pinning and clear ALL anchor
+   * bookkeeping so `maybeAnchorTurn()` no longer fires until the next send.
+   */
+  private releaseAnchor(): void {
+    this.scrollMode = 'idle';
+    this.anchorMessageId = null;
+    this.anchorScrollDone = false;
+    this.lastAnchorOffsetTop = null;
+    this.spacerHeight = 0;
   }
 
   // ---------------------------------------------------------------------------
@@ -456,26 +596,57 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   }
 
   /**
-   * AC #2/#4/#5 — drive the top-anchor from the post-layout `ngAfterViewChecked`
-   * pass. Fires the single first-anchor once the matched element renders, then
-   * re-pins only when the anchored element's OWN offset changes (late layout:
-   * image/code-block/late-expanding bubble). Downstream answer growth does not
-   * move the view because it does not change the anchor element's `offsetTop`.
+   * AC #2/#4/#5 (19-1) + AC #3 (19-2) — drive the top-anchor from the
+   * post-layout pass. Fires the single first-anchor once the matched element
+   * renders (sets `scrollMode = 'anchored'`), then re-pins only on the anchored
+   * element's OWN offset change (late layout). 19-2 additions: a hover defer
+   * (owe a `top-anchor` replay), and natural scroll-off release to `idle` when
+   * answer growth pushes the anchor above the fold. Downstream answer growth
+   * does not move the view (it does not change the anchor's `offsetTop`).
    */
   private maybeAnchorTurn(): void {
     if (this.anchorMessageId === null) return;
     const anchorEl = this.resolveAnchorElement(this.anchorMessageId);
     if (!anchorEl) return; // not yet rendered — retry on next emission (AC #4)
 
+    // Story 4.4 hover lock: defer the programmatic anchor write until mouseleave.
+    if (this.isHovered) {
+      this.owedScroll = 'top-anchor';
+      return;
+    }
+
     if (!this.anchorScrollDone) {
       this.applyAnchorScroll(anchorEl);
       this.anchorScrollDone = true;
+      this.scrollMode = 'anchored';
+      return;
+    }
+    // Natural scroll-off (AC #3): the answer grew tall enough that the anchored
+    // message scrolled above the top of the viewport — release, do NOT re-pin.
+    // Disjoint from the AC #5 re-pin below (Open Question 4): scroll-off is
+    // "anchor above the fold" (offsetTop − scrollTop < topPadding), re-pin is
+    // "anchor's OWN offsetTop changed".
+    if (this.isAnchorScrolledOff(anchorEl)) {
+      this.releaseAnchor();
       return;
     }
     // Anchor stability (AC #5): re-pin only on the anchor's OWN geometry change.
     if (anchorEl.offsetTop !== this.lastAnchorOffsetTop) {
       this.applyAnchorScroll(anchorEl);
     }
+  }
+
+  /**
+   * AC #3 (Open Question 4) — true when the anchored element has scrolled above
+   * the top of the viewport (answer growth pushed it off the fold). Uses the
+   * cached geometry vs the live container `scrollTop`, not a brittle per-frame
+   * heuristic. Distinct from the AC #5 re-pin (which keys off the anchor's OWN
+   * `offsetTop` change, not its position relative to the scroll position).
+   */
+  private isAnchorScrolledOff(anchorEl: HTMLElement): boolean {
+    if (!this.scrollContainer) return false;
+    const container = this.scrollContainer.nativeElement;
+    return anchorEl.offsetTop - container.scrollTop < this.anchorTopPadding;
   }
 
   /** Resolve the anchored element inside the scroll container via
@@ -503,7 +674,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     // --- derive + write spacer (AC #3) ---
     this.recomputeSpacerHeight(offsetTop);
     // --- write scroll (AC #4/#6) ---
+    // Story 19-2 (AC #5): the anchor write is PROGRAMMATIC — bracket it so the
+    // resulting `scroll` event does not release the anchor as a user-exit.
     const top = offsetTop - this.anchorTopPadding;
+    this.beginProgrammaticScroll();
     container.scrollTo({
       top,
       behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -126,8 +126,21 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   private hasDoneInitialScroll = false;
   /** ADR-016 §Decision 4 "critical" — set around every programmatic `scrollTop`/
    *  `scrollTo` write so the resulting `scroll` event is not mistaken for the
-   *  user scrolling away. Cleared after the event settles (queueMicrotask). */
+   *  user scrolling away. A smooth `scrollTo` dispatches `scroll` events across
+   *  many animation frames (macrotasks) — long after a microtask checkpoint —
+   *  so the flag is cleared on a TRAILING debounce: each programmatic-origin
+   *  `scroll` re-arms the timer and the flag only drops once the events stop
+   *  arriving (the animation has settled). This is the documented top regression
+   *  risk (§Consequences): a microtask clear would close the window before the
+   *  async `scroll` fired and the anchor would release itself on its own write. */
   private isProgrammaticScroll = false;
+  /** Trailing-debounce handle that clears `isProgrammaticScroll` once the
+   *  programmatic `scroll` events stop arriving. */
+  private programmaticScrollTimer: ReturnType<typeof setTimeout> | null = null;
+  /** ms of `scroll`-event silence after which a programmatic write is considered
+   *  settled — comfortably outlasts the smooth-scroll animation's frame cadence
+   *  while staying short enough that a genuine user scroll is not swallowed. */
+  private readonly programmaticScrollSettleMs = 150;
   /** Reused near-bottom threshold (px) — the constant from the retired
    *  `checkShouldAutoScroll`. Drives anchor-release classification (and, in
    *  19-3, the indicator + follow-exit) so they stay consistent. */
@@ -296,7 +309,13 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
    * anchored releases the anchor to `idle`.
    */
   onScroll(): void {
-    if (this.isProgrammaticScroll) return; // programmatic write — not a user exit
+    if (this.isProgrammaticScroll) {
+      // Still settling a programmatic write: this `scroll` is one of the
+      // animation's own frames. Re-arm the trailing debounce and ignore it —
+      // do NOT classify it as a user exit (the anchor must not release itself).
+      this.armProgrammaticScrollSettle();
+      return;
+    }
     if (this.scrollMode !== 'anchored') return;
     if (!this.isNearBottom()) {
       this.releaseAnchor();
@@ -320,6 +339,10 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     }
     if (this.justSentSubscription) {
       this.justSentSubscription.unsubscribe();
+    }
+    if (this.programmaticScrollTimer !== null) {
+      clearTimeout(this.programmaticScrollTimer);
+      this.programmaticScrollTimer = null;
     }
   }
 
@@ -546,16 +569,30 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
 
   /**
    * AC #5 — open the programmatic-scroll guard window around a `scrollTop`/
-   * `scrollTo` write. The `scroll` event fires asynchronously, so the flag is
-   * cleared via `queueMicrotask` after the write (mirroring Story 4.4's
-   * discipline) — long enough to bracket the programmatic `scroll` event,
-   * short enough that a genuine user scroll in a later tick still releases.
+   * `scrollTo` write. A smooth `scrollTo` dispatches its `scroll` events across
+   * many later animation frames, so the flag is NOT cleared on a microtask
+   * (that window closes before the first async `scroll` fires, letting the
+   * anchor release itself — §Consequences top regression risk). Instead the
+   * flag is cleared on a TRAILING debounce: it is armed here and re-armed by
+   * every programmatic-origin `scroll` in `onScroll`, dropping only once the
+   * events stop (the animation has settled). A genuine user scroll arriving
+   * after settle is then classified normally.
    */
   private beginProgrammaticScroll(): void {
     this.isProgrammaticScroll = true;
-    queueMicrotask(() => {
+    this.armProgrammaticScrollSettle();
+  }
+
+  /** Re-arm the trailing debounce that clears the programmatic-scroll guard
+   *  once `scroll` events stop arriving (the programmatic animation settled). */
+  private armProgrammaticScrollSettle(): void {
+    if (this.programmaticScrollTimer !== null) {
+      clearTimeout(this.programmaticScrollTimer);
+    }
+    this.programmaticScrollTimer = setTimeout(() => {
       this.isProgrammaticScroll = false;
-    });
+      this.programmaticScrollTimer = null;
+    }, this.programmaticScrollSettleMs);
   }
 
   /**

--- a/src/app/components/process/components/user-input/user-input.component.spec.ts
+++ b/src/app/components/process/components/user-input/user-input.component.spec.ts
@@ -58,6 +58,8 @@ describe('ProcessUserInputComponent', () => {
     chatServiceMock = {
       messages$: new BehaviorSubject<any[]>([]),
       loadingProcess$: new BehaviorSubject<boolean>(false),
+      // Story 19-1 (ADR-016 §Decision 1): just-sent side channel.
+      emitJustSent: jasmine.createSpy('emitJustSent'),
     };
 
     // sendMessage() guards on currentTeamRunning$.value (Story 2-5). Default
@@ -925,6 +927,106 @@ describe('ProcessUserInputComponent', () => {
       );
       expect(slash).toBeTruthy();
       expect((slash as any).disableSort).toBeTrue();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Story 19-1 (ADR-016 §Decision 1) — just-sent signal emission
+  // -------------------------------------------------------------------------
+  describe('just-sent signal (Story 19-1)', () => {
+    beforeEach(() => {
+      // Pin the send-origin key so assertions are deterministic.
+      spyOn<any>(component, 'nextJustSentKey').and.returnValue('1700000000000');
+      nodesSubject.next([
+        makeNode({ name: 'sup-1', actorName: '@Support', role: 'Human' }),
+        makeNode({ name: 'ops-1', actorName: '@Operator', role: 'Human' }),
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
+      ]);
+    });
+
+    it('emits once on Priority 1 (sender + recipients) with the send-origin key', async () => {
+      component.selectedSender = '@Support';
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.userInput = 'hello';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).toHaveBeenCalledOnceWith('1700000000000');
+      // Routing is unchanged — one call per recipient.
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledTimes(2);
+    });
+
+    it('emits once on Priority 2 (sender, no recipient -> first dropdown agent)', async () => {
+      nodesSubject.next([
+        makeNode({ name: 'mgr-1', actorName: '@Manager', role: 'Worker' }),
+        makeNode({ name: 'dev-1', actorName: '@Developer', role: 'Worker' }),
+      ]);
+      component.selectedSender = '@Support';
+      component.selectedAgents = [];
+      component.userInput = 'auto-target';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).toHaveBeenCalledOnceWith('1700000000000');
+      expect(apiServiceSpy.sendMessageFromTo).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits once on Priority 3 (default sender + recipients)', async () => {
+      component.selectedSender = null;
+      component.selectedAgents = ['@Manager', '@Developer'];
+      component.userInput = 'hello team';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).toHaveBeenCalledOnceWith('1700000000000');
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('emits once on Priority 4 (broadcast)', async () => {
+      component.selectedSender = null;
+      component.selectedAgents = [];
+      component.userInput = 'broadcast';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).toHaveBeenCalledOnceWith('1700000000000');
+      expect(apiServiceSpy.sendMessage).toHaveBeenCalledOnceWith(
+        'test-team-id', 'broadcast',
+      );
+    });
+
+    it('does NOT emit on the team-stopped guard', async () => {
+      contextServiceStub.currentTeamRunning$.next(false);
+      component.selectedAgents = [];
+      component.userInput = 'blocked';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).not.toHaveBeenCalled();
+      expect(apiServiceSpy.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit on the empty/whitespace input guard', async () => {
+      component.selectedAgents = [];
+      component.userInput = '   ';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit on the no-candidate-recipient guard (Priority 2 edge)', async () => {
+      component.dropdownAgents = [];
+      component.selectedSender = '@Support';
+      component.selectedAgents = [];
+      component.userInput = 'orphan';
+
+      await component.sendMessage();
+
+      expect(chatServiceMock.emitJustSent).not.toHaveBeenCalled();
+      expect(apiServiceSpy.sendMessageFromTo).not.toHaveBeenCalled();
+      expect(component.userInput).toBe('orphan');
     });
   });
 });

--- a/src/app/components/process/components/user-input/user-input.component.ts
+++ b/src/app/components/process/components/user-input/user-input.component.ts
@@ -137,6 +137,17 @@ export class ProcessUserInputComponent implements OnInit {
     this.selectedAgents = [];
   }
 
+  /**
+   * Story 19-1 (ADR-016 §Decision 1) — send-origin key source for the just-sent
+   * signal. Wrapped as an overridable method so specs can pin a deterministic
+   * value. `apiService.sendMessage*` returns no message id synchronously
+   * (Open Question 1), so the panel keys the top-anchor by send time and matches
+   * the first user-originated (Rule 1) message at/after this timestamp.
+   */
+  protected nextJustSentKey(): string {
+    return String(Date.now());
+  }
+
   async sendMessage() {
     if (!this.contextService.currentTeamRunning$.value || !this.userInput || this.userInput.trim() === '') {
       return;
@@ -145,6 +156,11 @@ export class ProcessUserInputComponent implements OnInit {
     const hasSender = this.selectedSender !== null && this.selectedSender !== '';
     const hasRecipients = this.selectedAgents.length > 0;
 
+    // Capture the send-origin key BEFORE dispatch so it precedes the answer's
+    // arrival; emitted only after a dispatch actually happens (never on the
+    // early-return guards above or the no-candidate-recipient guard below).
+    const justSentKey = this.nextJustSentKey();
+
     if (hasSender && hasRecipients) {
       // Priority 1: explicit sender + explicit recipients
       for (const recipient of this.selectedAgents) {
@@ -152,6 +168,7 @@ export class ProcessUserInputComponent implements OnInit {
           this.processId, this.selectedSender!, recipient, this.userInput,
         );
       }
+      this.chatService.emitJustSent(justSentKey);
     } else if (hasSender && !hasRecipients) {
       // Priority 2: explicit sender, no recipient -> first dropdown agent
       const defaultRecipient = this.dropdownAgents[0]?.value;
@@ -162,14 +179,17 @@ export class ProcessUserInputComponent implements OnInit {
       await this.apiService.sendMessageFromTo(
         this.processId, this.selectedSender!, defaultRecipient, this.userInput,
       );
+      this.chatService.emitJustSent(justSentKey);
     } else if (hasRecipients) {
       // Priority 3: default sender + explicit recipients (Story 3-1 preserved)
       for (const agentName of this.selectedAgents) {
         await this.apiService.sendMessage(this.processId, this.userInput, agentName);
       }
+      this.chatService.emitJustSent(justSentKey);
     } else {
       // Priority 4: broadcast (Story 3-1 preserved)
       await this.apiService.sendMessage(this.processId, this.userInput);
+      this.chatService.emitJustSent(justSentKey);
     }
 
     this.userInput = '';

--- a/src/app/components/process/selectors/chat.selector.ts
+++ b/src/app/components/process/selectors/chat.selector.ts
@@ -4,6 +4,7 @@ import {
   map,
   Observable,
   shareReplay,
+  Subject,
 } from 'rxjs';
 
 import {
@@ -345,4 +346,23 @@ export class ChatService {
   readonly pendingNotifications$: Observable<Set<string>> = this.messages$.pipe(
     map(computePendingNotifications),
   );
+
+  /**
+   * Story 19-1 (ADR-016 §Decision 1) — imperative "just-sent" side channel.
+   *
+   * Emits a send-origin key (a send-time timestamp string) the moment the user
+   * dispatches a message from the main chat input. The chat panel subscribes to
+   * latch the top-anchor for the turn. This is the ONLY imperative member on the
+   * service; it deliberately bypasses the pure `chat$`/`chatFold` lifecycle so
+   * the top-anchor trigger is derived from the send ORIGIN, never inferred from
+   * message content (which would be brittle under ADR-005 frame-batching).
+   */
+  private readonly justSentSubject = new Subject<string>();
+  readonly justSent$: Observable<string> = this.justSentSubject.asObservable();
+
+  /** Surface a send as the "just-sent" signal, keyed by `key` (a send-time
+   *  timestamp string). Called once per dispatching `sendMessage()`. */
+  emitJustSent(key: string): void {
+    this.justSentSubject.next(key);
+  }
 }


### PR DESCRIPTION
## Epic 19 — Top-Anchored Chat Scroll (ADR-016)

Umbrella PR for Epic 19. Reworks the main chat scroll so the user's just-sent
message parks at the top of the viewport while the agent's answer streams into
the space below. Stories land sequentially on this shared branch.

### Stories

- [x] 19-1-anchor-primitive-just-sent-signal-spacer-scroll-to-top (Relates to #160)
- [x] 19-2-retire-default-autoscroll-state-machine-mount-scroll (Relates to #162)
- [x] 19-3-jump-to-latest-indicator-and-follow-mode (Relates to #163)

### What 19-1 delivers (the anchor primitive)

- `ChatService`: `justSent$` / `emitJustSent` send-origin side channel
  (Subject-backed); the pure `chat$` / `chatFold` lifecycle is untouched.
- `user-input`: emits a send-time key after each of the four dispatching
  branches (never on the early-return guards); overridable `nextJustSentKey()`
  for deterministic specs. Routing is unchanged.
- `chat-panel`: records `anchorMessageId` from the first user-originated
  (Rule 1) message at/after the send time, fires a single id-matched
  top-anchor (latched per turn), reserves room with a trailing spacer
  (`min-height = max(0, viewport − content)`, capped at viewport), re-pins only
  on the anchor element's own offset change, smooth-scrolls honouring
  `prefers-reduced-motion`, with a single post-layout read/write task.
- `data-message-id` on the `app-chat-message` host; inert `.message-spacer`
  appended after the `*ngFor` (excluded from `trackByDisplayItem`).

Legacy stick-to-bottom autoscroll is left in place this story and is retired in
19-2. No backend or event-protocol change.

### What 19-2 delivers (state machine + mount scroll)

- Retires the legacy per-emission stick-to-bottom (`shouldScrollToBottom` /
  `checkShouldAutoScroll` / the `ngAfterViewChecked` default re-pin); the 100px
  near-bottom threshold survives in `isNearBottom()` / `distanceFromBottom()`.
- Explicit `scrollMode` state machine (`idle | anchored | following`; `following`
  is a 19-3 placeholder, never entered) as the single source of viewport truth.
- One-shot instant scroll-to-bottom on mount, latched by `hasDoneInitialScroll`
  (skipped when a turn is already anchored; never re-fires).
- Anchor release to `idle` on a genuine user scroll past the threshold or on
  natural scroll-off, kept disjoint from the 19-1 own-height re-pin.
- Programmatic-vs-user scroll guard (`isProgrammaticScroll`) bracketing every
  programmatic write; typed `owedScroll` hover owed-action replaces the boolean.

### What 19-3 delivers (jump-to-latest indicator + opt-in follow mode)

- Enters `following` — previously a reachable-but-unentered placeholder. The
  ONLY entry is the jump-to-latest indicator click (`onJumpToLatest` →
  `enterFollowMode`); it clears anchor bookkeeping then tails the bottom on
  every `messages$` growth via `maybeFollowTail` (post-layout, programmatic).
- Smooth, reduced-motion-aware `followScrollToBottom` — a sibling to the instant
  mount `scrollToBottom` (kept byte-stable for FR8).
- Exit `following → idle` on a genuine upward scroll (indicator reappears);
  `following → anchored` on send via the existing `justSent$` re-anchor path.
- Derived `showJumpToLatest` getter + `unseenContent` flag (set on growth below
  the fold, cleared at the bottom / on follow-enter). The getter is a cheap,
  side-effect-free geometry read (CD-safe).
- Typed owed-action union extended with `follow-tail`; the hover lock defers the
  tail and `onMouseLeave` replays the smooth tail through the programmatic guard.
- Indicator `<button>` overlays the bottom edge of the message list, OUTSIDE the
  scroll container so it does not change `scrollHeight`; `*ngIf`-gated so it is
  absent from the DOM (captures no pointer events) when hidden.
- FR12: the trace divergence is documented in `chat-panel`; the per-agent
  `akgent-chat` trace keeps stick-to-bottom and is untouched (zero edits).

## Review status

- **19-1** — Reviewed by Rex. All seven ACs verified against the diff
  (`e796bea`). Type safety, null safety (all `scrollContainer` accesses
  guarded), and the single post-layout read/write discipline are sound. No
  HIGH/MEDIUM findings — no fixup commit required. Local quality gate green:
  ESLint clean, 861 Karma tests pass (Chrome Headless), production build
  succeeds. **Verdict: done.**
- **19-2** — Reviewed by Rex. All eight ACs verified against the diff
  (`3fc474e`); scope confined to 3 files in `packages/akgentic-frontend/`; no
  ADR-string test assertions (Golden Rule 8); no cross-submodule edits. One
  **HIGH** finding fixed (`c06c2fc`): the programmatic-scroll guard cleared on
  a `queueMicrotask`, but a smooth `scrollTo()` dispatches its `scroll` events
  across later animation frames — so the anchor's own write fired after the flag
  was cleared and the anchor released itself (the §Consequences top regression
  risk). Replaced the microtask clear with a trailing debounce (re-armed by each
  programmatic-origin `scroll`, dropped on settle; cleared in `ngOnDestroy`) and
  added a regression spec. Local quality gate green: ESLint clean, **875** Karma
  tests pass (Chrome Headless), production build succeeds. **Verdict: done.**
- **19-3** — Reviewed by Rex. PASS — no fix-worthy issues; no fixup commit. All
  seven ACs verified against the diff (`98e91b8`); scope confined to the 4
  `chat-panel.component.*` files in `packages/akgentic-frontend/`. `following`
  is entered only via the indicator click; the follow tail and `mouseleave`
  replay both route through the `beginProgrammaticScroll` trailing-debounce
  guard so they never self-cancel `following`; `following`/`anchored` are kept
  mutually exclusive (enter-follow clears anchor bookkeeping); the
  `showJumpToLatest` getter is side-effect-free; the `follow-tail` owed-action
  honours the hover lock. No ADR-string test assertions (Golden Rule 8); no
  cross-submodule edits; the per-agent `akgent-chat` trace is untouched (FR12
  no-edit guarantee). Local quality gate green: ESLint clean, **889** Karma
  tests pass (Chrome Headless), production build succeeds. **Verdict: done.**

## Epic 19 slice complete

All three stories have landed on this shared branch — the top-anchored chat
scroll model (ADR-016) is now fully implemented:

- **19-1** laid the anchor primitive: the `justSent$` send signal, the
  `data-message-id` anchor target, the trailing spacer, and the per-turn
  top-anchor scroll (`prefers-reduced-motion` aware).
- **19-2** retired the legacy default autoscroll, introduced the explicit
  `idle | anchored | following` state machine, the one-shot mount scroll, and
  the programmatic-vs-user trailing-debounce guard.
- **19-3** completed the state machine by entering `following` (opt-in tail via
  the jump-to-latest indicator), with the `unseenContent` flag, the smooth
  reduced-motion-aware follow scroll, the `follow-tail` hover owed-action, and
  the FR12 trace-divergence docstring.

Net behaviour: the user's just-sent message parks at the top while the answer
streams below; nothing auto-follows unless the user clicks "↓ New messages",
which tails until they scroll up (→ idle) or send again (→ anchored). The
per-agent `akgent-chat` trace deliberately keeps its own stick-to-bottom
(divergence documented per FR12). After merge, flip ADR-016 from `Proposed` to
`Accepted` (a planning-doc action).

## Scope guard

All changes stay inside `packages/akgentic-frontend/`. No edits to any other
submodule, to the backend, or to the event protocol (CLAUDE.md Golden Rule #4).

Relates to #160
