### PR TITLE
feat(akgentic-frontend): member-chat keyboard submit + main-chat send-icon parity

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -50,12 +50,12 @@
       class="extra-small-button"
     ></button>
     &nbsp;
-    <!-- Story 11.2 — Edit namespace YAML button; opens the Monaco panel in a dialog. -->
+    <!-- Story 11.2 — Edit Configuration button; opens the Monaco panel in a dialog. -->
     <button
       pButton
       size="small"
       type="button"
-      label="Edit namespace YAML"
+      label="Configuration"
       icon="pi pi-pencil"
       [disabled]="!(selectedNamespace$ | async)"
       (click)="namespacePanelVisible = true"

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -348,7 +348,7 @@ describe('HomeComponent', () => {
     return el as HTMLButtonElement | null;
   }
 
-  it('(AC14 11.2) "Edit namespace YAML" button is disabled when no namespace is selected', async () => {
+  it('(AC14 11.2) "Edit Configuration" button is disabled when no namespace is selected', async () => {
     component.selectedNamespace$.next(null);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -360,7 +360,7 @@ describe('HomeComponent', () => {
     expect(btn!.disabled).toBeTrue();
   });
 
-  it('(AC14 11.2) "Edit namespace YAML" button is enabled when a namespace is selected', async () => {
+  it('(AC14 11.2) "Edit Configuration" button is enabled when a namespace is selected', async () => {
     // The refreshed list (driven by ngOnInit's loadNamespaces) must contain
     // the seeded selection — otherwise the Story 14.2 reconciliation correctly
     // drops a selection absent from the fetched list, clearing it to null.

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.html
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.html
@@ -1,11 +1,11 @@
 <ng-container *ngIf="agentsByCategory; else noAgentsPlaceholder">
   <p-tabs value="0">
     <p-tablist>
-      <p-tab value="0" *ngIf="(context$ | async)?.length">
+      <p-tab value="0" *ngIf="chatTabVisible$ | async">
         Chat with "{{ selectedAgent?.label }}"
       </p-tab>
       <p-tab
-        [value]="(context$ | async)?.length ? '1' : '0'"
+        [value]="(chatTabVisible$ | async) ? '1' : '0'"
         *ngIf="state$ | async"
       >
         State of "{{ selectedAgent?.label }}"
@@ -35,15 +35,16 @@
       </div>
     </p-tablist>
     <p-tabpanels>
-      <p-tabpanel value="0" *ngIf="(context$ | async)?.length">
+      <p-tabpanel value="0" *ngIf="chatTabVisible$ | async">
         <app-akgent-chat
           [context$]="context$"
+          [backstory$]="backstory$"
           [agentId]="akgentId"
           [agentName]="akgentName"
         ></app-akgent-chat>
       </p-tabpanel>
       <p-tabpanel
-        [value]="(context$ | async)?.length ? '1' : '0'"
+        [value]="(chatTabVisible$ | async) ? '1' : '0'"
         *ngIf="state$ | async"
       >
         <app-akgent-state

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
@@ -203,7 +203,7 @@ describe('AgentTabsComponent — store-backed state/context wiring (Story 17-2)'
   }
 
   // ===========================================================================
-  // Story 20-1 (ADR-007 §4) — never-run backstory head block + chat-tab
+  // Story 20-1 (akgentic-agent ADR-007 §4) — never-run backstory head block + chat-tab
   // visibility from AgentState.backstory. Visibility gates on conversation
   // context OR a non-empty trimmed `state.backstory` (a running agent always has
   // context; a never-run agent shows its backstory). The head-block fallback

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
@@ -187,4 +187,83 @@ describe('AgentTabsComponent — store-backed state/context wiring (Story 17-2)'
     expect(component.state$.value).toBeNull();
     expect(component.context$.value).toEqual([]);
   });
+
+  /** Synchronously read the current value of `chatTabVisible$`. */
+  function tabVisible(): boolean {
+    let visible: boolean | undefined;
+    component.chatTabVisible$.subscribe((v) => (visible = v)).unsubscribe();
+    return visible as boolean;
+  }
+
+  /** Synchronously read the current value of `backstory$`. */
+  function backstory(): string {
+    let value = '';
+    component.backstory$.subscribe((v) => (value = v)).unsubscribe();
+    return value;
+  }
+
+  // ===========================================================================
+  // Story 20-1 (ADR-007 §4) — never-run backstory head block + chat-tab
+  // visibility from AgentState.backstory. Visibility gates on conversation
+  // context OR a non-empty trimmed `state.backstory` (a running agent always has
+  // context; a never-run agent shows its backstory). The head-block fallback
+  // itself is verified at the consumer in akgent-chat.component.spec.ts.
+  // ===========================================================================
+
+  it('AC1/AC3 never-run: no system-prompt event but a non-empty state.backstory → backstory$ projects it and the chat tab is visible', () => {
+    // A freshly created agent: only a StateChangedMessage carrying the backstory,
+    // NO LlmSystemPromptEvent and NO LlmMessageEvent (never run).
+    log.append(mkStateChanged('agent-A', { backstory: 'You are Bob.' }, 's1'));
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    // No context …
+    expect(component.context$.value).toEqual([]);
+    // … but the backstory is on the client via the `state` store.
+    expect(backstory()).toBe('You are Bob.');
+    // The chat tab is reachable from state.backstory alone (no white panel).
+    expect(tabVisible()).toBeTrue();
+  });
+
+  it('AC1 trims: backstory$ projects the TRIMMED state.backstory', () => {
+    log.append(
+      mkStateChanged('agent-A', { backstory: '  You are Bob.\n' }, 's1'),
+    );
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    expect(backstory()).toBe('You are Bob.');
+    expect(tabVisible()).toBeTrue();
+  });
+
+  it('AC4 no false-positive: empty/whitespace state.backstory, no context → chat tab hidden', () => {
+    log.append(mkStateChanged('agent-A', { backstory: '   \n\t ' }, 's1'));
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    expect(component.context$.value).toEqual([]);
+    // Whitespace-only backstory trims to '' — it must NOT force the tab open.
+    expect(backstory()).toBe('');
+    expect(tabVisible()).toBeFalse();
+  });
+
+  it('AC4 no false-positive: a state with no backstory field at all → backstory$ is "" and the tab is hidden', () => {
+    log.append(mkStateChanged('agent-A', { phase: 'busy' }, 's1'));
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    expect(backstory()).toBe('');
+    expect(tabVisible()).toBeFalse();
+  });
+
+  it('chatTabVisible$ is false for an agent with neither context nor backstory', () => {
+    selectedAkgent$.next({ name: '@unknown', agentId: 'unknown' });
+
+    expect(backstory()).toBe('');
+    expect(tabVisible()).toBeFalse();
+  });
+
+  it('AC3 context-only: an agent with conversation context (no backstory) is visible', () => {
+    log.append(mkLlmEvent('agent-A', { role: 'user', content: 'hi' }, 'e1'));
+    selectedAkgent$.next({ name: '@agent-A', agentId: 'agent-A' });
+
+    expect(component.context$.value).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(tabVisible()).toBeTrue();
+  });
 });

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
@@ -48,7 +48,7 @@ export class AgentTabsComponent implements OnInit {
   context$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
   state$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
 
-  // ADR-007 §4: a NEVER-RUN agent has NO `LlmSystemPromptEvent` (the backend
+  // akgentic-agent ADR-007 §4: a NEVER-RUN agent has NO `LlmSystemPromptEvent` (the backend
   // emits no creation event). Its backstory is already on the client as the
   // serialized `AgentState.backstory`, folded by the `state` PerAgentStore
   // (value shape `{ schema, state }`). Project the trimmed backstory string so
@@ -57,7 +57,7 @@ export class AgentTabsComponent implements OnInit {
   backstory$ = this.state$.pipe(map((state) => this.readBackstory(state)));
 
   // The chat tab is shown when the agent has conversation context OR a non-empty
-  // `state.backstory` to display (ADR-007 §4 never-run case — an empty/whitespace
+  // `state.backstory` to display (akgentic-agent ADR-007 §4 never-run case — an empty/whitespace
   // backstory must NOT force the tab open). A running agent always has context;
   // a never-run agent shows `state.backstory`. When visible it occupies slot "0"
   // and the State tab moves to "1".
@@ -69,7 +69,7 @@ export class AgentTabsComponent implements OnInit {
   );
 
   /**
-   * ADR-007 §4 — read the agent's backstory from the `state` PerAgentStore
+   * akgentic-agent ADR-007 §4 — read the agent's backstory from the `state` PerAgentStore
    * value (`{ schema, state }`, where `state` is the serialized `AgentState`
    * carrying `backstory: str`). Returns the TRIMMED backstory, or `''` when the
    * state, raw state, or backstory is absent/blank. Defensive: never throws on

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
@@ -48,6 +48,38 @@ export class AgentTabsComponent implements OnInit {
   context$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
   state$: BehaviorSubject<any> = new BehaviorSubject<any>(null);
 
+  // ADR-007 §4: a NEVER-RUN agent has NO `LlmSystemPromptEvent` (the backend
+  // emits no creation event). Its backstory is already on the client as the
+  // serialized `AgentState.backstory`, folded by the `state` PerAgentStore
+  // (value shape `{ schema, state }`). Project the trimmed backstory string so
+  // the chat component can render it as the head-block fallback and so chat-tab
+  // visibility can account for it. Emits `''` when there is no backstory.
+  backstory$ = this.state$.pipe(map((state) => this.readBackstory(state)));
+
+  // The chat tab is shown when the agent has conversation context OR a non-empty
+  // `state.backstory` to display (ADR-007 §4 never-run case — an empty/whitespace
+  // backstory must NOT force the tab open). A running agent always has context;
+  // a never-run agent shows `state.backstory`. When visible it occupies slot "0"
+  // and the State tab moves to "1".
+  chatTabVisible$ = combineLatest([this.context$, this.state$]).pipe(
+    map(
+      ([context, state]) =>
+        (context?.length ?? 0) > 0 || this.readBackstory(state).length > 0,
+    ),
+  );
+
+  /**
+   * ADR-007 §4 — read the agent's backstory from the `state` PerAgentStore
+   * value (`{ schema, state }`, where `state` is the serialized `AgentState`
+   * carrying `backstory: str`). Returns the TRIMMED backstory, or `''` when the
+   * state, raw state, or backstory is absent/blank. Defensive: never throws on
+   * `null`/`undefined`/non-string.
+   */
+  private readBackstory(stateValue: any): string {
+    const raw = stateValue?.state?.backstory;
+    return typeof raw === 'string' ? raw.trim() : '';
+  }
+
   // Subject to unsubscribe from agent-specific subscriptions when agent changes
   private agentSubscriptions$ = new Subject<void>();
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -11,7 +11,7 @@
     Head system block — sourced from `headRows$`: the event-sourced
     `systemPrompt$` rows (SystemPromptSelector, Story 16-1) when present
     (latest-wins), else the never-run backstory fallback synthesized from
-    `backstory$` (ADR-007 §4). Independent of `context.length`. `*ngIf ... as
+    `backstory$` (akgentic-agent ADR-007 §4). Independent of `context.length`. `*ngIf ... as
     rows` + `rows.length` guard renders nothing when there are no rows (AC8).
     `async` keeps it OnPush-safe and self-unsubscribing.
   -->

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -118,6 +118,9 @@
           rows="4"
           cols="50"
           [(ngModel)]="userInput"
+          (keydown.enter)="userInputEnterKeySubmit ? sendMessage() : null"
+          (keydown.meta.enter)="sendMessage()"
+          (keydown.control.enter)="sendMessage()"
           [mentionConfig]="mentionConfig"
           [mentionListTemplate]="mentionItemTemplate"
         ></textarea>

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -8,14 +8,16 @@
 -->
 <div class="trace-scroll" #traceScroll (scroll)="onScroll()">
   <!--
-    Head system block — sourced ONCE from `systemPrompt$` (SystemPromptSelector,
-    Story 16-1), independently of `context.length`. Latest-wins. `*ngIf ... as
-    rows` + `rows.length` guard renders nothing when there are no system rows
-    (AC8). `async` keeps it OnPush-safe and self-unsubscribing.
+    Head system block — sourced from `headRows$`: the event-sourced
+    `systemPrompt$` rows (SystemPromptSelector, Story 16-1) when present
+    (latest-wins), else the never-run backstory fallback synthesized from
+    `backstory$` (ADR-007 §4). Independent of `context.length`. `*ngIf ... as
+    rows` + `rows.length` guard renders nothing when there are no rows (AC8).
+    `async` keeps it OnPush-safe and self-unsubscribing.
   -->
   <div
     class="head-system-container"
-    *ngIf="systemPrompt$ | async as rows"
+    *ngIf="headRows$ | async as rows"
   >
     <ng-container *ngIf="rows.length">
       <div class="card-container" *ngFor="let row of rows">

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -557,7 +557,7 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Story 20-1 (ADR-007 §4) — never-run backstory head-block FALLBACK. A
+// Story 20-1 (akgentic-agent ADR-007 §4) — never-run backstory head-block FALLBACK. A
 // never-run agent has NO LlmSystemPromptEvent; its backstory comes from the
 // host via the `backstory$` input (projected from AgentState.backstory). The
 // head block renders the synthetic backstory row when no event rows exist, the

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -556,6 +556,203 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Story 20-1 (ADR-007 §4) — never-run backstory head-block FALLBACK. A
+// never-run agent has NO LlmSystemPromptEvent; its backstory comes from the
+// host via the `backstory$` input (projected from AgentState.backstory). The
+// head block renders the synthetic backstory row when no event rows exist, the
+// event rows when present (latest-wins), and nothing when both are empty.
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — never-run backstory head block (Story 20-1)', () => {
+  const AGENT = 'a-mgr';
+
+  function setup(backstory = ''): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    component: AkgentChatComponent;
+    log: MessageLogService;
+    backstory$: BehaviorSubject<string>;
+  } {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        provideNoopAnimations(),
+      ],
+    });
+
+    const log = TestBed.inject(MessageLogService);
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    const backstory$ = new BehaviorSubject<string>(backstory);
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.backstory$ = backstory$;
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, component, log, backstory$ };
+  }
+
+  function headHeaders(fixture: ComponentFixture<AkgentChatComponent>): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.head-system-container .card-header')
+    ).map((n) => (n.textContent ?? '').trim());
+  }
+
+  function headBodies(fixture: ComponentFixture<AkgentChatComponent>): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.head-system-container .text-container')
+    ).map((n) => (n.textContent ?? '').trim());
+  }
+
+  it('AC1 never-run fallback: no event → head block shows a single backstory row from backstory$ (agent_backstory label parity)', () => {
+    const { fixture } = setup('You are Bob.');
+    // No LlmSystemPromptEvent in the log — never-run agent.
+    fixture.detectChanges();
+
+    expect(headHeaders(fixture)).toEqual(['System : agent_backstory']);
+    expect(headBodies(fixture)).toEqual(['You are Bob.']);
+  });
+
+  it('AC4 empty backstory + no event → no head fieldset, no throw', () => {
+    const { fixture } = setup('');
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(headHeaders(fixture)).toEqual([]);
+    expect(headBodies(fixture)).toEqual([]);
+  });
+
+  it('AC2 event wins: a LlmSystemPromptEvent is present → head block renders the EVENT rows, not the backstory fallback', () => {
+    const { fixture, log } = setup('You are Bob.');
+    log.append(
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'team.roster', content: 'roster v1' },
+      ]),
+    );
+    fixture.detectChanges();
+
+    // Event rows win — the synthetic backstory row is NOT shown.
+    expect(headHeaders(fixture)).toEqual(['System : roster']);
+    expect(headBodies(fixture)).toEqual(['roster v1']);
+  });
+
+  it('AC2 latest-wins handoff: state-sourced backstory → first run event replaces it with NO duplicate and NO leftover backstory row', () => {
+    const { fixture, log } = setup('You are Bob.');
+    // Phase 1 — never-run: the state backstory row renders.
+    fixture.detectChanges();
+    expect(headBodies(fixture)).toEqual(['You are Bob.']);
+
+    // Phase 2 — first run emits its system-prompt event.
+    log.append(
+      systemPromptEnvelope(AGENT, [
+        { dynamic_ref: 'agent_backstory', content: 'You are Bob (run 1).' },
+        { dynamic_ref: 'current_date', content: 'day 1' },
+      ]),
+    );
+    fixture.detectChanges();
+
+    // The head block switches to the event rendering; exactly the event rows,
+    // no leftover/duplicate synthetic backstory row.
+    expect(headHeaders(fixture)).toEqual([
+      'System : agent_backstory',
+      'System : current_date',
+    ]);
+    expect(headBodies(fixture)).toEqual(['You are Bob (run 1).', 'day 1']);
+  });
+
+  it('backstory$ updates live: a later non-empty backstory renders the fallback row when no event exists', () => {
+    const { fixture, backstory$ } = setup('');
+    fixture.detectChanges();
+    expect(headHeaders(fixture)).toEqual([]);
+
+    backstory$.next('Backstory arrived.');
+    fixture.detectChanges();
+    expect(headBodies(fixture)).toEqual(['Backstory arrived.']);
+  });
+
+  it('omitted backstory$ input (legacy caller): no event, no backstory → empty head block, no throw', () => {
+    // A caller that does NOT bind backstory$ keeps the event-only head block.
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        provideNoopAnimations(),
+      ],
+    });
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    // backstory$ intentionally left undefined.
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(headHeaders(fixture)).toEqual([]);
+  });
+});
+
 describe('AkgentChatComponent — follow mode + status pill', () => {
   let running: BehaviorSubject<boolean>;
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
 
@@ -924,4 +925,91 @@ describe('AkgentChatComponent — follow mode + status pill', () => {
     tick(0);
     expect(el.scrollTop).toBe(0);
   }));
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard-submit parity with the main chat (user-input): Enter submits only
+// when the `userInputEnterKeySubmit` setting is on; Cmd/Ctrl+Enter always send.
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — keyboard submit parity', () => {
+  let component: AkgentChatComponent;
+  let fixture: ComponentFixture<AkgentChatComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        { provide: UtilService, useValue: {} },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        provideNoopAnimations(),
+      ],
+    });
+
+    fixture = TestBed.createComponent(AkgentChatComponent);
+    component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = 'a-mgr';
+    component.agentName = '@Manager';
+    component.userInput = 'hello';
+    fixture.detectChanges();
+  });
+
+  function textareaEl() {
+    return fixture.debugElement.query(By.css('textarea'));
+  }
+
+  it('Enter submits when userInputEnterKeySubmit is enabled', () => {
+    const spy = spyOn(component, 'sendMessage');
+    component.userInputEnterKeySubmit = true;
+    textareaEl().triggerEventHandler('keydown.enter', {});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter does NOT submit when userInputEnterKeySubmit is disabled', () => {
+    const spy = spyOn(component, 'sendMessage');
+    component.userInputEnterKeySubmit = false;
+    textareaEl().triggerEventHandler('keydown.enter', {});
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('Cmd+Enter always submits regardless of the toggle', () => {
+    const spy = spyOn(component, 'sendMessage');
+    component.userInputEnterKeySubmit = false;
+    textareaEl().triggerEventHandler('keydown.meta.enter', {});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+Enter always submits regardless of the toggle', () => {
+    const spy = spyOn(component, 'sendMessage');
+    component.userInputEnterKeySubmit = false;
+    textareaEl().triggerEventHandler('keydown.control.enter', {});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -67,7 +67,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   // scroll-to-bottom targets this element so new messages stay in view.
   @ViewChild('traceScroll') traceScroll?: ElementRef<HTMLElement>;
   @Input() context$!: BehaviorSubject<any[]>;
-  // ADR-007 §4 — the selected agent's trimmed `AgentState.backstory`, projected
+  // akgentic-agent ADR-007 §4 — the selected agent's trimmed `AgentState.backstory`, projected
   // by the host (`AgentTabsComponent`) from the `state` PerAgentStore. Drives the
   // never-run head-block FALLBACK (a synthetic backstory row) when no
   // `LlmSystemPromptEvent` row exists yet. Optional so existing callers/tests
@@ -101,7 +101,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   systemPrompt$!: Observable<SystemPromptRow[]>;
 
   /**
-   * ADR-007 §4 — the head block actually bound in the template. Latest-wins:
+   * akgentic-agent ADR-007 §4 — the head block actually bound in the template. Latest-wins:
    * the event-sourced `systemPrompt$` rows when present; otherwise, for a
    * never-run agent (no `LlmSystemPromptEvent` row), a single synthetic backstory
    * row built from `backstory$` (label parity with the `agent_backstory` dynamic
@@ -167,7 +167,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     this.systemPrompt$ = this.systemPromptSelector.latestSystemPrompt$(
       this.agentId
     );
-    // ADR-007 §4: latest-wins — event rows win; otherwise synthesize a single
+    // akgentic-agent ADR-007 §4: latest-wins — event rows win; otherwise synthesize a single
     // backstory row from `backstory$` (a trimmed string; `''` ⇒ no fallback).
     // `backstory$` may be absent (callers/tests that omit the input) → `of('')`.
     this.headRows$ = combineLatest([

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -29,6 +29,7 @@ import { CapitalizePipe } from '../../../../../shared/pipes/capitalise.pipe';
 import { ApiService } from '../../../../../core/http/api.service';
 import { UtilService } from '../../../../../core/ui/utils.service';
 import { ContextService } from '../../../../../core/context/context.service';
+import { ConfigService } from '../../../../../core/config/config.service';
 import { IngestionService } from '../../../event/ingestion.service';
 import {
   SystemPromptRow,
@@ -80,6 +81,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   utilService: UtilService = inject(UtilService);
   contextService: ContextService = inject(ContextService);
   messageService: IngestionService = inject(IngestionService);
+  private config = inject(ConfigService);
   // ADR-004 §5b: component-scoped selector provided on ProcessComponent.providers
   // (Story 16-1) — resolves the same MessageLogService instance as this subtree.
   private systemPromptSelector: SystemPromptSelector = inject(
@@ -88,6 +90,10 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   private destroyRef = inject(DestroyRef);
 
   context: any[] = [];
+
+  // Mirror the main chat (user-input): Enter submits only when the
+  // `userInputEnterKeySubmit` setting is enabled; Cmd/Ctrl+Enter always submit.
+  userInputEnterKeySubmit: boolean = this.config.userInputEnterKeySubmit;
 
   /**
    * ADR-004 §5b step 2 — the head system block, derived once from the unified

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -22,7 +22,8 @@ import { TableModule } from 'primeng/table';
 import { TextareaModule } from 'primeng/textarea';
 import { MentionModule } from 'angular-mentions';
 
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { CapitalizePipe } from '../../../../../shared/pipes/capitalise.pipe';
 import { ApiService } from '../../../../../core/http/api.service';
@@ -32,6 +33,7 @@ import { IngestionService } from '../../../event/ingestion.service';
 import {
   SystemPromptRow,
   SystemPromptSelector,
+  systemPromptLabel,
 } from '../../../selectors/system-prompt.selector';
 import { CommandDescriptor } from '../../../../../protocol/message.types';
 
@@ -65,6 +67,12 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   // scroll-to-bottom targets this element so new messages stay in view.
   @ViewChild('traceScroll') traceScroll?: ElementRef<HTMLElement>;
   @Input() context$!: BehaviorSubject<any[]>;
+  // ADR-007 §4 — the selected agent's trimmed `AgentState.backstory`, projected
+  // by the host (`AgentTabsComponent`) from the `state` PerAgentStore. Drives the
+  // never-run head-block FALLBACK (a synthetic backstory row) when no
+  // `LlmSystemPromptEvent` row exists yet. Optional so existing callers/tests
+  // that omit it keep the event-only head block.
+  @Input() backstory$?: Observable<string>;
   @Input() agentId!: string;
   @Input() agentName!: string;
 
@@ -91,6 +99,17 @@ export class AkgentChatComponent implements OnInit, OnChanges {
    * `row.content` directly and renders nothing for an empty array.
    */
   systemPrompt$!: Observable<SystemPromptRow[]>;
+
+  /**
+   * ADR-007 §4 — the head block actually bound in the template. Latest-wins:
+   * the event-sourced `systemPrompt$` rows when present; otherwise, for a
+   * never-run agent (no `LlmSystemPromptEvent` row), a single synthetic backstory
+   * row built from `backstory$` (label parity with the `agent_backstory` dynamic
+   * block via `systemPromptLabel`). When the first run emits its event the rows
+   * become non-empty and the synthetic row is dropped — no duplicate, no flicker.
+   * Rebound alongside `systemPrompt$` in `bindSystemPrompt()` on agent switch.
+   */
+  headRows$!: Observable<SystemPromptRow[]>;
 
   /**
    * The agent-tabs dropdown REUSES this component across member selections (it
@@ -140,11 +159,34 @@ export class AkgentChatComponent implements OnInit, OnChanges {
       });
   }
 
-  /** Point `systemPrompt$` at the current `agentId`'s head system block. The
-   *  async pipe in the template resubscribes to the new stream on reassignment. */
+  /** Point `systemPrompt$` at the current `agentId`'s head system block and
+   *  rebuild the rendered `headRows$` (event rows, else the never-run backstory
+   *  fallback). The async pipe in the template resubscribes to the new stream on
+   *  reassignment. */
   private bindSystemPrompt(): void {
     this.systemPrompt$ = this.systemPromptSelector.latestSystemPrompt$(
       this.agentId
+    );
+    // ADR-007 §4: latest-wins — event rows win; otherwise synthesize a single
+    // backstory row from `backstory$` (a trimmed string; `''` ⇒ no fallback).
+    // `backstory$` may be absent (callers/tests that omit the input) → `of('')`.
+    this.headRows$ = combineLatest([
+      this.systemPrompt$,
+      this.backstory$ ?? of(''),
+    ]).pipe(
+      map(([rows, backstory]) => {
+        if (rows.length > 0) return rows;
+        if (backstory.length > 0) {
+          return [
+            {
+              type: 'system' as const,
+              name: systemPromptLabel('agent_backstory'),
+              content: backstory,
+            },
+          ];
+        }
+        return [];
+      }),
     );
   }
 

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -991,6 +991,19 @@ describe('ChatPanelComponent', () => {
     // Most scroll tests assume a RUNNING process (so "Auto scrolling" can show).
     beforeEach(() => {
       TestBed.inject(ContextService).currentTeamRunning$.next(true);
+      // The clamp-aware containers below are plain mock objects, not real DOM
+      // Elements, so `reserveSpacer`'s `getComputedStyle(c)` (chat-panel.component.ts)
+      // throws "parameter 1 is not of type 'Element'" in headless Chrome. Pass real
+      // Elements through to the real implementation (Angular/PrimeNG rendering is
+      // unaffected) and return a zero-padding stub for the non-Element mocks — the
+      // mock spacer math already assumes paddingBottom = 0.
+      const realGetComputedStyle = window.getComputedStyle.bind(window);
+      spyOn(window, 'getComputedStyle').and.callFake(
+        (el: Element, pseudo?: string | null) =>
+          el instanceof Element
+            ? realGetComputedStyle(el, pseudo)
+            : ({ paddingBottom: '0px' } as CSSStyleDeclaration),
+      );
     });
 
     function humanTurn(id: string): SentMessage {
@@ -1089,8 +1102,9 @@ describe('ChatPanelComponent', () => {
 
       component.ngAfterViewChecked();
 
-      // realBelow = spacer.offsetTop(120) - anchor.offsetTop(84) = 36 → spacer 320.
-      expect(getSpacerMin()).toBe(320);
+      // realBelow = spacer.offsetTop(120) - anchor.offsetTop(84) = 36;
+      // reserve = clientHeight(356) - realBelow(36) - TOP_PAD(8) - padBottom(0) = 312.
+      expect(getSpacerMin()).toBe(312);
       // target = 84 - containerOffsetTop(0) - pad(8) = 76 → message at the top.
       expect(container.scrollTop).toBe(76);
       expect(84 - container.scrollTop).toBe(8);
@@ -1137,14 +1151,14 @@ describe('ChatPanelComponent', () => {
       messagesSubject.next([humanTurn('u1')]);
       const { container, spacerEl, getSpacerMin } = installClamping(84, 36, 356);
       component.ngAfterViewChecked();
-      expect(getSpacerMin()).toBe(320);
-      const scrollHeightAfterPin = container.scrollHeight; // 120 + 320 = 440
+      expect(getSpacerMin()).toBe(312); // 356 - realBelow(36) - TOP_PAD(8) - padBottom(0)
+      const scrollHeightAfterPin = container.scrollHeight; // 120 + 312 = 432
 
       // The reply adds 100px of content below the anchor.
       spacerEl.offsetTop += 100; // content end moves down
       component.ngAfterViewChecked();
 
-      expect(getSpacerMin()).toBe(220); // shrank by exactly 100
+      expect(getSpacerMin()).toBe(212); // shrank by exactly 100 (312 → 212)
       expect(container.scrollHeight).toBe(scrollHeightAfterPin); // constant → no shift
     });
 

--- a/src/app/components/process/components/user-input/user-input.component.html
+++ b/src/app/components/process/components/user-input/user-input.component.html
@@ -66,6 +66,7 @@
     ></p-multiSelect>
     <p-button
       size="small"
+      icon="pi pi-send"
       label="Submit"
       (click)="sendMessage()"
       [disabled]="!userInput || !(contextService.currentTeamRunning$ | async)"

--- a/src/app/components/process/components/user-input/user-input.component.spec.ts
+++ b/src/app/components/process/components/user-input/user-input.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 
@@ -101,6 +102,12 @@ describe('ProcessUserInputComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders the send icon on the Submit button (parity with member chat)', () => {
+    const submitBtn = fixture.debugElement.query(By.css('p-button'));
+    expect(submitBtn).toBeTruthy();
+    expect(submitBtn.componentInstance.icon).toBe('pi pi-send');
   });
 
   describe('dropdown population from nodes$', () => {


### PR DESCRIPTION
## Submit parity between the two chat inputs

The main chat and member chat each had half of the submit UX. This makes them consistent.

**Member chat (`akgent-chat`)** — the input textarea gained the main chat's keyboard-submit behavior:
- `Enter` submits only when the `userInputEnterKeySubmit` setting is enabled;
- `Cmd+Enter` / `Ctrl+Enter` always submit.

Injects `ConfigService` for the toggle (same source as the main chat).

**Main chat (`user-input`)** — the Submit button gained the `pi pi-send` icon the member-chat Submit button already shows, so both match.

### Tests / gates
- 5 new specs: member-chat Enter-with-toggle (on/off), Cmd+Enter, Ctrl+Enter; main-chat send-icon present.
- Karma **895/895**, lint clean, `npm run build` succeeds.

### Notes
- **Stacked on `feat/166`** (PR #167) — it carries the ChatPanel scroll-spec fix so the suite is green; GitHub will retarget this PR to `master` once #167 merges. Merge order: #167 → #168.
- Scope confined to `packages/akgentic-frontend/`; no backend/event-protocol change.

Relates to #168
