### PR TITLE
feat(akgentic-frontend): epic 22 — Always-editable namespace panel (22-1-always-editable-namespace-panel-dirty-driven-action-row → 22-2-action-row-keyboard-shortcuts)

### DIFF
--- a/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
@@ -242,7 +242,7 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
   });
 
   // ----- AC 10 parity smoke test ------------------------------------------------
-  it('(AC10) parity smoke test — load → edit → save → validate-persisted → clone → edit → cancel', async () => {
+  it('(AC10) parity smoke test — load → edit → save → validate → clone → edit → reset', async () => {
     const srcYaml = `namespace: foo
 user_id: null
 entries:
@@ -262,7 +262,7 @@ entries:
       Promise.resolve([summary('foo'), summary('bar')]),
     );
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-    apiSpy.validatePersistedNamespace.and.returnValue(
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(cleanReport('foo')),
     );
 
@@ -273,43 +273,39 @@ entries:
 
     const panel = component.panel!;
     expect(panel.serverYaml).toBe(srcYaml);
-    expect(panel.mode).toBe('view');
+    expect(panel.hasUnsavedChanges()).toBe(false);
 
-    // --- Edit → Save ---
-    await panel.onEditClick();
+    // --- Edit (direct) → Save. Save re-exports for the drift check (returns
+    // the same srcYaml ⇒ no prompt) then imports. ---
     panel.buffer = srcYaml + '# edited\n';
     await panel.onSaveClick();
-    expect(panel.mode).toBe('view');
+    expect(panel.hasUnsavedChanges()).toBe(false);
     expect(panel.serverYaml).toBe(srcYaml + '# edited\n');
 
-    // --- Validate persisted ---
-    // Clean reports now flash the view-mode Validate button instead of
-    // populating the "Validation passed" pane — lastValidation stays null.
-    await panel.onValidatePersistedClick();
+    // --- Validate (single buffer handler). Clean report flashes the button
+    // instead of populating the pane — lastValidation stays null. ---
+    await panel.onValidateBufferClick();
     expect(panel.lastValidation).toBeNull();
-    expect(panel.validationFlashPersisted).toBeTrue();
+    expect(panel.validationFlashBuffer).toBeTrue();
 
-    // --- Clone (valid bundle yaml in buffer) ---
-    // Set buffer to a clean bundle root mapping so rewriteNamespaceInYaml
-    // succeeds, then invoke the Clone confirm path.
+    // --- Clone (from the clean panel — gated on clean) ---
     panel.onCloneClick();
     panel.cloneDestNs = 'new-ns';
     await panel.onCloneConfirmClick();
     await fixture.whenStable();
     await fixture.whenStable();
     expect(panel.namespace).toBe('new-ns');
-    expect(panel.mode).toBe('view');
+    expect(panel.hasUnsavedChanges()).toBe(false);
 
-    // --- Edit → Cancel (dirty) with ConfirmationService.accept ---
+    // --- Edit (direct) → Reset (dirty) with ConfirmationService.accept ---
     confirmationSpy.confirm.and.callFake((cfg) => {
       cfg.accept!();
       return confirmationSpy;
     });
-    await panel.onEditClick();
     panel.buffer = panel.serverYaml + '# dirty again\n';
-    panel.onCancelClick();
+    panel.onResetClick();
     expect(panel.buffer).toBe(panel.serverYaml);
-    expect(panel.mode).toBe('view');
+    expect(panel.hasUnsavedChanges()).toBe(false);
 
     // Verify the parity bundle of YAML round-trips the rewritten namespace
     // field (belts-and-braces — ensures Clone really rewrote the bundle).
@@ -321,7 +317,7 @@ entries:
   });
 
   // ----- AC 11 NFR7 REST call budget --------------------------------------------
-  it('(AC11) NFR7 REST budget — mount=2, +validate=+1, +save=+1, +clone=+3 (total 7)', async () => {
+  it('(AC11) NFR7 REST budget — mount=2, +validate=+1, +save=+2 (drift+import), +clone=+3 (total 9)', async () => {
     const srcYaml = `namespace: foo
 user_id: null
 entries: {}
@@ -351,13 +347,17 @@ entries: {}
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
 
     const panel = component.panel!;
+    apiSpy.validateNamespaceBuffer.and.returnValue(
+      Promise.resolve(cleanReport('foo')),
+    );
 
-    // +Validate persisted (+1).
-    await panel.onValidatePersistedClick();
-    expect(apiSpy.validatePersistedNamespace).toHaveBeenCalledTimes(1);
+    // +Validate buffer (+1) — the single Validate handler (ADR-017 §4).
+    await panel.onValidateBufferClick();
+    expect(apiSpy.validateNamespaceBuffer).toHaveBeenCalledTimes(1);
 
-    // +Save (+1 import).
-    await panel.onEditClick();
+    // +Save: the editor is always writable — dirty the buffer directly.
+    // onSaveClick re-exports for the drift check (+1 export; returns the same
+    // YAML ⇒ no prompt) then imports (+1 import).
     panel.buffer = srcYaml + '# edit\n';
     await panel.onSaveClick();
     await fixture.whenStable();
@@ -365,8 +365,8 @@ entries: {}
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(2);
 
-    // +Clone (+1 import + 1 export on the destNs re-load + 1 getNamespaces
-    // re-fetch from the shell's (saved) handler).
+    // +Clone from the now-clean panel (+1 import + 1 export on the destNs
+    // re-load + 1 getNamespaces re-fetch from the shell's (saved) handler).
     panel.onCloneClick();
     panel.cloneDestNs = 'dst';
     await panel.onCloneConfirmClick();
@@ -374,17 +374,14 @@ entries: {}
     await fixture.whenStable();
 
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(2);
-    // foo-mount + foo-drift-check-on-edit + dst-clone-reload = 3.
-    // Post-review UX refinement added the drift-check export on Edit.
+    // foo-mount + foo-save-drift-check + dst-clone-reload = 3.
+    // ADR-017 §6 relocated the drift-check export from Edit-entry into Save.
     expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(3);
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(3); // mount + (saved)×2
 
-    // Tally — 2 (mount) + 1 (validate) + 1 (edit-drift-check) + 1 (save-import)
+    // Tally — 2 (mount) + 1 (validate) + 1 (save-drift-check) + 1 (save-import)
     //         + 1 (save-refresh-ns) + 1 (clone-import) + 1 (clone-reload-export)
-    //         + 1 (clone-refresh-ns) = 9 total calls across all four spies.
-    // AC 11's original milestone-grouped total was 7 (save refresh counted as
-    // part of save, clone refresh counted as part of clone). The drift-check
-    // on Edit adds +1 → 10 by that accounting, 9 at the spy level.
+    //         + 1 (clone-refresh-ns) = 9 total calls across all spies.
     const totalCalls =
       apiSpy.exportNamespace.calls.count() +
       apiSpy.getNamespaces.calls.count() +
@@ -392,8 +389,8 @@ entries: {}
       apiSpy.validatePersistedNamespace.calls.count() +
       apiSpy.validateNamespaceBuffer.calls.count();
     expect(totalCalls).toBe(9);
-    // No polling / heartbeat / background fetches.
-    expect(apiSpy.validateNamespaceBuffer).not.toHaveBeenCalled();
+    // The retired persisted-validate endpoint is no longer called.
+    expect(apiSpy.validatePersistedNamespace).not.toHaveBeenCalled();
   });
 
   // ----- AC 8 clean buffer → no prompt on programmatic navigation ---------------
@@ -423,7 +420,7 @@ entries: {}
     fixture.detectChanges();
 
     const panel = component.panel!;
-    await panel.onEditClick();
+    // The editor is always writable — dirty the buffer directly.
     panel.buffer = 'key: modified\n';
     expect(panel.hasUnsavedChanges()).toBeTrue();
   });
@@ -441,7 +438,7 @@ entries: {}
     fixture.detectChanges();
 
     const panel = component.panel!;
-    await panel.onEditClick();
+    // The editor is always writable — dirty the buffer directly.
     panel.buffer = 'key: modified\n';
     fixture.detectChanges();
 
@@ -470,7 +467,9 @@ entries: {}
     expect(indicator).toBeNull();
   });
 
-  it('(11.7 AC10) route shell dirty indicator removed after Save 2xx (panel flips back to view)', async () => {
+  it('(11.7 AC10) route shell dirty indicator removed after Save 2xx (panel becomes clean)', async () => {
+    // The drift re-export returns the same server YAML ⇒ no prompt; import
+    // proceeds and snapshots serverYaml so the panel becomes clean.
     apiSpy.exportNamespace.and.returnValue(Promise.resolve('key: value\n'));
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
@@ -480,7 +479,7 @@ entries: {}
     fixture.detectChanges();
 
     const panel = component.panel!;
-    await panel.onEditClick();
+    // The editor is always writable — dirty the buffer directly.
     panel.buffer = 'key: modified\n';
     fixture.detectChanges();
     expect(
@@ -494,7 +493,6 @@ entries: {}
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(panel.mode).toBe('view');
     expect(panel.hasUnsavedChanges()).toBeFalse();
     expect(
       fixture.nativeElement.querySelector(

--- a/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
@@ -12,9 +12,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import yaml from 'js-yaml';
 import { BehaviorSubject } from 'rxjs';
 
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -87,7 +86,6 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
   let component: NamespacePanelRouteComponent;
   let apiSpy: jasmine.SpyObj<ApiService>;
   let messageSpy: jasmine.SpyObj<MessageService>;
-  let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
   let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
 
   async function buildFixture(namespace: string): Promise<void> {
@@ -109,10 +107,6 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
     apiSpy.getNamespaces.and.returnValue(Promise.resolve([summary('foo')]));
     messageSpy = jasmine.createSpyObj('MessageService', ['add']);
 
-    confirmationSpy =
-      new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
-    spyOn(confirmationSpy, 'confirm').and.callThrough();
-
     paramMap$ = new BehaviorSubject(convertToParamMap({ namespace: 'foo' }));
 
     await TestBed.configureTestingModule({
@@ -131,22 +125,21 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
       ],
     })
       // Swap real Monaco for the stub — the panel is nested inside the shell.
+      // Story 22.3 — the panel no longer uses ConfirmationService /
+      // <p-confirmDialog>; its confirm flows run through the panel-owned custom
+      // modal, so the old service override is gone.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
             CommonModule,
             FormsModule,
             ButtonModule,
-            ConfirmDialogModule,
             DialogModule,
             InputTextModule,
             ToggleSwitchModule,
             TooltipModule,
             StubMonacoEditorComponent,
             ValidationReportComponent,
-          ],
-          providers: [
-            { provide: ConfirmationService, useValue: confirmationSpy },
           ],
         },
       })
@@ -297,13 +290,12 @@ entries:
     expect(panel.namespace).toBe('new-ns');
     expect(panel.hasUnsavedChanges()).toBe(false);
 
-    // --- Edit (direct) → Reset (dirty) with ConfirmationService.accept ---
-    confirmationSpy.confirm.and.callFake((cfg) => {
-      cfg.accept!();
-      return confirmationSpy;
-    });
+    // --- Edit (direct) → Reset (dirty) via the custom confirm modal Proceed ---
     panel.buffer = panel.serverYaml + '# dirty again\n';
     panel.onResetClick();
+    expect(panel.confirmDialogVisible).toBeTrue();
+    expect(panel.confirmRequest!.variant).toBe('reset');
+    panel.onConfirmProceedClick();
     expect(panel.buffer).toBe(panel.serverYaml);
     expect(panel.hasUnsavedChanges()).toBe(false);
 
@@ -404,10 +396,10 @@ entries: {}
 
     const panel = component.panel!;
     expect(panel.hasUnsavedChanges()).toBeFalse();
-    // The functional guard short-circuits on this path before any
-    // ConfirmationService interaction — covered exhaustively in
-    // namespace-panel.guard.spec.ts.
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    // The functional guard short-circuits on this path before any confirm
+    // interaction — covered exhaustively in namespace-panel.guard.spec.ts. The
+    // panel's own custom confirm modal stays closed on a clean panel.
+    expect(panel.confirmDialogVisible).toBeFalse();
   });
 
   // ----- AC 7 dirty buffer → guard would prompt (component-level check) ---------

--- a/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel-route.component.spec.ts
@@ -30,13 +30,13 @@ import { NamespacePanelRouteComponent } from './namespace-panel-route.component'
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 /**
- * Story 11.6 — route-shell component tests.
+ * Route-shell component tests.
  *
  * Uses `RouterTestingModule` + a stubbed `ActivatedRoute.paramMap` (not
  * `RouterTestingHarness`) because every test mounts the shell directly
  * via `TestBed.createComponent` — we do not need the router to actually
  * navigate for these assertions. The separate `app.routes.spec.ts` covers
- * the route-registration / URL-parsing contract (AC 1, AC 15).
+ * the route-registration / URL-parsing contract.
  *
  * The inner `<nu-monaco-editor>` is swapped with `StubMonacoEditorComponent`
  * via `TestBed.overrideComponent(NamespacePanelComponent, ...)` so the real
@@ -125,9 +125,6 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
       ],
     })
       // Swap real Monaco for the stub — the panel is nested inside the shell.
-      // Story 22.3 — the panel no longer uses ConfirmationService /
-      // <p-confirmDialog>; its confirm flows run through the panel-owned custom
-      // modal, so the old service override is gone.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
@@ -147,7 +144,7 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
   });
 
   // ---------------------------------------------------------------------
-  // AC 19 route-shell spec — six required tests
+  // Route-shell spec
   // ---------------------------------------------------------------------
 
   it('(AC2) route activation with :namespace="foo" binds currentNamespace and mounts panel', async () => {
@@ -234,7 +231,7 @@ describe('NamespacePanelRouteComponent (Story 11.6)', () => {
     expect(backLink!.getAttribute('href')).toBe('/');
   });
 
-  // ----- AC 10 parity smoke test ------------------------------------------------
+  // ----- Parity smoke test ------------------------------------------------------
   it('(AC10) parity smoke test — load → edit → save → validate → clone → edit → reset', async () => {
     const srcYaml = `namespace: foo
 user_id: null
@@ -308,7 +305,7 @@ entries:
     expect(parsed['namespace']).toBe('new-ns');
   });
 
-  // ----- AC 11 NFR7 REST call budget --------------------------------------------
+  // ----- REST call budget -------------------------------------------------------
   it('(AC11) NFR7 REST budget — mount=2, +validate=+1, +save=+2 (drift+import), +clone=+3 (total 9)', async () => {
     const srcYaml = `namespace: foo
 user_id: null
@@ -343,7 +340,7 @@ entries: {}
       Promise.resolve(cleanReport('foo')),
     );
 
-    // +Validate buffer (+1) — the single Validate handler (ADR-017 §4).
+    // +Validate buffer (+1) — the single Validate handler.
     await panel.onValidateBufferClick();
     expect(apiSpy.validateNamespaceBuffer).toHaveBeenCalledTimes(1);
 
@@ -367,7 +364,7 @@ entries: {}
 
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(2);
     // foo-mount + foo-save-drift-check + dst-clone-reload = 3.
-    // ADR-017 §6 relocated the drift-check export from Edit-entry into Save.
+    // Save runs the drift-check export (see ADR-017).
     expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(3);
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(3); // mount + (saved)×2
 
@@ -418,7 +415,7 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.7 AC 8, 9, 10 — route-shell dirty indicator (FR15)
+  // Route-shell dirty indicator
   // ---------------------------------------------------------------------
 
   it('(11.7 AC8, AC9) route shell renders dirty indicator with aria-label when panel is dirty', async () => {

--- a/src/app/components/catalog/namespace-panel/namespace-panel-route.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel-route.component.ts
@@ -35,9 +35,12 @@ import { NamespacePanelComponent } from './namespace-panel.component';
  * What the shell does NOT do:
  * - Does NOT wire the panel's `(closed)` output — there is no dialog to
  *   dismiss in the route presentation.
- * - Does NOT embed its own `<p-confirmDialog>` — the panel already renders
- *   one via its scoped `providers: [ConfirmationService]`, and the guard
- *   reuses that scoped service.
+ * - Does NOT embed any `<p-confirmDialog>` / `ConfirmationService` — the
+ *   `CanDeactivate` guard's dirty-navigation prompt is rendered by the panel's
+ *   own custom confirmation modal via `panel.confirmDiscard()` (ADR-018
+ *   Amendment §c), so the shell needs no confirmation surface of its own. The
+ *   panel's secondary modals own their own Esc-close, so the bare route shell
+ *   (no host dialog, no `closeOnEscape`) needs no Escape gating either.
  * - Does NOT read panel internals (`loading`, `serverYaml`) — the
  *   back-to-home link is always-present in the header, so the shell never
  *   needs conditional logic based on panel state.

--- a/src/app/components/catalog/namespace-panel/namespace-panel-route.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel-route.component.ts
@@ -15,11 +15,11 @@ import { NamespacePanelComponent } from './namespace-panel.component';
 /**
  * Route-shell host for `NamespacePanelComponent` on the deep-link route.
  *
- * Story 11.6 — mounts the panel inside a full-page admin layout (header +
- * back-to-home link) for the route `/admin/catalog/namespace/:namespace`.
- * The shell exists to keep `NamespacePanelComponent` host-agnostic (NFR6):
- * the panel itself MUST NOT import `Router`, `ActivatedRoute`, `RouterLink`,
- * etc. — all route-level concerns live here.
+ * Mounts the panel inside a full-page admin layout (header + back-to-home
+ * link) for the route `/admin/catalog/namespace/:namespace`. The shell exists
+ * to keep `NamespacePanelComponent` host-agnostic: the panel itself MUST NOT
+ * import `Router`, `ActivatedRoute`, `RouterLink`, etc. — all route-level
+ * concerns live here.
  *
  * Responsibilities:
  * - Read the `:namespace` URL param and pass it to the panel's
@@ -35,12 +35,12 @@ import { NamespacePanelComponent } from './namespace-panel.component';
  * What the shell does NOT do:
  * - Does NOT wire the panel's `(closed)` output — there is no dialog to
  *   dismiss in the route presentation.
- * - Does NOT embed any `<p-confirmDialog>` / `ConfirmationService` — the
- *   `CanDeactivate` guard's dirty-navigation prompt is rendered by the panel's
- *   own custom confirmation modal via `panel.confirmDiscard()` (ADR-018
- *   Amendment §c), so the shell needs no confirmation surface of its own. The
- *   panel's secondary modals own their own Esc-close, so the bare route shell
- *   (no host dialog, no `closeOnEscape`) needs no Escape gating either.
+ * - Does NOT embed any confirmation surface — the `CanDeactivate` guard's
+ *   dirty-navigation prompt is rendered by the panel's own custom confirmation
+ *   modal via `panel.confirmDiscard()` (ADR-018), so the shell needs no
+ *   confirmation surface of its own. The panel's secondary modals own their
+ *   own Esc-close, so the bare route shell (no host dialog, no `closeOnEscape`)
+ *   needs no Escape gating either.
  * - Does NOT read panel internals (`loading`, `serverYaml`) — the
  *   back-to-home link is always-present in the header, so the shell never
  *   needs conditional logic based on panel state.
@@ -68,8 +68,8 @@ export class NamespacePanelRouteComponent implements OnInit {
 
   /**
    * Bound to the panel's `@Input() existingNamespaces` (Clone pre-flight
-   * collision check — Story 11.5). Populated by a fire-and-forget fetch in
-   * `ngOnInit` and refreshed on the panel's `(saved)` emission.
+   * collision check). Populated by a fire-and-forget fetch in `ngOnInit` and
+   * refreshed on the panel's `(saved)` emission.
    */
   existingNamespaces: string[] = [];
 
@@ -97,8 +97,8 @@ export class NamespacePanelRouteComponent implements OnInit {
     // Fire-and-forget. Mirrors HomeComponent's `loadNamespaces()` pattern:
     // the panel's own `exportNamespace` runs in parallel, and a rejection
     // here just leaves `existingNamespaces` empty (the Clone pre-flight
-    // collision check degrades to "empty-or-source" which is acceptable
-    // per ADR-011 D5 — last-writer-wins collision-on-race).
+    // collision check degrades to "empty-or-source", which is acceptable —
+    // last-writer-wins collision-on-race).
     this.apiService
       .getNamespaces()
       .then((list) => {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -27,6 +27,7 @@
       [options]="editorOptions"
       [ngModel]="buffer"
       (ngModelChange)="onBufferChange($event)"
+      (event)="onEditorEvent($event)"
       [height]="'calc(90vh - 240px)'"
     ></nu-monaco-editor>
 
@@ -51,7 +52,7 @@
         [class.p-button-success]="validationFlashBuffer"
         label="Validate"
         [icon]="validationFlashBuffer ? 'pi pi-check' : 'pi pi-check-circle'"
-        [disabled]="saving || validating"
+        [disabled]="!canValidate"
         (click)="onValidateBufferClick()"
         data-test="validate-btn"
       ></button>
@@ -63,7 +64,7 @@
         size="small"
         label="Save"
         [icon]="saving ? 'pi pi-spinner pi-spin' : 'pi pi-save'"
-        [disabled]="buffer === serverYaml || saving || isSaveGated"
+        [disabled]="!canSave"
         [pTooltip]="saveTooltip"
         (click)="onSaveClick()"
         data-test="save-btn"
@@ -79,7 +80,7 @@
         severity="secondary"
         label="Reset"
         icon="pi pi-undo"
-        [disabled]="buffer === serverYaml || saving"
+        [disabled]="!canReset"
         (click)="onResetClick()"
         data-test="reset-btn"
       ></button>
@@ -96,7 +97,7 @@
         severity="secondary"
         label="Clone"
         icon="pi pi-copy"
-        [disabled]="buffer !== serverYaml || cloning || isCloneGated"
+        [disabled]="!canClone"
         [pTooltip]="cloneTooltip"
         (click)="onCloneClick()"
         data-test="clone-btn"
@@ -112,7 +113,7 @@
         severity="danger"
         label="Delete"
         icon="pi pi-trash"
-        [disabled]="deleting"
+        [disabled]="!canDelete"
         (click)="onDeleteClick()"
         data-test="delete-ns-btn"
       ></button>

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -150,7 +150,7 @@
     (onShow)="onCloneDialogShow()"
     (onHide)="onCloneDialogHide()"
     [modal]="true"
-    [draggable]="true"
+    [draggable]="false"
     [closeOnEscape]="false"
     styleClass="np-secondary-modal"
     maskStyleClass="np-secondary-modal-mask"
@@ -159,12 +159,13 @@
     data-test="clone-dialog"
   >
     <!-- ADR-018 Amendment §a/§b — the secondary modal is properly modal
-         (draggable, pointer-contained) but paints NO dimming backdrop: the
+         (pointer-contained) but paints NO dimming backdrop: the
          `np-secondary-modal` styleClass makes `.p-dialog-mask` transparent (see
-         the component SCSS). `[closeOnEscape]="false"` disables PrimeNG's
-         document-level Esc listener for THIS modal; the single coordinated
-         Escape handler (the host's capture-phase keydown → `handleSecondaryEscape`)
-         closes only the topmost secondary panel. -->
+         the component SCSS). `[draggable]="false"` — fixed-position, dragging is
+         disabled (operator preference; it was glitchy). `[closeOnEscape]="false"`
+         disables PrimeNG's document-level Esc listener for THIS modal; the single
+         coordinated Escape handler (the host's capture-phase keydown →
+         `handleSecondaryEscape`) closes only the topmost secondary panel. -->
     <div class="namespace-panel__clone-body">
       <label for="clone-dest-name-input">Destination name</label>
       <input
@@ -294,9 +295,10 @@
     (`confirmDialogVisible` + the typed `confirmRequest`), not an imperative
     service call.
 
-    - `[modal]="true"` + `[draggable]="true"` + `styleClass="np-secondary-modal"`
-      (transparent `.p-dialog-mask` in the SCSS) → properly modal and draggable
-      with NO dimming backdrop (ADR-018 Amendment §a / FIX 4).
+    - `[modal]="true"` + `[draggable]="false"` + `styleClass="np-secondary-modal"`
+      (transparent `.p-dialog-mask` in the SCSS) → properly modal, fixed-position
+      (dragging disabled — operator preference; it was glitchy), NO dimming
+      backdrop (ADR-018 Amendment §a / FIX 4).
     - `[closeOnEscape]="false"` (Amendment §b / FIX 2): the host's single
       coordinated Escape handler closes only the topmost secondary modal via
       `handleSecondaryEscape`.
@@ -310,7 +312,7 @@
     (onShow)="onConfirmDialogShow()"
     (onHide)="onConfirmDialogHide()"
     [modal]="true"
-    [draggable]="true"
+    [draggable]="false"
     [closeOnEscape]="false"
     styleClass="np-secondary-modal"
     maskStyleClass="np-secondary-modal-mask"

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -149,20 +149,23 @@
     (visibleChange)="onCloneDialogVisibleChange($event)"
     (onShow)="onCloneDialogShow()"
     (onHide)="onCloneDialogHide()"
-    [modal]="false"
+    [modal]="true"
+    [draggable]="true"
+    [closeOnEscape]="false"
+    styleClass="np-secondary-modal"
+    maskStyleClass="np-secondary-modal-mask"
     [style]="{ width: '30rem' }"
     header="Clone namespace"
     data-test="clone-dialog"
   >
-    <!-- ADR-018 §3 — the secondary panel owns its Esc→cancel: stop the
-         keystroke from bubbling so it cannot reach the host config dialog. The
-         dialog's own [closeOnEscape] (default true) closes THIS modal; the host
-         dialog's [closeOnEscape] is separately gated off via
-         `hasSecondaryPanelOpen` while any secondary panel is open. -->
-    <div
-      class="namespace-panel__clone-body"
-      (keydown.escape)="$event.stopPropagation()"
-    >
+    <!-- ADR-018 Amendment §a/§b — the secondary modal is properly modal
+         (draggable, pointer-contained) but paints NO dimming backdrop: the
+         `np-secondary-modal` styleClass makes `.p-dialog-mask` transparent (see
+         the component SCSS). `[closeOnEscape]="false"` disables PrimeNG's
+         document-level Esc listener for THIS modal; the single coordinated
+         Escape handler (the host's capture-phase keydown → `handleSecondaryEscape`)
+         closes only the topmost secondary panel. -->
+    <div class="namespace-panel__clone-body">
       <label for="clone-dest-name-input">Destination name</label>
       <input
         #cloneDestInput
@@ -283,24 +286,34 @@
   >{{ a11yAnnouncement }}</div>
 
   <!--
-    Story 22.3 (ADR-018 §1–§4) — panel-owned custom confirmation modal. Same
-    `<p-dialog>` shell + `namespace-panel__clone-body` / `__clone-actions`
-    styling as the Clone modal above; reused for Reset-discard, Save-drift, and
-    Delete. Driven from component state (`confirmDialogVisible` + the typed
-    `confirmRequest`), not an imperative service call.
+    Story 22.3 (ADR-018 §1–§4 + Amendment) — panel-owned custom confirmation
+    modal. Same `<p-dialog>` shell + `namespace-panel__clone-body` /
+    `__clone-actions` styling as the Clone modal above; reused for Reset-discard,
+    Save-drift, Delete, AND the dirty-CLOSE / dirty-NAV discard confirm
+    (`confirmDiscard()` — Amendment §c). Driven from component state
+    (`confirmDialogVisible` + the typed `confirmRequest`), not an imperative
+    service call.
 
-    - No `[modal]` → no backdrop under the secondary panel (ADR-018 §3 / AC 14).
-    - `(onShow)` autofocuses the safe button so Enter/Esc cancel (ADR-018 §2);
-      `(onHide)` resets state + settles a pending drift dismissal to the safe
-      branch (AC 8, 19).
-    - Esc on the body stops propagation so it cannot reach the host config
-      dialog (ADR-018 §3); the dialog's own [closeOnEscape] closes THIS modal.
+    - `[modal]="true"` + `[draggable]="true"` + `styleClass="np-secondary-modal"`
+      (transparent `.p-dialog-mask` in the SCSS) → properly modal and draggable
+      with NO dimming backdrop (ADR-018 Amendment §a / FIX 4).
+    - `[closeOnEscape]="false"` (Amendment §b / FIX 2): the host's single
+      coordinated Escape handler closes only the topmost secondary modal via
+      `handleSecondaryEscape`.
+    - `(onShow)` autofocuses the PRIMARY/proceed button so Enter activates the
+      main action (Amendment §e / FIX 5); `(onHide)` resets state + settles a
+      pending drift/discard dismissal to the safe branch (AC 8, 19, Amendment §c).
   -->
   <p-dialog
     [visible]="confirmDialogVisible"
     (visibleChange)="confirmDialogVisible = $event"
     (onShow)="onConfirmDialogShow()"
     (onHide)="onConfirmDialogHide()"
+    [modal]="true"
+    [draggable]="true"
+    [closeOnEscape]="false"
+    styleClass="np-secondary-modal"
+    maskStyleClass="np-secondary-modal-mask"
     [style]="{ width: '30rem' }"
     [header]="confirmRequest?.header ?? ''"
     data-test="confirm-dialog"
@@ -308,26 +321,16 @@
     <div
       *ngIf="confirmRequest as req"
       class="namespace-panel__clone-body"
-      (keydown.escape)="$event.stopPropagation()"
     >
       <p class="namespace-panel__confirm-message" data-test="confirm-message">
         {{ req.message }}
       </p>
     </div>
     <div class="namespace-panel__clone-actions" *ngIf="confirmRequest as req">
-      <!-- Drift variant: two explicit named buttons — Reload (safe, focused
-           default) + Overwrite (destructive branch). ADR-018 §1 / AC 7. -->
+      <!-- Drift variant: two explicit named buttons — Reload (recommended
+           primary, focused so Enter reloads) + Overwrite (destructive branch).
+           ADR-018 §1 / Amendment §d/§e. -->
       <ng-container *ngIf="req.variant === 'drift'; else cancelProceed">
-        <button
-          #confirmSafeBtn
-          pButton
-          type="button"
-          size="small"
-          severity="secondary"
-          label="Reload"
-          (click)="onConfirmReloadClick()"
-          data-test="confirm-reload-btn"
-        ></button>
         <button
           pButton
           type="button"
@@ -337,13 +340,23 @@
           (click)="onConfirmOverwriteClick()"
           data-test="confirm-overwrite-btn"
         ></button>
+        <button
+          #confirmPrimaryBtn
+          pButton
+          type="button"
+          size="small"
+          severity="secondary"
+          label="Reload"
+          (click)="onConfirmReloadClick()"
+          data-test="confirm-reload-btn"
+        ></button>
       </ng-container>
-      <!-- Reset / Delete variants: [Cancel] [Proceed]. Cancel holds focus so
-           Enter/Esc cancel (ADR-018 §2 / AC 9, 10). The Delete-flow Proceed
-           button is destructive — shared dark-red class (ADR-018 §4 / AC 16). -->
+      <!-- Reset / Delete / Discard variants: [Cancel] [Proceed]. The Proceed
+           button holds focus so Enter proceeds (ADR-018 Amendment §e); Esc still
+           cancels. The Delete-flow Proceed button is destructive — shared
+           dark-red class (ADR-018 §4 / AC 16). -->
       <ng-template #cancelProceed>
         <button
-          #confirmSafeBtn
           pButton
           type="button"
           size="small"
@@ -353,6 +366,7 @@
           data-test="confirm-cancel-btn"
         ></button>
         <button
+          #confirmPrimaryBtn
           pButton
           type="button"
           size="small"

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -104,13 +104,15 @@
       ></button>
 
       <!-- Delete (Story 14.1 / ADR-028 frontend leg). Always available;
-           dark-red destructive action; opens a confirm naming the namespace
-           before issuing DELETE. Disabled only while a delete is in flight. -->
+           dark-red destructive action (ADR-018 §4 — shared `namespace-panel__danger`
+           class, NOT PrimeNG's bright `severity="danger"`); opens the custom
+           confirm naming the namespace before issuing DELETE. Disabled only
+           while a delete is in flight. -->
       <button
         pButton
         type="button"
         size="small"
-        severity="danger"
+        class="namespace-panel__danger"
         label="Delete"
         icon="pi pi-trash"
         [disabled]="!canDelete"
@@ -147,12 +149,20 @@
     (visibleChange)="onCloneDialogVisibleChange($event)"
     (onShow)="onCloneDialogShow()"
     (onHide)="onCloneDialogHide()"
-    [modal]="true"
+    [modal]="false"
     [style]="{ width: '30rem' }"
     header="Clone namespace"
     data-test="clone-dialog"
   >
-    <div class="namespace-panel__clone-body">
+    <!-- ADR-018 §3 — the secondary panel owns its Esc→cancel: stop the
+         keystroke from bubbling so it cannot reach the host config dialog. The
+         dialog's own [closeOnEscape] (default true) closes THIS modal; the host
+         dialog's [closeOnEscape] is separately gated off via
+         `hasSecondaryPanelOpen` while any secondary panel is open. -->
+    <div
+      class="namespace-panel__clone-body"
+      (keydown.escape)="$event.stopPropagation()"
+    >
       <label for="clone-dest-name-input">Destination name</label>
       <input
         #cloneDestInput
@@ -272,8 +282,86 @@
     data-test="a11y-live-region"
   >{{ a11yAnnouncement }}</div>
 
-  <!-- PrimeNG ConfirmDialog — scoped to this component via `providers:
-       [ConfirmationService]` so the dialog and future route presentations
-       both get an instance without app-root wiring. -->
-  <p-confirmDialog></p-confirmDialog>
+  <!--
+    Story 22.3 (ADR-018 §1–§4) — panel-owned custom confirmation modal. Same
+    `<p-dialog>` shell + `namespace-panel__clone-body` / `__clone-actions`
+    styling as the Clone modal above; reused for Reset-discard, Save-drift, and
+    Delete. Driven from component state (`confirmDialogVisible` + the typed
+    `confirmRequest`), not an imperative service call.
+
+    - No `[modal]` → no backdrop under the secondary panel (ADR-018 §3 / AC 14).
+    - `(onShow)` autofocuses the safe button so Enter/Esc cancel (ADR-018 §2);
+      `(onHide)` resets state + settles a pending drift dismissal to the safe
+      branch (AC 8, 19).
+    - Esc on the body stops propagation so it cannot reach the host config
+      dialog (ADR-018 §3); the dialog's own [closeOnEscape] closes THIS modal.
+  -->
+  <p-dialog
+    [visible]="confirmDialogVisible"
+    (visibleChange)="confirmDialogVisible = $event"
+    (onShow)="onConfirmDialogShow()"
+    (onHide)="onConfirmDialogHide()"
+    [style]="{ width: '30rem' }"
+    [header]="confirmRequest?.header ?? ''"
+    data-test="confirm-dialog"
+  >
+    <div
+      *ngIf="confirmRequest as req"
+      class="namespace-panel__clone-body"
+      (keydown.escape)="$event.stopPropagation()"
+    >
+      <p class="namespace-panel__confirm-message" data-test="confirm-message">
+        {{ req.message }}
+      </p>
+    </div>
+    <div class="namespace-panel__clone-actions" *ngIf="confirmRequest as req">
+      <!-- Drift variant: two explicit named buttons — Reload (safe, focused
+           default) + Overwrite (destructive branch). ADR-018 §1 / AC 7. -->
+      <ng-container *ngIf="req.variant === 'drift'; else cancelProceed">
+        <button
+          #confirmSafeBtn
+          pButton
+          type="button"
+          size="small"
+          severity="secondary"
+          label="Reload"
+          (click)="onConfirmReloadClick()"
+          data-test="confirm-reload-btn"
+        ></button>
+        <button
+          pButton
+          type="button"
+          size="small"
+          severity="secondary"
+          label="Overwrite"
+          (click)="onConfirmOverwriteClick()"
+          data-test="confirm-overwrite-btn"
+        ></button>
+      </ng-container>
+      <!-- Reset / Delete variants: [Cancel] [Proceed]. Cancel holds focus so
+           Enter/Esc cancel (ADR-018 §2 / AC 9, 10). The Delete-flow Proceed
+           button is destructive — shared dark-red class (ADR-018 §4 / AC 16). -->
+      <ng-template #cancelProceed>
+        <button
+          #confirmSafeBtn
+          pButton
+          type="button"
+          size="small"
+          severity="secondary"
+          label="Cancel"
+          (click)="onConfirmCancelClick()"
+          data-test="confirm-cancel-btn"
+        ></button>
+        <button
+          pButton
+          type="button"
+          size="small"
+          [class.namespace-panel__danger]="req.variant === 'delete'"
+          [label]="confirmProceedLabel"
+          (click)="onConfirmProceedClick()"
+          data-test="confirm-proceed-btn"
+        ></button>
+      </ng-template>
+    </div>
+  </p-dialog>
 </div>

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -17,9 +17,10 @@
   <ng-container *ngIf="!loading && serverYaml !== ''">
     <!--
       ngModel is split into [ngModel] + (ngModelChange) so the change
-      handler can invalidate the edit-mode Validate-buffer success flash
-      as soon as the user modifies the YAML — a clean-report ack should
-      not outlive the buffer it validated.
+      handler can invalidate the Validate success flash as soon as the user
+      modifies the YAML — a clean-report ack should not outlive the buffer it
+      validated. The editor is permanently writable (ADR-017 §1):
+      `editorOptions.readOnly` is `false` and the object is a stable constant.
     -->
     <nu-monaco-editor
       class="namespace-panel__editor"
@@ -30,101 +31,33 @@
     ></nu-monaco-editor>
 
     <!--
-      Action row.
-      VIEW mode order (post-review UX refinement): Validate · Edit · Clone.
-      EDIT mode order (post-review UX refinement): Validate · Save · Reset · Cancel.
-      Clone is NO LONGER rendered in edit mode — "Save As from a dirty buffer" was a
-      confusing mental model (the clone captures in-memory state, not the server
-      state the operator sees in view mode). Operators save first, then clone.
+      Action row (ADR-017 §2) — five always-present actions in a single,
+      non-mode-split row: Validate · Save · Reset · Clone · Delete. Enablement
+      is driven by one boolean — dirty (`buffer !== serverYaml`):
+        • Save / Reset enabled when dirty.
+        • Clone enabled when clean.
+        • Validate / Delete orthogonal (always available; only gated by an
+          in-flight request). Validate is NEVER disabled by the FR14 gate.
     -->
     <div class="namespace-panel__actions">
-      <!-- VIEW mode: Validate · Edit · Clone (in that order) -->
-
-      <!-- Validate persisted state. Flash-to-green pattern on clean report
-           via `[class.p-button-success]` — PrimeNG's own `[severity]`
-           binding does not strip the prior class on revert, so we toggle
-           the class explicitly. -->
+      <!-- Validate (over the buffer; single handler — ADR-017 §4). Flash-to-
+           green on a clean report via `[class.p-button-success]` — PrimeNG's
+           own `[severity]` binding does not strip the prior class on revert,
+           so we toggle the class explicitly. NEVER gated by FR14 (§5). -->
       <button
-        *ngIf="mode === 'view'"
-        pButton
-        type="button"
-        size="small"
-        [class.p-button-success]="validationFlashPersisted"
-        label="Validate persisted state"
-        [icon]="validationFlashPersisted ? 'pi pi-check' : 'pi pi-check-circle'"
-        [disabled]="validating"
-        (click)="onValidatePersistedClick()"
-        data-test="validate-persisted-btn"
-      ></button>
-
-      <!-- Edit. Post-review refinement: re-fetches the server namespace
-           on click and prompts the operator to reload if it drifted since
-           the initial load. Shows a spinner while the drift check is in
-           flight. See `onEditClick()` in the component. -->
-      <button
-        *ngIf="mode === 'view'"
-        pButton
-        type="button"
-        size="small"
-        label="Edit"
-        [icon]="refreshingForEdit ? 'pi pi-spinner pi-spin' : 'pi pi-pencil'"
-        [disabled]="refreshingForEdit"
-        (click)="onEditClick()"
-        data-test="edit-btn"
-      ></button>
-
-      <!-- Clone. VIEW-MODE ONLY per post-review UX refinement. -->
-      <button
-        *ngIf="mode === 'view'"
-        #cloneBtn
-        pButton
-        type="button"
-        size="small"
-        severity="secondary"
-        label="Clone"
-        icon="pi pi-copy"
-        [disabled]="cloning || isCloneGated"
-        [pTooltip]="cloneTooltip"
-        (click)="onCloneClick()"
-        data-test="clone-btn"
-      ></button>
-
-      <!-- Delete. VIEW-MODE ONLY (Story 14.1 / ADR-028 frontend leg). Dark-red
-           destructive action; opens a confirm naming the namespace before
-           issuing DELETE. Disabled while a delete is in flight. -->
-      <button
-        *ngIf="mode === 'view'"
-        pButton
-        type="button"
-        size="small"
-        severity="danger"
-        label="Delete"
-        icon="pi pi-trash"
-        [disabled]="deleting"
-        (click)="onDeleteClick()"
-        data-test="delete-ns-btn"
-      ></button>
-
-      <!-- EDIT mode: Validate · Save · Reset · Cancel (in that order) -->
-
-      <!-- Validate buffer. Same flash pattern as the view-mode counterpart. -->
-      <button
-        *ngIf="mode === 'edit'"
         pButton
         type="button"
         size="small"
         [class.p-button-success]="validationFlashBuffer"
-        label="Validate buffer"
-        [icon]="validationFlashBuffer ? 'pi pi-check' : 'pi pi-check-square'"
+        label="Validate"
+        [icon]="validationFlashBuffer ? 'pi pi-check' : 'pi pi-check-circle'"
         [disabled]="saving || validating"
         (click)="onValidateBufferClick()"
-        data-test="validate-buffer-btn"
+        data-test="validate-btn"
       ></button>
 
-      <!-- Save. Disabled when the buffer matches serverYaml, during save,
-           or when the FR14 gate is active (known-bad validation). -->
+      <!-- Save. Enabled iff dirty AND not saving AND not FR14-gated. -->
       <button
-        *ngIf="mode === 'edit'"
         pButton
         type="button"
         size="small"
@@ -136,12 +69,10 @@
         data-test="save-btn"
       ></button>
 
-      <!-- Reset. Post-review new feature — revert the buffer to the last
-           server snapshot WITHOUT exiting edit mode. Dirty buffer triggers
-           a confirm (same "Discard unsaved changes?" prompt as Cancel);
-           clean buffer is a no-op and the button is disabled. -->
+      <!-- Reset — the sole undo affordance (Cancel is removed; ADR-017 §2).
+           Reverts the buffer to the last server snapshot behind a "Discard
+           unsaved changes?" confirm. Enabled iff dirty; a no-op when clean. -->
       <button
-        *ngIf="mode === 'edit'"
         pButton
         type="button"
         size="small"
@@ -153,18 +84,37 @@
         data-test="reset-btn"
       ></button>
 
-      <!-- Cancel. Same dirty-state guard as the dialog-close X (Story 11.3). -->
+      <!-- Clone — gated on CLEAN state (ADR-017 §3): disabled while dirty so
+           it always duplicates the saved bundle, never a half-edited draft.
+           Also FR14-gated. `#cloneBtn` is the focus-return target for
+           `onCloneDialogHide()`. -->
       <button
-        *ngIf="mode === 'edit'"
+        #cloneBtn
         pButton
         type="button"
         size="small"
         severity="secondary"
-        label="Cancel"
-        icon="pi pi-times"
-        [disabled]="saving"
-        (click)="onCancelClick()"
-        data-test="cancel-btn"
+        label="Clone"
+        icon="pi pi-copy"
+        [disabled]="buffer !== serverYaml || cloning || isCloneGated"
+        [pTooltip]="cloneTooltip"
+        (click)="onCloneClick()"
+        data-test="clone-btn"
+      ></button>
+
+      <!-- Delete (Story 14.1 / ADR-028 frontend leg). Always available;
+           dark-red destructive action; opens a confirm naming the namespace
+           before issuing DELETE. Disabled only while a delete is in flight. -->
+      <button
+        pButton
+        type="button"
+        size="small"
+        severity="danger"
+        label="Delete"
+        icon="pi pi-trash"
+        [disabled]="deleting"
+        (click)="onDeleteClick()"
+        data-test="delete-ns-btn"
       ></button>
     </div>
 

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.html
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.html
@@ -16,11 +16,11 @@
   <!-- Editor branch: we have content -->
   <ng-container *ngIf="!loading && serverYaml !== ''">
     <!--
-      ngModel is split into [ngModel] + (ngModelChange) so the change
-      handler can invalidate the Validate success flash as soon as the user
-      modifies the YAML — a clean-report ack should not outlive the buffer it
-      validated. The editor is permanently writable (ADR-017 §1):
-      `editorOptions.readOnly` is `false` and the object is a stable constant.
+      ngModel is split into [ngModel] + (ngModelChange) so the change handler
+      can invalidate the Validate success flash as soon as the user modifies
+      the YAML — a clean-report ack should not outlive the buffer it validated.
+      The editor is permanently writable: `editorOptions.readOnly` is `false`
+      and the object is a stable constant (ADR-017).
     -->
     <nu-monaco-editor
       class="namespace-panel__editor"
@@ -32,19 +32,19 @@
     ></nu-monaco-editor>
 
     <!--
-      Action row (ADR-017 §2) — five always-present actions in a single,
-      non-mode-split row: Validate · Save · Reset · Clone · Delete. Enablement
-      is driven by one boolean — dirty (`buffer !== serverYaml`):
+      Action row — five always-present actions in a single row: Validate ·
+      Save · Reset · Clone · Delete. Enablement is driven by the dirty flag
+      (`buffer !== serverYaml`):
         • Save / Reset enabled when dirty.
         • Clone enabled when clean.
         • Validate / Delete orthogonal (always available; only gated by an
-          in-flight request). Validate is NEVER disabled by the FR14 gate.
+          in-flight request). Validate is never gated by the validation gate.
     -->
     <div class="namespace-panel__actions">
-      <!-- Validate (over the buffer; single handler — ADR-017 §4). Flash-to-
-           green on a clean report via `[class.p-button-success]` — PrimeNG's
-           own `[severity]` binding does not strip the prior class on revert,
-           so we toggle the class explicitly. NEVER gated by FR14 (§5). -->
+      <!-- Validate over the buffer (single handler). Flash-to-green on a clean
+           report via `[class.p-button-success]` — PrimeNG's own `[severity]`
+           binding does not strip the prior class on revert, so we toggle the
+           class explicitly. Never gated by the validation gate. -->
       <button
         pButton
         type="button"
@@ -57,7 +57,7 @@
         data-test="validate-btn"
       ></button>
 
-      <!-- Save. Enabled iff dirty AND not saving AND not FR14-gated. -->
+      <!-- Save. Enabled iff dirty AND not saving AND not validation-gated. -->
       <button
         pButton
         type="button"
@@ -70,9 +70,9 @@
         data-test="save-btn"
       ></button>
 
-      <!-- Reset — the sole undo affordance (Cancel is removed; ADR-017 §2).
-           Reverts the buffer to the last server snapshot behind a "Discard
-           unsaved changes?" confirm. Enabled iff dirty; a no-op when clean. -->
+      <!-- Reset — the sole undo affordance. Reverts the buffer to the last
+           server snapshot behind a "Discard unsaved changes?" confirm. Enabled
+           iff dirty; a no-op when clean. -->
       <button
         pButton
         type="button"
@@ -85,9 +85,9 @@
         data-test="reset-btn"
       ></button>
 
-      <!-- Clone — gated on CLEAN state (ADR-017 §3): disabled while dirty so
-           it always duplicates the saved bundle, never a half-edited draft.
-           Also FR14-gated. `#cloneBtn` is the focus-return target for
+      <!-- Clone — gated on CLEAN state: disabled while dirty so it always
+           duplicates the saved bundle, never a half-edited draft. Also
+           validation-gated. `#cloneBtn` is the focus-return target for
            `onCloneDialogHide()`. -->
       <button
         #cloneBtn
@@ -103,11 +103,10 @@
         data-test="clone-btn"
       ></button>
 
-      <!-- Delete (Story 14.1 / ADR-028 frontend leg). Always available;
-           dark-red destructive action (ADR-018 §4 — shared `namespace-panel__danger`
-           class, NOT PrimeNG's bright `severity="danger"`); opens the custom
-           confirm naming the namespace before issuing DELETE. Disabled only
-           while a delete is in flight. -->
+      <!-- Delete. Always available; dark-red destructive action (shared
+           `namespace-panel__danger` class, NOT PrimeNG's bright
+           `severity="danger"`); opens the custom confirm naming the namespace
+           before issuing DELETE. Disabled only while a delete is in flight. -->
       <button
         pButton
         type="button"
@@ -121,9 +120,9 @@
       ></button>
     </div>
 
-    <!-- Validation-report sub-component (11.4 AC 9): renders the clean
-         pass / findings / unstructured fallback / nothing branches. The
-         clearRequested output nulls both parent fields on click. -->
+    <!-- Validation-report sub-component: renders the clean pass / findings /
+         unstructured fallback / nothing branches. The clearRequested output
+         nulls both parent fields on click. -->
     <app-validation-report
       [report]="lastValidation"
       [rawError]="rawSaveError"
@@ -131,18 +130,16 @@
     ></app-validation-report>
   </ng-container>
 
-  <!-- Story 11.5 — Clone sub-dialog (AC 3). Kept INSIDE the panel to
-       preserve NFR6 (host-agnostic): the panel owns the dialog, the form,
-       the validation, and the confirm handler. The host supplies only
-       `[existingNamespaces]` for the pre-flight collision check. -->
+  <!-- Clone sub-dialog. Kept INSIDE the panel so the panel stays
+       host-agnostic: the panel owns the dialog, the form, the validation, and
+       the confirm handler. The host supplies only `[existingNamespaces]` for
+       the pre-flight collision check. -->
   <!--
-    Story 11.7 AC 16 — `(onShow)` defers focus to the destination input
-    after PrimeNG mounts the overlay (programmatic focus from the host
-    component, fallback for [focusOnShow] which requires the input to be
-    the first focusable in the dialog tree).
-    Story 11.7 AC 18, 19, 21 — `(onHide)` runs the cleanup (clears
-    `cloneDestNs` + `cloneInlineError`) and returns focus to the outer
-    Clone button.
+    `(onShow)` defers focus to the destination input after PrimeNG mounts the
+    overlay (programmatic focus, fallback for [focusOnShow] which requires the
+    input to be the first focusable in the dialog tree).
+    `(onHide)` runs the cleanup (clears `cloneDestNs` + `cloneInlineError`) and
+    returns focus to the outer Clone button.
   -->
   <p-dialog
     [visible]="cloneDialogVisible"
@@ -158,14 +155,14 @@
     header="Clone namespace"
     data-test="clone-dialog"
   >
-    <!-- ADR-018 Amendment §a/§b — the secondary modal is properly modal
-         (pointer-contained) but paints NO dimming backdrop: the
-         `np-secondary-modal` styleClass makes `.p-dialog-mask` transparent (see
-         the component SCSS). `[draggable]="false"` — fixed-position, dragging is
-         disabled (operator preference; it was glitchy). `[closeOnEscape]="false"`
-         disables PrimeNG's document-level Esc listener for THIS modal; the single
-         coordinated Escape handler (the host's capture-phase keydown →
-         `handleSecondaryEscape`) closes only the topmost secondary panel. -->
+    <!-- The secondary modal is properly modal (pointer-contained) but paints
+         NO dimming backdrop: the `np-secondary-modal` styleClass makes
+         `.p-dialog-mask` transparent (see the component SCSS) while the mask
+         still absorbs clicks. `[draggable]="false"` — fixed-position, dragging
+         disabled. `[closeOnEscape]="false"` disables PrimeNG's document-level
+         Esc listener for THIS modal; the host's single coordinated Escape
+         handler (capture-phase keydown → `handleSecondaryEscape`) closes only
+         the topmost secondary panel (ADR-018). -->
     <div class="namespace-panel__clone-body">
       <label for="clone-dest-name-input">Destination name</label>
       <input
@@ -200,8 +197,8 @@
         Technical identifier that uniquely groups all elements of the
         configuration (DB view). Cannot be changed after cloning.
       </small>
-      <!-- Story 12.2 — Shareable toggle. Controls cross-namespace
-           REFERENCEABILITY (distinct from listing/cloning). -->
+      <!-- Shareable toggle. Controls cross-namespace REFERENCEABILITY
+           (distinct from listing/cloning). -->
       <label for="clone-shareable-toggle">Shareable</label>
       <p-toggleswitch
         [(ngModel)]="cloneShareable"
@@ -214,8 +211,8 @@
         Other namespaces can reference entries in this one (cross-namespace
         links).
       </small>
-      <!-- Story 12.2 — Public toggle. Controls LISTABILITY / CLONEABILITY by
-           other users (distinct from referenceability). -->
+      <!-- Public toggle. Controls LISTABILITY / CLONEABILITY by other users
+           (distinct from referenceability). -->
       <label for="clone-public-toggle">Public</label>
       <p-toggleswitch
         [(ngModel)]="clonePublic"
@@ -234,9 +231,9 @@
       >
         {{ cloneValidationError }}
       </div>
-      <!-- Story 11.7 AC 21 — inline alert for the unstructured-422 branch.
-           role="alert" implies aria-live="assertive" + aria-atomic="true"
-           so the message is announced as soon as the element appears. -->
+      <!-- Inline alert for the unstructured-422 branch. role="alert" implies
+           aria-live="assertive" + aria-atomic="true" so the message is
+           announced as soon as the element appears. -->
       <small
         *ngIf="cloneInlineError !== null"
         class="namespace-panel__clone-inline-error"
@@ -270,13 +267,12 @@
   </p-dialog>
 
   <!--
-    Story 11.7 AC 11–15 — visually-hidden polite live region (FR16).
-    role="status" + aria-live="polite" is the WCAG-recommended pattern
-    for non-disruptive operator feedback. aria-atomic="true" forces a
-    full re-announce on every text change (avoids partial diff
-    announcements on some screen readers). The element stays in the
-    DOM and accessibility tree but is clipped from view via the
-    .namespace-panel__a11y-live class.
+    Visually-hidden polite live region for assistive tech. role="status" +
+    aria-live="polite" is the WCAG-recommended pattern for non-disruptive
+    operator feedback. aria-atomic="true" forces a full re-announce on every
+    text change (avoids partial diff announcements on some screen readers).
+    The element stays in the DOM and accessibility tree but is clipped from
+    view via the .namespace-panel__a11y-live class.
   -->
   <div
     class="namespace-panel__a11y-live"
@@ -287,24 +283,22 @@
   >{{ a11yAnnouncement }}</div>
 
   <!--
-    Story 22.3 (ADR-018 §1–§4 + Amendment) — panel-owned custom confirmation
-    modal. Same `<p-dialog>` shell + `namespace-panel__clone-body` /
-    `__clone-actions` styling as the Clone modal above; reused for Reset-discard,
-    Save-drift, Delete, AND the dirty-CLOSE / dirty-NAV discard confirm
-    (`confirmDiscard()` — Amendment §c). Driven from component state
+    Panel-owned custom confirmation modal. Same `<p-dialog>` shell +
+    `namespace-panel__clone-body` / `__clone-actions` styling as the Clone modal
+    above; reused for Reset-discard, Save-drift, Delete, AND the dirty-CLOSE /
+    dirty-NAV discard confirm (`confirmDiscard()`). Driven from component state
     (`confirmDialogVisible` + the typed `confirmRequest`), not an imperative
     service call.
 
     - `[modal]="true"` + `[draggable]="false"` + `styleClass="np-secondary-modal"`
-      (transparent `.p-dialog-mask` in the SCSS) → properly modal, fixed-position
-      (dragging disabled — operator preference; it was glitchy), NO dimming
-      backdrop (ADR-018 Amendment §a / FIX 4).
-    - `[closeOnEscape]="false"` (Amendment §b / FIX 2): the host's single
-      coordinated Escape handler closes only the topmost secondary modal via
-      `handleSecondaryEscape`.
+      (transparent `.p-dialog-mask` in the SCSS, mask still absorbs clicks) →
+      properly modal, fixed-position (dragging disabled), NO dimming backdrop.
+    - `[closeOnEscape]="false"`: PrimeNG attaches closeOnEscape as a
+      document-level listener, so the host's single coordinated Escape handler
+      closes only the topmost secondary modal via `handleSecondaryEscape`.
     - `(onShow)` autofocuses the PRIMARY/proceed button so Enter activates the
-      main action (Amendment §e / FIX 5); `(onHide)` resets state + settles a
-      pending drift/discard dismissal to the safe branch (AC 8, 19, Amendment §c).
+      main action; `(onHide)` resets state + settles a pending drift/discard
+      dismissal to the safe branch (ADR-018).
   -->
   <p-dialog
     [visible]="confirmDialogVisible"
@@ -330,8 +324,7 @@
     </div>
     <div class="namespace-panel__clone-actions" *ngIf="confirmRequest as req">
       <!-- Drift variant: two explicit named buttons — Reload (recommended
-           primary, focused so Enter reloads) + Overwrite (destructive branch).
-           ADR-018 §1 / Amendment §d/§e. -->
+           primary, focused so Enter reloads) + Overwrite (destructive branch). -->
       <ng-container *ngIf="req.variant === 'drift'; else cancelProceed">
         <button
           pButton
@@ -354,9 +347,8 @@
         ></button>
       </ng-container>
       <!-- Reset / Delete / Discard variants: [Cancel] [Proceed]. The Proceed
-           button holds focus so Enter proceeds (ADR-018 Amendment §e); Esc still
-           cancels. The Delete-flow Proceed button is destructive — shared
-           dark-red class (ADR-018 §4 / AC 16). -->
+           button holds focus so Enter proceeds; Esc still cancels. The
+           Delete-flow Proceed button is destructive — shared dark-red class. -->
       <ng-template #cancelProceed>
         <button
           pButton

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
@@ -127,6 +127,23 @@
     line-height: 1.4;
   }
 
+  // ADR-018 Amendment §a (FIX 4) — TRANSPARENT secondary-modal mask. The Clone
+  // and confirmation `<p-dialog>`s stay `[modal]="true"` + `[draggable]="true"`
+  // (properly modal: draggable, pointer-contained, correctly stacked) but paint
+  // NO dimming backdrop over the configuration panel. PrimeNG's modal mask
+  // (`maskStyleClass="np-secondary-modal-mask"`) keeps `pointer-events: auto`
+  // (it absorbs clicks — no click-through to the config panel) while we force
+  // its background transparent here, so the config panel behind stays fully
+  // visible (no dimming). `!important` overrides the theme's mask background
+  // token. The mask is teleported to <body>, so this lives under
+  // `:host ::ng-deep` (encapsulation removed → matches the teleported element).
+  .np-secondary-modal-mask {
+    &.p-dialog-mask,
+    &.p-overlay-mask {
+      background: transparent !important;
+    }
+  }
+
   // ADR-018 §4 — single shared DARK-RED destructive style, defined ONCE and
   // reused by BOTH the action-row Delete button and the Delete-confirm's
   // Proceed button (replacing PrimeNG's bright `severity="danger"` red). Lives

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
@@ -28,12 +28,12 @@
     padding-top: 0.75rem;
   }
 
-  // Story 11.7 AC 11, 15 — visually-hidden polite live-region. The element
-  // stays in the DOM and accessibility tree but is clipped from view.
-  // Avoids `display: none` / `visibility: hidden` which remove the element
-  // from the AT tree entirely. Pattern equivalent to Tailwind's `sr-only`
-  // and Angular CDK's `cdk-visually-hidden` (we ship the rule inline to
-  // avoid pulling in @angular/cdk solely for this — see story AC 33).
+  // Visually-hidden polite live-region. The element stays in the DOM and
+  // accessibility tree but is clipped from view. Avoids `display: none` /
+  // `visibility: hidden` which remove the element from the AT tree entirely.
+  // Pattern equivalent to Tailwind's `sr-only` and Angular CDK's
+  // `cdk-visually-hidden` (shipped inline to avoid pulling in @angular/cdk
+  // solely for this rule).
   &__a11y-live {
     position: absolute;
     width: 1px;
@@ -53,8 +53,7 @@
 // `:host ::ng-deep` because PrimeNG's `<p-dialog>` teleports its content
 // to `document.body` via the CDK overlay. View-encapsulated selectors
 // (scoped via `[_ngcontent-xxx]` attribute suffix) do not match the
-// teleported DOM — so nested-inside-.namespace-panel rules silently
-// no-op. Same pattern Amelia used in Story 11-7 for the dialog header.
+// teleported DOM — so nested-inside-.namespace-panel rules silently no-op.
 // -------------------------------------------------------------------
 :host ::ng-deep {
   // Clone modal body — flex-column stacks the label + input + error
@@ -98,9 +97,8 @@
     line-height: 1.25;
   }
 
-  // Story 11.7 AC 21 — inline error in the Clone modal for the
-  // unstructured-422 fallback. Same red token; `display: block` so it
-  // takes its own line beneath the input.
+  // Inline error in the Clone modal for the unstructured-422 fallback. Same
+  // red token; `display: block` so it takes its own line beneath the input.
   .namespace-panel__clone-inline-error {
     display: block;
     margin-top: 0.4rem;
@@ -111,7 +109,7 @@
 
   // Clone modal action row — right-aligned Cancel + Confirm with a small
   // gap and a top separator so they don't crowd the input. Reused by the
-  // custom confirmation modal (ADR-018 §1).
+  // custom confirmation modal.
   .namespace-panel__clone-actions {
     display: flex;
     justify-content: flex-end;
@@ -119,7 +117,7 @@
     padding-top: 1rem;
   }
 
-  // ADR-018 §1 — custom confirmation modal body message. Sits in the shared
+  // Custom confirmation modal body message. Sits in the shared
   // `.namespace-panel__clone-body` flex-column; reset the default <p> margins
   // so the single message line aligns with the dialog padding.
   .namespace-panel__confirm-message {
@@ -127,10 +125,9 @@
     line-height: 1.4;
   }
 
-  // ADR-018 Amendment §a (FIX 4) — TRANSPARENT secondary-modal mask. The Clone
-  // and confirmation `<p-dialog>`s stay `[modal]="true"` + `[draggable]="true"`
-  // (properly modal: draggable, pointer-contained, correctly stacked) but paint
-  // NO dimming backdrop over the configuration panel. PrimeNG's modal mask
+  // TRANSPARENT secondary-modal mask. The Clone and confirmation `<p-dialog>`s
+  // are `[modal]="true"` (pointer-contained, correctly stacked) but paint NO
+  // dimming backdrop over the configuration panel. PrimeNG's modal mask
   // (`maskStyleClass="np-secondary-modal-mask"`) keeps `pointer-events: auto`
   // (it absorbs clicks — no click-through to the config panel) while we force
   // its background transparent here, so the config panel behind stays fully
@@ -144,12 +141,12 @@
     }
   }
 
-  // ADR-018 §4 — single shared DARK-RED destructive style, defined ONCE and
-  // reused by BOTH the action-row Delete button and the Delete-confirm's
-  // Proceed button (replacing PrimeNG's bright `severity="danger"` red). Lives
+  // Single shared DARK-RED destructive style, defined ONCE and reused by BOTH
+  // the action-row Delete button and the Delete-confirm's Proceed button. Lives
   // under `:host ::ng-deep` so it matches the teleported modal button as well
   // as the in-panel action-row button. `!important` overrides PrimeNG's own
-  // button background/border tokens, which otherwise win on specificity.
+  // button background/border tokens, which otherwise win on specificity
+  // (ADR-018).
   .namespace-panel__danger {
     &,
     &.p-button {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.scss
@@ -110,11 +110,41 @@
   }
 
   // Clone modal action row — right-aligned Cancel + Confirm with a small
-  // gap and a top separator so they don't crowd the input.
+  // gap and a top separator so they don't crowd the input. Reused by the
+  // custom confirmation modal (ADR-018 §1).
   .namespace-panel__clone-actions {
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
     padding-top: 1rem;
+  }
+
+  // ADR-018 §1 — custom confirmation modal body message. Sits in the shared
+  // `.namespace-panel__clone-body` flex-column; reset the default <p> margins
+  // so the single message line aligns with the dialog padding.
+  .namespace-panel__confirm-message {
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  // ADR-018 §4 — single shared DARK-RED destructive style, defined ONCE and
+  // reused by BOTH the action-row Delete button and the Delete-confirm's
+  // Proceed button (replacing PrimeNG's bright `severity="danger"` red). Lives
+  // under `:host ::ng-deep` so it matches the teleported modal button as well
+  // as the in-panel action-row button. `!important` overrides PrimeNG's own
+  // button background/border tokens, which otherwise win on specificity.
+  .namespace-panel__danger {
+    &,
+    &.p-button {
+      background: #991b1b !important;
+      border-color: #991b1b !important;
+      color: #ffffff !important;
+    }
+
+    &:enabled:hover,
+    &.p-button:enabled:hover {
+      background: #7f1d1d !important;
+      border-color: #7f1d1d !important;
+    }
   }
 }

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, forwardRef, Input } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  forwardRef,
+  Input,
+  Output,
+} from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
@@ -11,7 +18,9 @@ import {
   FormsModule,
   NG_VALUE_ACCESSOR,
 } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { NuMonacoEditorEvent } from '@ng-util/monaco-editor';
 import yaml from 'js-yaml';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -55,10 +64,40 @@ import { ValidationReportComponent } from './validation-report/validation-report
 class StubMonacoEditorComponent implements ControlValueAccessor {
   @Input() options?: Record<string, unknown>;
   @Input() height?: string;
+  // Story 22.2 — mirror the real component's `(event)` output so the Monaco
+  // capture path (`onEditorEvent`) is reachable from the template binding.
+  @Output() event = new EventEmitter<NuMonacoEditorEvent>();
   writeValue(_value: string): void {}
   registerOnChange(_fn: (value: string) => void): void {}
   registerOnTouched(_fn: () => void): void {}
   setDisabledState?(_isDisabled: boolean): void {}
+}
+
+/**
+ * Story 22.2 — a hand-rolled Monaco editor double whose `addAction` records the
+ * descriptors passed to it. Tests drive `component.onEditorEvent({ type:
+ * 'init', editor })` with one of these, then locate a descriptor by id and
+ * invoke its `run()` to exercise the Monaco capture path.
+ */
+interface RecordedAction {
+  id: string;
+  label: string;
+  keybindings?: number[];
+  run: (editor: unknown, ...args: unknown[]) => void | Promise<void>;
+}
+
+function makeEditorStub(): {
+  editor: unknown;
+  actions: RecordedAction[];
+} {
+  const actions: RecordedAction[] = [];
+  const editor = {
+    addAction(descriptor: RecordedAction): { dispose(): void } {
+      actions.push(descriptor);
+      return { dispose(): void {} };
+    },
+  };
+  return { editor, actions };
 }
 
 function makeHttpError(status: number, body: unknown = ''): HttpError {
@@ -87,6 +126,29 @@ describe('NamespacePanelComponent', () => {
   // to the anonymous user so pre-existing Save tests — whose buffers carry
   // `user_id: null` (unresolvable owner → defer to server) — are unaffected.
   let authStub: { currentUserValue: { user_id: string; roles?: string[] } };
+
+  // Story 22.2 — the real Monaco library (and its `window.monaco` global
+  // carrying `KeyMod`/`KeyCode`) is NOT loaded in Karma (the AMD loader is
+  // stubbed out via StubMonacoEditorComponent). The component's
+  // `registerEditorShortcuts` reads `monaco.KeyMod`/`monaco.KeyCode` when it
+  // builds the chord keybindings, so install a minimal runtime stub. Values
+  // are arbitrary-but-stable distinct bits — the assertions only require that
+  // the production code and the test compute the SAME chord number from the
+  // SAME stub (the real bit values live in the browser-loaded library).
+  let prevMonaco: unknown;
+  beforeAll(() => {
+    const w = globalThis as unknown as { monaco?: unknown };
+    prevMonaco = w.monaco;
+    if (w.monaco === undefined) {
+      w.monaco = {
+        KeyMod: { Alt: 1 << 9, Shift: 1 << 10, CtrlCmd: 1 << 11, WinCtrl: 1 << 8 },
+        KeyCode: { KeyS: 49, KeyV: 52, KeyR: 48, KeyC: 33, KeyD: 34 },
+      };
+    }
+  });
+  afterAll(() => {
+    (globalThis as unknown as { monaco?: unknown }).monaco = prevMonaco;
+  });
 
   async function buildFixture(namespace: string) {
     fixture = TestBed.createComponent(NamespacePanelComponent);
@@ -2161,5 +2223,534 @@ entries: {}
     expect(shareableHint).not.toContain('clone');
     expect(publicHint).toContain('clone');
     expect(publicHint).toMatch(/list|read/);
+  });
+
+  // ---------------------------------------------------------------------
+  // Story 22.2 (ADR-017 §7) — action-row keyboard shortcuts.
+  // ⌥S Save · ⌥V Validate · ⌥R Reset · ⌥⇧C Clone · ⌥D Delete.
+  // Match on altKey + code (NOT key); preventDefault on handled combos;
+  // two capture sites (HostListener + Monaco addAction) over one shared
+  // dispatch surface honouring each button's enablement.
+  // ---------------------------------------------------------------------
+
+  /**
+   * Build a KeyboardEvent with explicit code/altKey/shiftKey/key.
+   * `cancelable: true` so `event.defaultPrevented` reflects a
+   * `preventDefault()` call even when the event is invoked directly (not
+   * dispatched) — a non-cancelable synthetic event ignores preventDefault.
+   */
+  function keyEvent(
+    code: string,
+    init: Partial<KeyboardEventInit> = {},
+  ): KeyboardEvent {
+    return new KeyboardEvent('keydown', {
+      altKey: true,
+      cancelable: true,
+      code,
+      ...init,
+    });
+  }
+
+  // ----- can* enablement getters mirror the button [disabled] (AC 6) -----
+
+  it('(22.2 AC6) can* getters mirror the button [disabled] expressions', async () => {
+    await loaded('foo: 1\n');
+
+    // Clean, idle: Save/Reset disabled, Validate/Clone/Delete enabled.
+    expect(component.canSave).toBeFalse();
+    expect(component.canReset).toBeFalse();
+    expect(component.canValidate).toBeTrue();
+    expect(component.canClone).toBeTrue();
+    expect(component.canDelete).toBeTrue();
+
+    // Dirty: Save/Reset enable, Clone disables.
+    component.buffer = 'foo: 2\n';
+    expect(component.canSave).toBeTrue();
+    expect(component.canReset).toBeTrue();
+    expect(component.canClone).toBeFalse();
+
+    // FR14-gated: Save off, Clone off (when clean), Validate STILL on.
+    component.buffer = component.serverYaml;
+    component.lastValidation = failingReport(1);
+    expect(component.canSave).toBeFalse();
+    expect(component.canClone).toBeFalse();
+    expect(component.canValidate).toBeTrue();
+
+    // In-flight flags.
+    component.lastValidation = null;
+    component.saving = true;
+    expect(component.canValidate).toBeFalse();
+    component.saving = false;
+    component.validating = true;
+    expect(component.canValidate).toBeFalse();
+    component.validating = false;
+    component.cloning = true;
+    expect(component.canClone).toBeFalse();
+    component.cloning = false;
+    component.deleting = true;
+    expect(component.canDelete).toBeFalse();
+  });
+
+  it('(22.2 AC6) the button [disabled] bindings consume the can* getters (single source of truth)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    fixture.detectChanges();
+
+    const dis = (test: string): boolean =>
+      (
+        fixture.nativeElement.querySelector(
+          `button[data-test="${test}"]`,
+        ) as HTMLButtonElement
+      ).disabled;
+
+    // Dirty state: Save/Reset enabled, Clone disabled — matches can*.
+    expect(dis('save-btn')).toBe(!component.canSave);
+    expect(dis('reset-btn')).toBe(!component.canReset);
+    expect(dis('clone-btn')).toBe(!component.canClone);
+    expect(dis('validate-btn')).toBe(!component.canValidate);
+    expect(dis('delete-ns-btn')).toBe(!component.canDelete);
+  });
+
+  // ----- HostListener path: per-action dispatch + enablement (AC 1–6, 11) -----
+
+  it('(22.2 AC1/AC6) ⌥S fires Save when dirty+enabled; no-op while clean', async () => {
+    await loaded('foo: 1\n');
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // Clean → no-op.
+    component.onKeydown(keyEvent('KeyS'));
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    // Dirty → fires.
+    component.buffer = 'foo: 2\n';
+    component.onKeydown(keyEvent('KeyS'));
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('(22.2 AC1/AC6) ⌥S is a no-op while saving or FR14-gated even when dirty', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    component.saving = true;
+    component.onKeydown(keyEvent('KeyS'));
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    component.saving = false;
+    component.lastValidation = failingReport(1);
+    component.onKeydown(keyEvent('KeyS'));
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC2/AC6) ⌥V fires Validate in clean AND dirty states; never FR14-suppressed', async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // Clean.
+    component.onKeydown(keyEvent('KeyV'));
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+
+    // Dirty + FR14-gated → still fires.
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+    component.rawSaveError = 'raw';
+    expect(component.isSaveGated).toBeTrue();
+    component.onKeydown(keyEvent('KeyV'));
+    expect(validateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('(22.2 AC2/AC6) ⌥V is a no-op while validating or saving', async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    component.validating = true;
+    component.onKeydown(keyEvent('KeyV'));
+    expect(validateSpy).not.toHaveBeenCalled();
+
+    component.validating = false;
+    component.saving = true;
+    component.onKeydown(keyEvent('KeyV'));
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC3/AC6) ⌥R fires Reset when dirty; no-op while clean; routes through the confirm', async () => {
+    await loaded('foo: 1\n');
+    const resetSpy = spyOn(component, 'onResetClick').and.callThrough();
+
+    // Clean → no-op (and no confirm).
+    component.onKeydown(keyEvent('KeyR'));
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+
+    // Dirty → fires onResetClick, which opens the discard confirm.
+    component.buffer = 'foo: 2\n';
+    component.onKeydown(keyEvent('KeyR'));
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    expect(args.message as string).toContain('Discard unsaved changes');
+  });
+
+  it('(22.2 AC3/AC6) ⌥R is a no-op while saving even when dirty', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.saving = true;
+    const resetSpy = spyOn(component, 'onResetClick');
+
+    component.onKeydown(keyEvent('KeyR'));
+
+    expect(resetSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC4/AC6/AC8) ⌥⇧C fires Clone when clean; no-op while dirty', async () => {
+    await loaded('foo: 1\n');
+    const cloneSpy = spyOn(component, 'onCloneClick').and.callThrough();
+
+    // Clean + Shift → opens the modal.
+    component.onKeydown(keyEvent('KeyC', { shiftKey: true }));
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+    expect(component.cloneDialogVisible).toBeTrue();
+
+    // Dirty → no-op even with Shift.
+    cloneSpy.calls.reset();
+    component.cloneDialogVisible = false;
+    component.buffer = 'foo: 2\n';
+    component.onKeydown(keyEvent('KeyC', { shiftKey: true }));
+    expect(cloneSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC4/AC6) ⌥⇧C is a no-op while cloning or FR14-gated', async () => {
+    await loaded('foo: 1\n');
+    const cloneSpy = spyOn(component, 'onCloneClick');
+
+    component.cloning = true;
+    component.onKeydown(keyEvent('KeyC', { shiftKey: true }));
+    expect(cloneSpy).not.toHaveBeenCalled();
+
+    component.cloning = false;
+    component.lastValidation = failingReport(1);
+    component.onKeydown(keyEvent('KeyC', { shiftKey: true }));
+    expect(cloneSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC5) ⌥D opens the Delete confirm; does NOT call deleteNamespace until accept', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+    const deleteSpy = spyOn(component, 'onDeleteClick').and.callThrough();
+
+    component.onKeydown(keyEvent('KeyD'));
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    expect(args.header).toBe('Delete namespace');
+    // No direct DELETE before accept.
+    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
+
+    args.accept!();
+    await fixture.whenStable();
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
+  });
+
+  it('(22.2 AC5/AC6) ⌥D is a no-op while a delete is in flight', async () => {
+    await loaded('foo: 1\n');
+    component.deleting = true;
+    const deleteSpy = spyOn(component, 'onDeleteClick').and.callThrough();
+
+    component.onKeydown(keyEvent('KeyD'));
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+  });
+
+  // ----- Match on code, NOT key — macOS dead-key survival (AC 7) -----
+
+  it('(22.2 AC7) ⌥S still fires when key carries the dead-key glyph ß (matcher ignores event.key)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    component.onKeydown(keyEvent('KeyS', { key: 'ß' }));
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('(22.2 AC7) ⌥V still fires when key carries the dead-key glyph √', async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    component.onKeydown(keyEvent('KeyV', { key: '√' }));
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ----- Shift gating for Clone (AC 8) -----
+
+  it('(22.2 AC8) Alt+KeyC WITHOUT Shift does not trigger Clone and does not preventDefault', async () => {
+    await loaded('foo: 1\n');
+    const cloneSpy = spyOn(component, 'onCloneClick');
+    const evt = keyEvent('KeyC', { shiftKey: false });
+
+    component.onKeydown(evt);
+
+    expect(cloneSpy).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBeFalse();
+  });
+
+  it('(22.2 AC8) Alt+Shift+KeyC triggers ONLY Clone — no S/V/R/D handler fires', async () => {
+    await loaded('foo: 1\n');
+    const cloneSpy = spyOn(component, 'onCloneClick').and.callThrough();
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const resetSpy = spyOn(component, 'onResetClick');
+    const deleteSpy = spyOn(component, 'onDeleteClick');
+
+    component.onKeydown(keyEvent('KeyC', { shiftKey: true }));
+
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(validateSpy).not.toHaveBeenCalled();
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC8) S/V/R/D match regardless of shiftKey state', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // Alt+Shift+KeyS still fires Save (Shift is irrelevant for S/V/R/D).
+    component.onKeydown(keyEvent('KeyS', { shiftKey: true }));
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ----- preventDefault on handled combos only (AC 9) -----
+
+  it('(22.2 AC9) preventDefault is called on a handled combo even when the action is a no-op (⌥S while clean)', async () => {
+    await loaded('foo: 1\n');
+    // Clean → triggerSave is a no-op, but the keystroke is "ours".
+    const evt = keyEvent('KeyS');
+    const pd = spyOn(evt, 'preventDefault').and.callThrough();
+    const saveSpy = spyOn(component, 'onSaveClick');
+
+    component.onKeydown(evt);
+
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(pd).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBeTrue();
+  });
+
+  it('(22.2 AC9) preventDefault is NOT called for an event without Alt', async () => {
+    await loaded('foo: 1\n');
+    const evt = new KeyboardEvent('keydown', {
+      altKey: false,
+      cancelable: true,
+      code: 'KeyS',
+    });
+    const pd = spyOn(evt, 'preventDefault').and.callThrough();
+
+    component.onKeydown(evt);
+
+    expect(pd).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBeFalse();
+  });
+
+  it('(22.2 AC9) preventDefault is NOT called for Alt + a non-bound code', async () => {
+    await loaded('foo: 1\n');
+    const evt = keyEvent('KeyX');
+    const pd = spyOn(evt, 'preventDefault').and.callThrough();
+
+    component.onKeydown(evt);
+
+    expect(pd).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC9) preventDefault IS called on a handled+enabled combo (⌥S while dirty)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    spyOn(component, 'onSaveClick').and.returnValue(Promise.resolve());
+    const evt = keyEvent('KeyS');
+    const pd = spyOn(evt, 'preventDefault').and.callThrough();
+
+    component.onKeydown(evt);
+
+    expect(pd).toHaveBeenCalledTimes(1);
+  });
+
+  // ----- HostListener binding wired end-to-end via dispatchEvent (AC 11) -----
+
+  it('(22.2 AC11) the @HostListener binding catches a dispatched keydown on the host element', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    const evt = keyEvent('KeyS');
+    fixture.nativeElement.dispatchEvent(evt);
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ----- Monaco capture path via editor.addAction (AC 10, 12) -----
+
+  function findAction(actions: RecordedAction[], id: string): RecordedAction {
+    const action = actions.find((a) => a.id.endsWith(id));
+    expect(action).withContext(`addAction for ${id}`).toBeDefined();
+    return action!;
+  }
+
+  it('(22.2 AC10) onEditorEvent("init") registers five chord actions with the expected keybindings', async () => {
+    await loaded('foo: 1\n');
+    const { editor, actions } = makeEditorStub();
+
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+
+    expect(actions.length).toBe(5);
+    const save = findAction(actions, 'save');
+    const validate = findAction(actions, 'validate');
+    const reset = findAction(actions, 'reset');
+    const clone = findAction(actions, 'clone');
+    const del = findAction(actions, 'delete');
+
+    // Alt = bit, Shift = bit, codes resolve to distinct chord numbers.
+    expect(save.keybindings![0]).toBe(monaco.KeyMod.Alt | monaco.KeyCode.KeyS);
+    expect(validate.keybindings![0]).toBe(
+      monaco.KeyMod.Alt | monaco.KeyCode.KeyV,
+    );
+    expect(reset.keybindings![0]).toBe(monaco.KeyMod.Alt | monaco.KeyCode.KeyR);
+    expect(clone.keybindings![0]).toBe(
+      monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
+    );
+    expect(del.keybindings![0]).toBe(monaco.KeyMod.Alt | monaco.KeyCode.KeyD);
+  });
+
+  it('(22.2 AC10) a non-init event (or missing editor) registers nothing', async () => {
+    await loaded('foo: 1\n');
+    const { editor, actions } = makeEditorStub();
+
+    component.onEditorEvent({ type: 're-init' });
+    component.onEditorEvent({ type: 'resize' });
+    component.onEditorEvent({
+      type: 'init',
+      editor: undefined,
+    });
+    expect(actions.length).toBe(0);
+
+    // A real init registers; a following re-init does NOT double-register.
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+    expect(actions.length).toBe(5);
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+    expect(actions.length).toBe(5);
+  });
+
+  it('(22.2 AC10/AC12) Monaco run() routes through the same dispatch + enablement as the HostListener', async () => {
+    await loaded('foo: 1\n');
+    const { editor, actions } = makeEditorStub();
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const save = findAction(actions, 'save');
+
+    // Clean → run() is a no-op (enablement parity with the HostListener).
+    save.run(editor);
+    expect(saveSpy).not.toHaveBeenCalled();
+
+    // Dirty → run() fires Save.
+    component.buffer = 'foo: 2\n';
+    save.run(editor);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('(22.2 AC12) Monaco path and HostListener path reach the same handler under the same state', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const { editor, actions } = makeEditorStub();
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // HostListener path.
+    component.onKeydown(keyEvent('KeyS'));
+    // Monaco path.
+    findAction(actions, 'save').run(editor);
+
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('(22.2 AC10/AC12) Monaco Clone run() honours the clean-only enablement', async () => {
+    await loadedWithCloneSrc(['src']);
+    const { editor, actions } = makeEditorStub();
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+    const cloneSpy = spyOn(component, 'onCloneClick').and.callThrough();
+    const clone = findAction(actions, 'clone');
+
+    // Clean → opens the modal.
+    clone.run(editor);
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+
+    // Dirty → no-op.
+    cloneSpy.calls.reset();
+    component.cloneDialogVisible = false;
+    component.buffer = cloneSrcYaml + '# dirty\n';
+    clone.run(editor);
+    expect(cloneSpy).not.toHaveBeenCalled();
+  });
+
+  it('(22.2 AC10) the template wires nu-monaco-editor (event) → onEditorEvent', async () => {
+    await loaded('foo: 1\n');
+    const onEditorEventSpy = spyOn(component, 'onEditorEvent').and.callThrough();
+    const { editor } = makeEditorStub();
+
+    const stub = fixture.debugElement.query(By.css('nu-monaco-editor'));
+    expect(stub).withContext('nu-monaco-editor present').not.toBeNull();
+    (stub.componentInstance as StubMonacoEditorComponent).event.emit({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+
+    expect(onEditorEventSpy).toHaveBeenCalledTimes(1);
+    const arg = onEditorEventSpy.calls.mostRecent().args[0];
+    expect(arg.type).toBe('init');
   });
 });

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -24,7 +24,7 @@ import { NuMonacoEditorEvent } from '@ng-util/monaco-editor';
 import yaml from 'js-yaml';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { DialogModule } from 'primeng/dialog';
+import { Dialog, DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
@@ -3605,24 +3605,51 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // ADR-018 Amendment §a (FIX 4) — secondary modals are modal + draggable.
+  // ADR-018 Amendment §a (FIX 4) — secondary modals are modal but NON-draggable.
+  // Read the PrimeNG Dialog inputs back off the component instance so the test
+  // FAILS if someone flips `draggable` on or drops `modal`.
   // ---------------------------------------------------------------------
 
-  it('(ADR-018 §a) the confirmation <p-dialog> is rendered modal and draggable', async () => {
+  /**
+   * Resolve a PrimeNG `Dialog` directive instance by its host `data-test`
+   * attribute. `modal` / `draggable` are `booleanAttribute`-transformed inputs,
+   * so reading them back yields the resolved boolean the template bound.
+   */
+  function dialogInstanceByTestId(testId: string): Dialog {
+    const debugEl = fixture.debugElement
+      .queryAll(By.directive(Dialog))
+      .find(
+        (de) =>
+          (de.nativeElement as HTMLElement).getAttribute('data-test') ===
+          testId,
+      );
+    expect(debugEl)
+      .withContext(`p-dialog[data-test="${testId}"] present`)
+      .toBeTruthy();
+    return debugEl!.componentInstance as Dialog;
+  }
+
+  it('(ADR-018 §a) the confirmation <p-dialog> is modal and NON-draggable', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     component.onResetClick();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    // Draggable dialogs expose a grab cursor on their header in PrimeNG; the
-    // deterministic contract here is that the dialog container rendered (modal
-    // mask present) — the modal/draggable inputs are asserted via the template
-    // binding, which compiles only if the inputs exist on <p-dialog>.
-    const container = document.querySelector(
-      '[data-test="confirm-dialog"] .p-dialog, .p-dialog',
-    ) as HTMLElement | null;
-    expect(container).withContext('confirm dialog container rendered').not.toBeNull();
+    const confirmDialog = dialogInstanceByTestId('confirm-dialog');
+    expect(confirmDialog.modal).toBe(true);
+    expect(confirmDialog.draggable).toBe(false);
     component.onConfirmDialogHide();
+  });
+
+  it('(ADR-018 §a) the Clone <p-dialog> is modal and NON-draggable', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const cloneDialog = dialogInstanceByTestId('clone-dialog');
+    expect(cloneDialog.modal).toBe(true);
+    expect(cloneDialog.draggable).toBe(false);
   });
 });

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -63,8 +63,8 @@ import { ValidationReportComponent } from './validation-report/validation-report
 class StubMonacoEditorComponent implements ControlValueAccessor {
   @Input() options?: Record<string, unknown>;
   @Input() height?: string;
-  // Story 22.2 — mirror the real component's `(event)` output so the Monaco
-  // capture path (`onEditorEvent`) is reachable from the template binding.
+  // Mirror the real component's `(event)` output so the Monaco capture path
+  // (`onEditorEvent`) is reachable from the template binding.
   @Output() event = new EventEmitter<NuMonacoEditorEvent>();
   writeValue(_value: string): void {}
   registerOnChange(_fn: (value: string) => void): void {}
@@ -73,10 +73,10 @@ class StubMonacoEditorComponent implements ControlValueAccessor {
 }
 
 /**
- * Story 22.2 — a hand-rolled Monaco editor double whose `addAction` records the
- * descriptors passed to it. Tests drive `component.onEditorEvent({ type:
- * 'init', editor })` with one of these, then locate a descriptor by id and
- * invoke its `run()` to exercise the Monaco capture path.
+ * A hand-rolled Monaco editor double whose `addAction` records the descriptors
+ * passed to it. Tests drive `component.onEditorEvent({ type: 'init', editor })`
+ * with one of these, then locate a descriptor by id and invoke its `run()` to
+ * exercise the Monaco capture path.
  */
 interface RecordedAction {
   id: string;
@@ -121,18 +121,18 @@ describe('NamespacePanelComponent', () => {
   let messageSpy: jasmine.SpyObj<MessageService>;
   // Minimal AuthService stub exposing only a settable `currentUserValue`
   // (the sole surface the panel's advisory owner pre-check reads). Defaults
-  // to the anonymous user so pre-existing Save tests — whose buffers carry
-  // `user_id: null` (unresolvable owner → defer to server) — are unaffected.
+  // to the anonymous user so Save tests whose buffers carry `user_id: null`
+  // (unresolvable owner → defer to server) are unaffected.
   let authStub: { currentUserValue: { user_id: string; roles?: string[] } };
 
-  // Story 22.2 — the real Monaco library (and its `window.monaco` global
-  // carrying `KeyMod`/`KeyCode`) is NOT loaded in Karma (the AMD loader is
-  // stubbed out via StubMonacoEditorComponent). The component's
-  // `registerEditorShortcuts` reads `monaco.KeyMod`/`monaco.KeyCode` when it
-  // builds the chord keybindings, so install a minimal runtime stub. Values
-  // are arbitrary-but-stable distinct bits — the assertions only require that
-  // the production code and the test compute the SAME chord number from the
-  // SAME stub (the real bit values live in the browser-loaded library).
+  // The real Monaco library (and its `window.monaco` global carrying
+  // `KeyMod`/`KeyCode`) is NOT loaded in Karma (the AMD loader is stubbed out
+  // via StubMonacoEditorComponent). The component's `registerEditorShortcuts`
+  // reads `monaco.KeyMod`/`monaco.KeyCode` when it builds the chord
+  // keybindings, so install a minimal runtime stub. Values are
+  // arbitrary-but-stable distinct bits — the assertions only require that the
+  // production code and the test compute the SAME chord number from the SAME
+  // stub (the real bit values live in the browser-loaded library).
   let prevMonaco: unknown;
   beforeAll(() => {
     const w = globalThis as unknown as { monaco?: unknown };
@@ -175,15 +175,13 @@ describe('NamespacePanelComponent', () => {
     })
       // Swap the real NuMonacoEditor for a lightweight stub that honours
       // the same template surface (selector + `options` + `ControlValueAccessor`)
-      // but does not kick off Monaco's AMD loader — which previously leaked
+      // but does not kick off Monaco's AMD loader — which would otherwise leak
       // late `onDestroy` registrations across tests (NG0911).
       //
-      // Story 22.3 (ADR-018 §1) — the panel no longer uses
-      // `ConfirmationService` / `<p-confirmDialog>`; the three confirm flows
-      // run through the panel-owned custom modal driven by component state, so
-      // the old `confirmationSpy` real-instance wiring + provider override are
-      // gone. Confirm assertions read `confirmDialogVisible` / `confirmRequest`
-      // and exercise the modal's button handlers directly.
+      // The panel does not use `ConfirmationService` / `<p-confirmDialog>`; the
+      // confirm flows run through the panel-owned custom modal driven by
+      // component state. Confirm assertions read `confirmDialogVisible` /
+      // `confirmRequest` and exercise the modal's button handlers directly.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
@@ -203,11 +201,10 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // Story 22.3 — custom confirmation modal helpers. These replace the old
-  // `confirmationSpy.confirm` call-count / `args.accept!()` idiom: a confirm
-  // is "open" when `confirmDialogVisible` is true and `confirmRequest` carries
-  // the flow's header/message/variant; Proceed / Cancel / Reload / Overwrite
-  // are exercised via the component's button handlers.
+  // Custom confirmation modal helpers. A confirm is "open" when
+  // `confirmDialogVisible` is true and `confirmRequest` carries the flow's
+  // header/message/variant; Proceed / Cancel / Reload / Overwrite are
+  // exercised via the component's button handlers.
   // ---------------------------------------------------------------------
 
   /** True iff the custom confirmation modal is open. */
@@ -249,7 +246,7 @@ describe('NamespacePanelComponent', () => {
   }
 
   // ---------------------------------------------------------------------
-  // Load / view tests carried forward (no `mode` axis).
+  // Load / view tests (no `mode` axis).
   // ---------------------------------------------------------------------
 
   it('(AC13) load flow (happy path) — populates serverYaml/buffer and clears loading', async () => {
@@ -260,8 +257,8 @@ describe('NamespacePanelComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    // Story 14.4 — exportNamespace now carries the admin "show all" flag
-    // ({ all: showAll }); default showAll=false ⇒ owner-scoped read.
+    // exportNamespace carries the admin "show all" flag ({ all: showAll });
+    // default showAll=false ⇒ owner-scoped read.
     expect(apiSpy.exportNamespace).toHaveBeenCalledOnceWith('foo', {
       all: false,
     });
@@ -364,7 +361,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §1 — Monaco always writable; editorOptions stable constant.
+  // Monaco always writable; editorOptions stable constant (ADR-017).
   // ---------------------------------------------------------------------
 
   it('(22.1 AC1/AC2) editorOptions.readOnly === false and the object preserves theme/language/automaticLayout', async () => {
@@ -441,7 +438,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §1 — hasUnsavedChanges() collapse (AC4, AC5).
+  // hasUnsavedChanges() collapse (ADR-017).
   // ---------------------------------------------------------------------
 
   it('(22.1 AC4/AC5) hasUnsavedChanges() === (buffer !== serverYaml) — no mode axis', async () => {
@@ -461,7 +458,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §2 — action row renders five buttons whenever there is content.
+  // Action row renders five buttons whenever there is content (ADR-017).
   // ---------------------------------------------------------------------
 
   it('(22.1 AC3/AC6) all five action buttons render whenever the panel has content (no per-mode *ngIf)', async () => {
@@ -476,7 +473,7 @@ describe('NamespacePanelComponent', () => {
       row.querySelector('button[data-test="delete-ns-btn"]'),
     ).not.toBeNull();
 
-    // The retired buttons are gone.
+    // The edit/cancel/per-mode validate buttons are not rendered.
     expect(row.querySelector('button[data-test="edit-btn"]')).toBeNull();
     expect(row.querySelector('button[data-test="cancel-btn"]')).toBeNull();
     expect(
@@ -508,7 +505,7 @@ describe('NamespacePanelComponent', () => {
     ).toBeNull();
   });
 
-  // ----- Save enablement (AC7) -----
+  // ----- Save enablement -----
 
   it('(22.1 AC7) Save disabled when clean, enabled when dirty', async () => {
     await loaded('foo: 1\n');
@@ -546,7 +543,7 @@ describe('NamespacePanelComponent', () => {
     expect(saveBtn.disabled).toBeTrue();
   });
 
-  // ----- Validate enablement (AC8) -----
+  // ----- Validate enablement -----
 
   it('(22.1 AC8) Validate enabled in both clean and dirty states, and never gated by FR14', async () => {
     await loaded('foo: 1\n');
@@ -578,7 +575,7 @@ describe('NamespacePanelComponent', () => {
     expect(validateBtn.disabled).toBeTrue();
   });
 
-  // ----- Reset enablement (AC9) -----
+  // ----- Reset enablement -----
 
   it('(22.1 AC9) Reset disabled when clean, enabled when dirty, disabled while saving', async () => {
     await loaded('foo: 1\n');
@@ -603,7 +600,7 @@ describe('NamespacePanelComponent', () => {
     expect(resetBtn.disabled).toBeTrue();
   });
 
-  // ----- Clone enablement (AC10) -----
+  // ----- Clone enablement -----
 
   it('(22.1 AC10) Clone enabled when clean, disabled when dirty', async () => {
     await loaded('foo: 1\n');
@@ -640,7 +637,7 @@ describe('NamespacePanelComponent', () => {
     expect(cloneBtn.disabled).toBeTrue();
   });
 
-  // ----- Delete enablement (AC11) -----
+  // ----- Delete enablement -----
 
   it('(22.1 AC11) Delete enabled by default, disabled only while deleting', async () => {
     await loaded('foo: 1\n');
@@ -659,7 +656,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §2/§6 — Save flow (gate, drift check, success, errors).
+  // Save flow (gate, drift check, success, errors) (ADR-017).
   // ---------------------------------------------------------------------
 
   it('(22.1 AC12) onSaveClick is a no-op when clean (gated on hasUnsavedChanges)', async () => {
@@ -808,7 +805,7 @@ describe('NamespacePanelComponent', () => {
     expect(messageSpy.add).not.toHaveBeenCalled();
   });
 
-  // ----- Save buffer-namespace guard preserved (AC12) -----
+  // ----- Save buffer-namespace guard -----
 
   it('(22.1 AC12) Save refuses when buffer namespace has been edited — error toast, no import, no drift export', async () => {
     await loaded('namespace: foo\nuser_id: null\nentries: {}\n');
@@ -852,7 +849,7 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
   });
 
-  // ----- Advisory owner-or-admin pre-flight preserved (AC12) -----
+  // ----- Advisory owner-or-admin pre-flight -----
 
   it('(22.1 AC12 / 14.3) owner can Save — import fires, no owner-block toast', async () => {
     authStub.currentUserValue = { user_id: 'alice', roles: [] };
@@ -914,7 +911,7 @@ describe('NamespacePanelComponent', () => {
     expect(toast.summary).toBe('Cannot change namespace on Save');
   });
 
-  // ----- Save drift check (AC20, AC21) -----
+  // ----- Save drift check -----
 
   it('(22.1 AC20/AC21) Save with a matching server export imports without a drift prompt', async () => {
     await loaded('foo: 1\n');
@@ -1028,7 +1025,7 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
   });
 
-  // ----- Destroy-during-save (AC13) -----
+  // ----- Destroy-during-save -----
 
   it('(22.1) destroy-during-save — late-resolving import does not write state', async () => {
     await loaded('foo: 1\n');
@@ -1059,7 +1056,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §2 — Reset is the only undo (AC14, AC15).
+  // Reset is the only undo (ADR-017).
   // ---------------------------------------------------------------------
 
   it('(22.1 AC14) onCancelClick is removed from the component', async () => {
@@ -1115,7 +1112,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §4 — single Validate handler (AC17, AC18).
+  // Single Validate handler (ADR-017).
   // ---------------------------------------------------------------------
 
   function cleanReport(namespace = 'foo'): NamespaceValidationReport {
@@ -1138,7 +1135,7 @@ describe('NamespacePanelComponent', () => {
 
   it('(22.1 AC17) Validate validates the buffer via validateNamespaceBuffer; clean state equals persisted', async () => {
     await loaded('foo: 1\n');
-    // Clean: buffer === serverYaml, so the buffer-validate equals a
+    // Clean: buffer === serverYaml, so a buffer-validate equals a
     // persisted-validate.
     apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(cleanReport()),
@@ -1346,7 +1343,7 @@ describe('NamespacePanelComponent', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  // ----- onClearValidationClick nulls both fields -----
+  // ----- onClearValidationClick nulls both validation fields -----
 
   it('(11.4 AC8) onClearValidationClick nulls lastValidation AND rawSaveError', async () => {
     await loaded('foo: 1\n');
@@ -1377,7 +1374,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // ADR-017 §5 — FR14 gate retained, orthogonal to Validate (AC19).
+  // Save/Clone gate retained, orthogonal to Validate (ADR-017).
   // ---------------------------------------------------------------------
 
   /** A non-clean validation report with a known finding count. */
@@ -1480,7 +1477,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // Clone flow (ADR-012 modal unchanged; gated on clean — ADR-017 §3).
+  // Clone flow — modal gated on a clean buffer (ADR-017).
   // ---------------------------------------------------------------------
 
   const cloneSrcYaml = `namespace: src
@@ -1549,7 +1546,7 @@ entries:
     expect(component.cloneDialogVisible).toBeFalse();
   });
 
-  // ----- Clone modal pre-flight validation (AC4) -----
+  // ----- Clone modal pre-flight validation -----
 
   it('(11.5 AC4) Confirm disabled — empty destNs', async () => {
     await loadedWithCloneSrc();
@@ -1939,7 +1936,7 @@ entries:
   });
 
   // ---------------------------------------------------------------------
-  // Delete flow (Story 14.1 / ADR-028 frontend leg) — always available.
+  // Delete flow — always available (ADR-028).
   // ---------------------------------------------------------------------
 
   it('(14.1 AC11) Delete button renders whenever the panel has content', async () => {
@@ -2133,7 +2130,7 @@ entries:
   });
 
   // ---------------------------------------------------------------------
-  // Story 12.2 — Clone modal shareable / public toggles (modal unchanged).
+  // Clone modal shareable / public toggles.
   // ---------------------------------------------------------------------
 
   const cloneSrcYamlWithFlags = `namespace: src
@@ -2305,7 +2302,7 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // Story 22.2 (ADR-017 §7) — action-row keyboard shortcuts.
+  // Action-row keyboard shortcuts (ADR-017).
   // ⌥S Save · ⌥V Validate · ⌥R Reset · ⌥⇧C Clone · ⌥D Delete.
   // Match on altKey + code (NOT key); preventDefault on handled combos;
   // two capture sites (HostListener + Monaco addAction) over one shared
@@ -2330,7 +2327,7 @@ entries: {}
     });
   }
 
-  // ----- can* enablement getters mirror the button [disabled] (AC 6) -----
+  // ----- can* enablement getters mirror the button [disabled] -----
 
   it('(22.2 AC6) can* getters mirror the button [disabled] expressions', async () => {
     await loaded('foo: 1\n');
@@ -2390,7 +2387,7 @@ entries: {}
     expect(dis('delete-ns-btn')).toBe(!component.canDelete);
   });
 
-  // ----- HostListener path: per-action dispatch + enablement (AC 1–6, 11) -----
+  // ----- HostListener path: per-action dispatch + enablement -----
 
   it('(22.2 AC1/AC6) ⌥S fires Save when dirty+enabled; no-op while clean', async () => {
     await loaded('foo: 1\n');
@@ -2550,7 +2547,7 @@ entries: {}
     expect(confirmOpen()).toBeFalse();
   });
 
-  // ----- Match on code, NOT key — macOS dead-key survival (AC 7) -----
+  // ----- Match on code, NOT key — macOS dead-key survival -----
 
   it('(22.2 AC7) ⌥S still fires when key carries the dead-key glyph ß (matcher ignores event.key)', async () => {
     await loaded('foo: 1\n');
@@ -2575,7 +2572,7 @@ entries: {}
     expect(validateSpy).toHaveBeenCalledTimes(1);
   });
 
-  // ----- Shift gating for Clone (AC 8) -----
+  // ----- Shift gating for Clone -----
 
   it('(22.2 AC8) Alt+KeyC WITHOUT Shift does not trigger Clone and does not preventDefault', async () => {
     await loaded('foo: 1\n');
@@ -2622,7 +2619,7 @@ entries: {}
     expect(saveSpy).toHaveBeenCalledTimes(1);
   });
 
-  // ----- preventDefault on handled combos only (AC 9) -----
+  // ----- preventDefault on handled combos only -----
 
   it('(22.2 AC9) preventDefault is called on a handled combo even when the action is a no-op (⌥S while clean)', async () => {
     await loaded('foo: 1\n');
@@ -2675,7 +2672,7 @@ entries: {}
     expect(pd).toHaveBeenCalledTimes(1);
   });
 
-  // ----- HostListener binding wired end-to-end via dispatchEvent (AC 11) -----
+  // ----- HostListener binding wired end-to-end via dispatchEvent -----
 
   it('(22.2 AC11) the @HostListener binding catches a dispatched keydown on the host element', async () => {
     await loaded('foo: 1\n');
@@ -2690,7 +2687,7 @@ entries: {}
     expect(saveSpy).toHaveBeenCalledTimes(1);
   });
 
-  // ----- Monaco capture path via editor.addAction (AC 10, 12) -----
+  // ----- Monaco capture path via editor.addAction -----
 
   function findAction(actions: RecordedAction[], id: string): RecordedAction {
     const action = actions.find((a) => a.id.endsWith(id));
@@ -2834,25 +2831,25 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // Story 22.4 (ADR-018 §5) — macOS Option-shortcut robustness
-  // (dead-key / IME composition). On some macOS layouts an ⌥-chord initiates
-  // a dead-key composition: the keydown arrives flagged composing
-  // (isComposing:true, keyCode:229, key:'Dead'). The matcher MUST still fire
-  // (it keys off altKey+code, never key) AND preventDefault to suppress the
-  // composition. The host capture-phase listener is the AUTHORITATIVE path.
+  // macOS Option-shortcut robustness (dead-key / IME composition) (ADR-018).
+  // On some macOS layouts an ⌥-chord initiates a dead-key composition: the
+  // keydown arrives flagged composing (isComposing:true, keyCode:229,
+  // key:'Dead'). The matcher MUST still fire (it keys off altKey+code, never
+  // key) AND preventDefault to suppress the composition. The host capture-phase
+  // listener is the AUTHORITATIVE path.
   //
-  // NOTE (NFR5): synthetic KeyboardEvents bypass the OS composition layer, so
-  // these specs prove the matcher WOULD handle a composing event (guarding a
-  // future composing-skip regression) but CANNOT reproduce the real macOS
-  // chord — that is the manual-verification gate (AC 8), left for the operator.
+  // NOTE: synthetic KeyboardEvents bypass the OS composition layer, so these
+  // specs prove the matcher WOULD handle a composing event (guarding a future
+  // composing-skip regression) but CANNOT reproduce the real macOS chord —
+  // that remains a manual-verification gate left for the operator.
   // ---------------------------------------------------------------------
 
   /**
    * Build a composing (dead-key / IME) keydown — the macOS failure shape:
    * `isComposing:true`, `keyCode:229`, `key:'Dead'`. Merges any extra init
-   * (e.g. `{ shiftKey: true }` for ⌥⇧C). Reuses the Story 22-2 `keyEvent`
-   * helper (altKey:true + cancelable:true), so `evt.defaultPrevented` is
-   * observable after a direct `component.onKeydown(evt)` call.
+   * (e.g. `{ shiftKey: true }` for ⌥⇧C). Reuses the `keyEvent` helper
+   * (altKey:true + cancelable:true), so `evt.defaultPrevented` is observable
+   * after a direct `component.onKeydown(evt)` call.
    */
   function composingKeyEvent(
     code: string,
@@ -2866,7 +2863,7 @@ entries: {}
     });
   }
 
-  // ----- AC 1, 2, 3 — composing-event survival + preventDefault, uniform -----
+  // ----- composing-event survival + preventDefault, uniform -----
 
   interface ComposingChordCase {
     name: string;
@@ -2970,7 +2967,7 @@ entries: {}
   it('(22.4 AC2) preventDefault fires under a composing + no-op-by-enablement combo (⌥S while clean)', async () => {
     await loaded('foo: 1\n');
     // Clean → triggerSave is a no-op, but the keystroke is "ours" and the
-    // composition MUST still be suppressed (parity with Story 22-2 AC9).
+    // composition MUST still be suppressed (parity with the non-composing path).
     const saveSpy = spyOn(component, 'onSaveClick');
     const evt = composingKeyEvent('KeyS');
 
@@ -3021,7 +3018,7 @@ entries: {}
     expect(withShift.defaultPrevented).toBeTrue();
   });
 
-  // ----- AC 4 — host capture-phase listener is the authoritative path -----
+  // ----- host capture-phase listener is the authoritative path -----
 
   it('(22.4 AC4) a composing keydown dispatched on the host element fires the action via the capture-phase listener', async () => {
     await loaded('foo: 1\n');
@@ -3053,7 +3050,7 @@ entries: {}
     expect(saveSpy).not.toHaveBeenCalled();
   });
 
-  // ----- AC 5 — single dispatch per keystroke (no double-fire) -----
+  // ----- single dispatch per keystroke (no double-fire) -----
 
   it('(22.4 AC5) a composing ⌥R opens EXACTLY ONE reset confirm via the host path', async () => {
     await loaded('foo: 1\n');
@@ -3074,9 +3071,8 @@ entries: {}
 
     // ONE physical keystroke reaches the ONE authoritative host capture site
     // (real macOS delivers a single keystroke to a single listener). It opens a
-    // single delete confirm via the idempotent triggerDelete() surface — no
-    // second uncoordinated host dispatch (the old bubble-phase @HostListener is
-    // gone, so there is exactly one host dispatch per keystroke).
+    // single delete confirm via the idempotent triggerDelete() surface — there
+    // is exactly one host dispatch per keystroke.
     component.onKeydown(composingKeyEvent('KeyD'));
 
     expect(openSpy).toHaveBeenCalledTimes(1);
@@ -3110,7 +3106,7 @@ entries: {}
     expect(component.confirmRequest!.variant).toBe('delete');
   });
 
-  // ----- AC 6 — non-composing regression guard (Story 22-2 path intact) -----
+  // ----- non-composing regression guard (non-composing path intact) -----
 
   it('(22.4 AC6) the non-composing path is unchanged — ⌥V (no composing flags) still validates and preventDefaults', async () => {
     await loaded('foo: 1\n');
@@ -3140,13 +3136,13 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // Story 22.3 (ADR-018 §1–§4) — custom confirmation modal + secondary-modal
-  // interaction contract: no <p-confirmDialog>; Clone-idiom custom modal;
-  // focus-Cancel/Enter-cancels; hasSecondaryPanelOpen predicate; no backdrop;
-  // shared dark-red destructive style.
+  // Custom confirmation modal + secondary-modal interaction contract
+  // (ADR-018): no <p-confirmDialog>; Clone-idiom custom modal; focused
+  // proceed button / Esc cancels; hasSecondaryPanelOpen predicate; no
+  // backdrop; shared dark-red destructive style.
   // ---------------------------------------------------------------------
 
-  // ----- AC 1 — <p-confirmDialog> removed; custom modal renders -----
+  // ----- <p-confirmDialog> removed; custom modal renders -----
 
   it('(22.3 AC1) the rendered panel contains no <p-confirmDialog>', async () => {
     await loaded('foo: 1\n');
@@ -3198,7 +3194,7 @@ entries: {}
     expect(confirmOpen()).toBeFalse();
   });
 
-  // ----- ADR-018 Amendment §e — focus the PRIMARY/proceed button; Esc cancels -----
+  // ----- focus the PRIMARY/proceed button; Esc cancels (ADR-018) -----
 
   it('(ADR-018 §e) onConfirmDialogShow focuses the primary/proceed button (reset/delete/discard)', fakeAsync(async () => {
     await loaded('foo: 1\n');
@@ -3256,7 +3252,7 @@ entries: {}
     expect(confirmOpen()).toBeFalse();
   });
 
-  // ----- AC 19 — confirm-request state cleared on hide -----
+  // ----- confirm-request state cleared on hide -----
 
   it('(22.3 AC19) onConfirmDialogHide clears confirmRequest so a stale request cannot leak', async () => {
     await loaded('foo: 1\n');
@@ -3270,7 +3266,7 @@ entries: {}
     expect(component.confirmDialogVisible).toBeFalse();
   });
 
-  // ----- AC 11 / AC 12 / AC 13 — hasSecondaryPanelOpen predicate -----
+  // ----- hasSecondaryPanelOpen predicate -----
 
   it('(22.3 AC12) hasSecondaryPanelOpen is true when the Clone modal is open, false otherwise', async () => {
     await loadedWithCloneSrc(['src']);
@@ -3295,14 +3291,13 @@ entries: {}
     expect(component.hasSecondaryPanelOpen).toBeFalse();
   });
 
-  // ----- ADR-018 Amendment §a (FIX 4) — transparent-mask draggable modals -----
+  // ----- transparent-mask modals (ADR-018) -----
   //
-  // The secondary panels stay `[modal]="true"` + `[draggable]="true"` (properly
-  // modal: draggable, pointer-contained) but paint NO dimming backdrop. PrimeNG
-  // v19 always renders a `.p-dialog-mask` wrapper; the no-dimming is achieved by
-  // tagging that wrapper with `np-secondary-modal-mask` (whose background the
-  // component SCSS forces transparent). In modal mode the mask keeps
-  // `pointer-events: auto`, so it ABSORBS clicks (no click-through). The
+  // The secondary panels stay `[modal]="true"` but paint NO dimming backdrop.
+  // PrimeNG v19 always renders a `.p-dialog-mask` wrapper; the no-dimming is
+  // achieved by tagging that wrapper with `np-secondary-modal-mask` (whose
+  // background the component SCSS forces transparent). In modal mode the mask
+  // keeps `pointer-events: auto`, so it ABSORBS clicks (no click-through). The
   // deterministic, headless-stable contract is the mask class + modal pointer
   // behaviour (computed background transparency is a real-browser concern).
 
@@ -3336,7 +3331,7 @@ entries: {}
     expect(mask!.style.pointerEvents).toBe('auto');
   });
 
-  // ----- AC 16 / AC 18 — shared dark-red destructive class -----
+  // ----- shared dark-red destructive class -----
 
   it('(22.3 AC16) the action-row Delete button carries namespace-panel__danger and drops severity="danger"', async () => {
     await loaded('foo: 1\n');
@@ -3412,7 +3407,7 @@ entries: {}
   }));
 
   // ---------------------------------------------------------------------
-  // ADR-018 Amendment §c — public confirmDiscard() (dirty-CLOSE / dirty-NAV)
+  // Public confirmDiscard() for dirty-close / dirty-nav (ADR-018).
   // ---------------------------------------------------------------------
 
   it('(ADR-018 §c) confirmDiscard opens the discard variant with the canonical header/message', async () => {
@@ -3511,8 +3506,8 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // ADR-018 Amendment §d — affirmative label is "Proceed" for every single-
-  // affirmative variant (reset, delete, discard); dark-red is class-only.
+  // Affirmative label is "Proceed" for every single-affirmative variant
+  // (reset, delete, discard); dark-red is class-only (ADR-018).
   // ---------------------------------------------------------------------
 
   it('(ADR-018 §d) confirmProceedLabel is "Proceed" for reset / delete / discard', async () => {
@@ -3550,8 +3545,8 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // ADR-018 Amendment §b (FIX 2) — handleSecondaryEscape: only the topmost
-  // secondary modal closes; exactly one action per Escape.
+  // handleSecondaryEscape: only the topmost secondary modal closes;
+  // exactly one action per Escape (ADR-018).
   // ---------------------------------------------------------------------
 
   it('(ADR-018 §b) handleSecondaryEscape closes ONLY the confirm modal (topmost) and returns true', async () => {
@@ -3605,9 +3600,9 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
-  // ADR-018 Amendment §a (FIX 4) — secondary modals are modal but NON-draggable.
-  // Read the PrimeNG Dialog inputs back off the component instance so the test
-  // FAILS if someone flips `draggable` on or drops `modal`.
+  // Secondary modals are modal but NON-draggable (ADR-018). Read the PrimeNG
+  // Dialog inputs back off the component instance so the test FAILS if someone
+  // flips `draggable` on or drops `modal`.
   // ---------------------------------------------------------------------
 
   /**

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -65,6 +65,17 @@ function makeHttpError(status: number, body: unknown = ''): HttpError {
   return new HttpError('boom', status, body);
 }
 
+/**
+ * Drain the microtask queue a few times so an awaited async chain (e.g. the
+ * Save drift re-export resolving before `confirmationService.confirm` fires)
+ * settles before assertions read its side effects.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe('NamespacePanelComponent', () => {
   let fixture: ComponentFixture<NamespacePanelComponent>;
   let component: NamespacePanelComponent;
@@ -128,7 +139,8 @@ describe('NamespacePanelComponent', () => {
             ValidationReportComponent,
           ],
           // Swap the locally-provided real ConfirmationService for a spy so
-          // the Cancel + confirm-dialog flow is testable deterministically.
+          // the Reset + drift + confirm-dialog flows are testable
+          // deterministically.
           providers: [
             { provide: ConfirmationService, useValue: confirmationSpy },
           ],
@@ -138,7 +150,20 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.2 load/view-mode tests carried forward from the prior spec.
+  // Shared load helper — drives ngOnInit → loadNamespace → stable view.
+  // The panel lands clean (buffer === serverYaml) and always editable.
+  // ---------------------------------------------------------------------
+
+  async function loaded(yaml = 'foo: 1\n'): Promise<void> {
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve(yaml));
+    await buildFixture('foo');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  // ---------------------------------------------------------------------
+  // Load / view tests carried forward (no `mode` axis).
   // ---------------------------------------------------------------------
 
   it('(AC13) load flow (happy path) — populates serverYaml/buffer and clears loading', async () => {
@@ -156,9 +181,10 @@ describe('NamespacePanelComponent', () => {
     });
     expect(component.serverYaml).toBe('key: value\n');
     expect(component.buffer).toBe('key: value\n');
-    expect(component.mode).toBe('view');
     expect(component.lastValidation).toBeNull();
     expect(component.loading).toBe(false);
+    // Lands clean — Save/Reset disabled, Clone enabled.
+    expect(component.hasUnsavedChanges()).toBe(false);
   });
 
   it('(14.4 AC8, AC17) admin foreign-open — showAll=true threads all:true into the entry read', async () => {
@@ -251,18 +277,33 @@ describe('NamespacePanelComponent', () => {
     expect(component.loading).toBe(false);
   });
 
-  it('(AC13) editorOptions.readOnly === true when mode === "view"', async () => {
-    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
-    await buildFixture('foo');
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+  // ---------------------------------------------------------------------
+  // ADR-017 §1 — Monaco always writable; editorOptions stable constant.
+  // ---------------------------------------------------------------------
+
+  it('(22.1 AC1/AC2) editorOptions.readOnly === false and the object preserves theme/language/automaticLayout', async () => {
+    await loaded('foo: 1\n');
 
     const options = component.editorOptions;
-    expect(options['readOnly']).toBe(true);
+    expect(options['readOnly']).toBe(false);
     expect(options['language']).toBe('yaml');
     expect(options['automaticLayout']).toBe(true);
     expect(options['theme']).toBe('vs');
+  });
+
+  it('(22.1 AC1) editorOptions is a single stable object reference — never reassigned', async () => {
+    await loaded('foo: 1\n');
+    const first = component.editorOptions;
+
+    // Dirtying the buffer (no Edit click exists) does not churn the reference.
+    component.buffer = 'foo: 2\n';
+    fixture.detectChanges();
+    expect(component.editorOptions).toBe(first);
+
+    // Saving and resetting also leave the reference untouched.
+    component.onResetClick();
+    fixture.detectChanges();
+    expect(component.editorOptions).toBe(first);
   });
 
   it('(AC13) public surface — namespace @Input, closed/saved @Output, hasUnsavedChanges', async () => {
@@ -274,7 +315,6 @@ describe('NamespacePanelComponent', () => {
     expect(component.namespace).toBe('foo');
     expect(typeof component.closed.emit).toBe('function');
     expect(typeof component.saved.emit).toBe('function');
-    // Story 11.3: hasUnsavedChanges is now a real check.
     expect(typeof component.hasUnsavedChanges).toBe('function');
   });
 
@@ -315,111 +355,242 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.3 — Edit flip (AC 1)
+  // ADR-017 §1 — hasUnsavedChanges() collapse (AC4, AC5).
   // ---------------------------------------------------------------------
 
-  async function loadedEditMode(yaml = 'foo: 1\n'): Promise<void> {
-    apiSpy.exportNamespace.and.returnValue(Promise.resolve(yaml));
+  it('(22.1 AC4/AC5) hasUnsavedChanges() === (buffer !== serverYaml) — no mode axis', async () => {
+    await loaded('foo: 1\n');
+
+    // Clean buffer.
+    expect(component.buffer).toBe(component.serverYaml);
+    expect(component.hasUnsavedChanges()).toBe(false);
+
+    // Dirty buffer — true with no Edit click (the editor is always writable).
+    component.buffer = 'foo: 2\n';
+    expect(component.hasUnsavedChanges()).toBe(true);
+
+    // Back to clean.
+    component.buffer = component.serverYaml;
+    expect(component.hasUnsavedChanges()).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------
+  // ADR-017 §2 — action row renders five buttons whenever there is content.
+  // ---------------------------------------------------------------------
+
+  it('(22.1 AC3/AC6) all five action buttons render whenever the panel has content (no per-mode *ngIf)', async () => {
+    await loaded('foo: 1\n');
+
+    const row = fixture.nativeElement as HTMLElement;
+    expect(row.querySelector('button[data-test="validate-btn"]')).not.toBeNull();
+    expect(row.querySelector('button[data-test="save-btn"]')).not.toBeNull();
+    expect(row.querySelector('button[data-test="reset-btn"]')).not.toBeNull();
+    expect(row.querySelector('button[data-test="clone-btn"]')).not.toBeNull();
+    expect(
+      row.querySelector('button[data-test="delete-ns-btn"]'),
+    ).not.toBeNull();
+
+    // The retired buttons are gone.
+    expect(row.querySelector('button[data-test="edit-btn"]')).toBeNull();
+    expect(row.querySelector('button[data-test="cancel-btn"]')).toBeNull();
+    expect(
+      row.querySelector('button[data-test="validate-persisted-btn"]'),
+    ).toBeNull();
+    expect(
+      row.querySelector('button[data-test="validate-buffer-btn"]'),
+    ).toBeNull();
+  });
+
+  it('(22.1 AC3) action row + editor are hidden while loading and in the empty state', async () => {
+    // Loading: pending export keeps loading true.
+    apiSpy.exportNamespace.and.returnValue(new Promise<string>(() => {}));
+    await buildFixture('foo');
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('button[data-test="save-btn"]'),
+    ).toBeNull();
+    fixture.destroy();
+
+    // Empty / error state: serverYaml === ''.
+    apiSpy.exportNamespace.and.returnValue(Promise.reject(new Error('boom')));
     await buildFixture('foo');
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
-  }
-
-  it('(11.3 AC1) onEditClick flips mode to edit and Monaco readOnly to false', async () => {
-    await loadedEditMode();
-    expect(component.mode).toBe('view');
-
-    await component.onEditClick();
-    fixture.detectChanges();
-
-    expect(component.mode).toBe('edit');
-    expect(component.editorOptions['readOnly']).toBe(false);
+    expect(
+      fixture.nativeElement.querySelector('button[data-test="save-btn"]'),
+    ).toBeNull();
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Save enabled/disabled (AC 2)
-  // ---------------------------------------------------------------------
+  // ----- Save enablement (AC7) -----
 
-  it('(11.3 AC2) Save is disabled when buffer === serverYaml, enabled otherwise', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    fixture.detectChanges();
+  it('(22.1 AC7) Save disabled when clean, enabled when dirty', async () => {
+    await loaded('foo: 1\n');
 
-    // Clean buffer — button[data-test="save-btn"] is disabled.
     let saveBtn = fixture.nativeElement.querySelector(
       'button[data-test="save-btn"]',
-    ) as HTMLButtonElement | null;
-    expect(saveBtn).not.toBeNull();
-    expect(saveBtn!.disabled).toBeTrue();
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBeTrue();
 
-    // Dirty buffer.
     component.buffer = 'foo: 2\n';
     fixture.detectChanges();
     saveBtn = fixture.nativeElement.querySelector(
       'button[data-test="save-btn"]',
-    ) as HTMLButtonElement | null;
-    expect(saveBtn!.disabled).toBeFalse();
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBeFalse();
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Cancel flows (AC 3 + AC 4)
-  // ---------------------------------------------------------------------
+  it('(22.1 AC7) Save disabled while saving and while FR14-gated even when dirty', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
 
-  it('(11.3 AC4) onCancelClick with clean buffer flips mode directly — no confirm', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+    component.saving = true;
+    fixture.detectChanges();
+    let saveBtn = fixture.nativeElement.querySelector(
+      'button[data-test="save-btn"]',
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBeTrue();
+
+    component.saving = false;
+    component.lastValidation = failingReport(1);
+    fixture.detectChanges();
+    saveBtn = fixture.nativeElement.querySelector(
+      'button[data-test="save-btn"]',
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBeTrue();
+  });
+
+  // ----- Validate enablement (AC8) -----
+
+  it('(22.1 AC8) Validate enabled in both clean and dirty states, and never gated by FR14', async () => {
+    await loaded('foo: 1\n');
+
+    // Clean — enabled.
+    let validateBtn = fixture.nativeElement.querySelector(
+      'button[data-test="validate-btn"]',
+    ) as HTMLButtonElement;
+    expect(validateBtn.disabled).toBeFalse();
+
+    // Dirty AND FR14-gated (a known-bad report is pending) — STILL enabled.
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(2);
+    component.rawSaveError = 'raw';
+    expect(component.isSaveGated).toBeTrue();
     fixture.detectChanges();
 
-    component.onCancelClick();
+    validateBtn = fixture.nativeElement.querySelector(
+      'button[data-test="validate-btn"]',
+    ) as HTMLButtonElement;
+    expect(validateBtn.disabled).toBeFalse();
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
-    expect(component.mode).toBe('view');
+    // Only an in-flight validating / saving disables it.
+    component.validating = true;
+    fixture.detectChanges();
+    validateBtn = fixture.nativeElement.querySelector(
+      'button[data-test="validate-btn"]',
+    ) as HTMLButtonElement;
+    expect(validateBtn.disabled).toBeTrue();
   });
 
-  it('(11.3 AC3) onCancelClick with dirty buffer triggers confirm — accept reverts', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  // ----- Reset enablement (AC9) -----
+
+  it('(22.1 AC9) Reset disabled when clean, enabled when dirty, disabled while saving', async () => {
+    await loaded('foo: 1\n');
+
+    let resetBtn = fixture.nativeElement.querySelector(
+      'button[data-test="reset-btn"]',
+    ) as HTMLButtonElement;
+    expect(resetBtn.disabled).toBeTrue();
+
     component.buffer = 'foo: 2\n';
     fixture.detectChanges();
+    resetBtn = fixture.nativeElement.querySelector(
+      'button[data-test="reset-btn"]',
+    ) as HTMLButtonElement;
+    expect(resetBtn.disabled).toBeFalse();
 
-    component.onCancelClick();
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.message as string).toContain('Discard unsaved changes');
-
-    // Accept → revert.
-    args.accept!();
-    expect(component.buffer).toBe('foo: 1\n');
-    expect(component.mode).toBe('view');
+    component.saving = true;
+    fixture.detectChanges();
+    resetBtn = fixture.nativeElement.querySelector(
+      'button[data-test="reset-btn"]',
+    ) as HTMLButtonElement;
+    expect(resetBtn.disabled).toBeTrue();
   });
 
-  it('(11.3 AC3) onCancelClick with dirty buffer — dismiss leaves state unchanged', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  // ----- Clone enablement (AC10) -----
+
+  it('(22.1 AC10) Clone enabled when clean, disabled when dirty', async () => {
+    await loaded('foo: 1\n');
+
+    let cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(cloneBtn.disabled).toBeFalse();
+
     component.buffer = 'foo: 2\n';
     fixture.detectChanges();
+    cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(cloneBtn.disabled).toBeTrue();
+  });
 
-    component.onCancelClick();
-    // Simulate dismiss: call reject if present, else just don't call accept.
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    if (args.reject) {
-      args.reject();
-    }
+  it('(22.1 AC10) Clone disabled while cloning and while FR14-gated (clean state)', async () => {
+    await loaded('foo: 1\n');
 
-    expect(component.buffer).toBe('foo: 2\n');
-    expect(component.mode).toBe('edit');
+    component.cloning = true;
+    fixture.detectChanges();
+    let cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(cloneBtn.disabled).toBeTrue();
+
+    component.cloning = false;
+    component.lastValidation = failingReport(1);
+    fixture.detectChanges();
+    cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(cloneBtn.disabled).toBeTrue();
+  });
+
+  // ----- Delete enablement (AC11) -----
+
+  it('(22.1 AC11) Delete enabled by default, disabled only while deleting', async () => {
+    await loaded('foo: 1\n');
+
+    let deleteBtn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    ) as HTMLButtonElement;
+    expect(deleteBtn.disabled).toBeFalse();
+
+    component.deleting = true;
+    fixture.detectChanges();
+    deleteBtn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    ) as HTMLButtonElement;
+    expect(deleteBtn.disabled).toBeTrue();
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.3 — Save direct-to-import, NOT via validate (AC 5)
+  // ADR-017 §2/§6 — Save flow (gate, drift check, success, errors).
   // ---------------------------------------------------------------------
 
-  it('(11.3 AC5) Save posts buffer directly to importNamespace — validateNamespaceBuffer NOT called', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC12) onSaveClick is a no-op when clean (gated on hasUnsavedChanges)', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+  });
+
+  it('(22.1 AC12) Save posts buffer directly to importNamespace — validateNamespaceBuffer NOT called', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+    // Drift re-export returns the same server YAML → no prompt.
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
 
     await component.onSaveClick();
 
@@ -427,35 +598,39 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Save 2xx success path (AC 6)
-  // ---------------------------------------------------------------------
-
-  it('(11.3 AC6) Save 2xx — serverYaml updates, mode flips to view, saved.emit + success toast', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC13) Save 2xx — serverYaml updates, saved.emit + success toast + a11y, panel becomes clean', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     const savedEmit = spyOn(component.saved, 'emit');
 
     await component.onSaveClick();
 
     expect(component.serverYaml).toBe('foo: 2\n');
-    expect(component.mode).toBe('view');
     expect(component.saving).toBe(false);
+    expect(component.hasUnsavedChanges()).toBe(false);
+    expect(component.a11yAnnouncement).toBe('Namespace saved');
     expect(savedEmit).toHaveBeenCalledTimes(1);
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('success');
+
+    // Now clean → Save/Reset disabled, Clone enabled.
+    fixture.detectChanges();
+    const saveBtn = fixture.nativeElement.querySelector(
+      'button[data-test="save-btn"]',
+    ) as HTMLButtonElement;
+    const cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBeTrue();
+    expect(cloneBtn.disabled).toBeFalse();
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Save 422 structured (AC 7)
-  // ---------------------------------------------------------------------
-
-  it('(11.3 AC7) Save 422 structured — lastValidation populated, mode stays edit, buffer preserved', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC13) Save 422 structured — lastValidation populated, buffer preserved', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     const report: NamespaceValidationReport = {
       namespace: 'foo',
       ok: false,
@@ -468,18 +643,16 @@ describe('NamespacePanelComponent', () => {
 
     await component.onSaveClick();
 
-    expect(component.mode).toBe('edit');
     expect(component.buffer).toBe('foo: 2\n');
     expect(component.saving).toBe(false);
     expect(component.lastValidation).toEqual(report);
     expect(component.rawSaveError).toBeNull();
   });
 
-  it('(11.3 AC7) Save 422 unstructured — rawSaveError populated, lastValidation null', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC13) Save 422 unstructured — rawSaveError populated, lastValidation null', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
-    // FastAPI-style error body — does NOT match NamespaceValidationReport.
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     const rawBody = { detail: [{ msg: 'field required', loc: ['body'] }] };
     apiSpy.importNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, rawBody)),
@@ -489,97 +662,90 @@ describe('NamespacePanelComponent', () => {
 
     expect(component.lastValidation).toBeNull();
     expect(component.rawSaveError).toContain('field required');
-    expect(component.mode).toBe('edit');
     expect(component.buffer).toBe('foo: 2\n');
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Save 5xx failure path (AC 8)
-  // Retry affordance is the regular Save button itself — re-click retries.
-  // The dedicated "Retry Save" action-row button from the first 11.3 draft
-  // was removed as redundant; Save stays enabled (buffer still dirty) so
-  // clicking it again IS the retry. Toast is sticky so the outcome is
-  // visible post-dismiss.
-  // ---------------------------------------------------------------------
-
-  it('(11.3 AC8) Save 5xx — sticky toast; re-clicking Save retries with the same buffer', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC12) Save 5xx — sticky toast; re-clicking Save retries with the same buffer', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     apiSpy.importNamespace.and.returnValue(Promise.reject(makeHttpError(500)));
 
     await component.onSaveClick();
 
-    expect(component.mode).toBe('edit');
     expect(component.buffer).toBe('foo: 2\n');
     expect(component.saving).toBe(false);
-
-    // Sticky error toast fired.
     const errorToast = messageSpy.add.calls.mostRecent().args[0];
     expect(errorToast.severity).toBe('error');
     expect(errorToast.sticky).toBeTrue();
 
-    // No dedicated Retry Save button renders — removed as redundant with Save.
+    // No dedicated Retry button renders.
     fixture.detectChanges();
     const retryBtn = fixture.nativeElement.querySelector(
       'button[data-test="retry-save-btn"]',
     ) as HTMLButtonElement | null;
     expect(retryBtn).toBeNull();
 
-    // Save button stays enabled (buffer still !== serverYaml, not saving).
+    // Save still enabled (dirty, not saving).
     const saveBtn = fixture.nativeElement.querySelector(
       'button[data-test="save-btn"]',
     ) as HTMLButtonElement;
     expect(saveBtn.disabled).toBeFalse();
 
-    // Second click — this time a 2xx success — retries with the same buffer.
+    // Second click — 2xx — retries with the same buffer.
     apiSpy.importNamespace.calls.reset();
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
     await component.onSaveClick();
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
   });
 
-  it('(11.3 AC8) Save 500 does NOT auto-invoke importNamespace a second time', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC12) Save 500 does NOT auto-invoke importNamespace a second time', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     apiSpy.importNamespace.and.returnValue(Promise.reject(makeHttpError(500)));
 
     await component.onSaveClick();
-    // No further calls until the operator explicitly clicks Retry.
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
   });
 
-  // ---------------------------------------------------------------------
-  // Post-review guardrail — refuse to Save when the buffer's namespace
-  // field has been edited away from the panel's namespace (use Clone).
-  // ---------------------------------------------------------------------
-
-  it('Save refuses when buffer namespace has been edited — shows error toast, no import', async () => {
-    // Load a bundle whose root namespace matches the panel's namespace.
-    await loadedEditMode('namespace: foo\nuser_id: null\nentries: {}\n');
-    await component.onEditClick();
-    // Operator edits the namespace field to something else.
-    component.buffer = 'namespace: bar\nuser_id: null\nentries: {}\n';
+  it('(22.1 AC9) Save 401 — no panel toast, buffer preserved, saving resets', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.reject(makeHttpError(401)));
 
     await component.onSaveClick();
 
-    // Import must NOT have fired.
-    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    expect(component.buffer).toBe('foo: 2\n');
+    expect(component.saving).toBe(false);
+    expect(messageSpy.add).not.toHaveBeenCalled();
+  });
 
-    // A sticky error toast with the namespace-change guardrail message
-    // was surfaced.
-    expect(messageSpy.add).toHaveBeenCalled();
+  // ----- Save buffer-namespace guard preserved (AC12) -----
+
+  it('(22.1 AC12) Save refuses when buffer namespace has been edited — error toast, no import, no drift export', async () => {
+    await loaded('namespace: foo\nuser_id: null\nentries: {}\n');
+    component.buffer = 'namespace: bar\nuser_id: null\nentries: {}\n';
+    apiSpy.exportNamespace.calls.reset();
+
+    await component.onSaveClick();
+
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    // The guard fires before the drift re-export.
+    expect(apiSpy.exportNamespace).not.toHaveBeenCalled();
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('error');
     expect(toast.sticky).toBeTrue();
     expect(toast.detail).toContain('Clone');
   });
 
-  it('Save proceeds when the buffer namespace matches the panel namespace (guardrail is a no-op)', async () => {
-    await loadedEditMode('namespace: foo\nuser_id: null\nentries: {}\n');
-    await component.onEditClick();
+  it('(22.1 AC12) Save proceeds when the buffer namespace matches (guard is a no-op)', async () => {
+    await loaded('namespace: foo\nuser_id: null\nentries: {}\n');
     component.buffer = 'namespace: foo\nuser_id: null\nentries:\n  x: 1\n';
+    apiSpy.exportNamespace.and.returnValue(
+      Promise.resolve('namespace: foo\nuser_id: null\nentries: {}\n'),
+    );
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     await component.onSaveClick();
@@ -587,11 +753,12 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
   });
 
-  it('Save falls through the guardrail when the buffer is unparseable — server decides', async () => {
-    await loadedEditMode('namespace: foo\nuser_id: null\nentries: {}\n');
-    await component.onEditClick();
-    // Unparseable YAML — our helper returns null, guardrail skips.
+  it('(22.1 AC12) Save falls through the guard when the buffer is unparseable — server decides', async () => {
+    await loaded('namespace: foo\nuser_id: null\nentries: {}\n');
     component.buffer = 'namespace: foo\nentries: [\n  unclosed\n';
+    apiSpy.exportNamespace.and.returnValue(
+      Promise.resolve('namespace: foo\nuser_id: null\nentries: {}\n'),
+    );
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     await component.onSaveClick();
@@ -599,17 +766,15 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
   });
 
-  // ---------------------------------------------------------------------
-  // Story 14.3 — Advisory owner-or-admin pre-flight guard on Edit-Save.
-  // The buffer's namespace MUST match the panel's (`foo`) so the existing
-  // namespace-change guard is a no-op and the ownership guard is reached.
-  // ---------------------------------------------------------------------
+  // ----- Advisory owner-or-admin pre-flight preserved (AC12) -----
 
-  it('(14.3 AC2/AC10) owner can Save — import fires, no owner-block toast', async () => {
+  it('(22.1 AC12 / 14.3) owner can Save — import fires, no owner-block toast', async () => {
     authStub.currentUserValue = { user_id: 'alice', roles: [] };
-    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
-    await component.onEditClick();
+    await loaded('namespace: foo\nuser_id: alice\nentries: {}\n');
     component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
+    apiSpy.exportNamespace.and.returnValue(
+      Promise.resolve('namespace: foo\nuser_id: alice\nentries: {}\n'),
+    );
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     await component.onSaveClick();
@@ -621,10 +786,9 @@ describe('NamespacePanelComponent', () => {
     expect(ownerBlocked).toBeFalse();
   });
 
-  it('(14.3 AC1/AC4/AC11) non-owner non-admin is blocked — no import, sticky toast, stays edit', async () => {
+  it('(22.1 AC12 / 14.3) non-owner non-admin is blocked — no import, sticky toast', async () => {
     authStub.currentUserValue = { user_id: 'bob', roles: [] };
-    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
-    await component.onEditClick();
+    await loaded('namespace: foo\nuser_id: alice\nentries: {}\n');
     component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
@@ -635,65 +799,26 @@ describe('NamespacePanelComponent', () => {
     expect(toast.severity).toBe('error');
     expect(toast.sticky).toBeTrue();
     expect(toast.summary).toBe('Cannot save changes to this namespace');
-    expect(component.mode).toBe('edit');
     expect(component.saving).toBeFalse();
   });
 
-  it('(14.3 AC3/AC12) admin can Save another user\'s namespace — import fires, no block', async () => {
+  it('(22.1 AC12 / 14.3) admin can Save another user\'s namespace — import fires', async () => {
     authStub.currentUserValue = { user_id: 'bob', roles: ['admin'] };
-    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
-    await component.onEditClick();
+    await loaded('namespace: foo\nuser_id: alice\nentries: {}\n');
     component.buffer = 'namespace: foo\nuser_id: alice\nentries:\n  x: 1\n';
+    apiSpy.exportNamespace.and.returnValue(
+      Promise.resolve('namespace: foo\nuser_id: alice\nentries: {}\n'),
+    );
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     await component.onSaveClick();
 
     expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
-    const ownerBlocked = messageSpy.add.calls
-      .allArgs()
-      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
-    expect(ownerBlocked).toBeFalse();
   });
 
-  it('(14.3 AC5/AC13) community anonymous can Save anonymous-owned namespace — no block', async () => {
-    authStub.currentUserValue = { user_id: 'anonymous' };
-    await loadedEditMode('namespace: foo\nuser_id: anonymous\nentries: {}\n');
-    await component.onEditClick();
-    component.buffer = 'namespace: foo\nuser_id: anonymous\nentries:\n  x: 1\n';
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-
-    await component.onSaveClick();
-
-    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
-    const ownerBlocked = messageSpy.add.calls
-      .allArgs()
-      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
-    expect(ownerBlocked).toBeFalse();
-  });
-
-  it('(14.3 AC7/AC14) unresolvable owner defers to server for non-admin — import fires', async () => {
+  it('(22.1 AC12 / 14.3) namespace-change guard still wins over ownership guard', async () => {
     authStub.currentUserValue = { user_id: 'bob', roles: [] };
-    // No root user_id → extractYamlUserId returns null → fall through.
-    await loadedEditMode('namespace: foo\nentries: {}\n');
-    await component.onEditClick();
-    component.buffer = 'namespace: foo\nentries:\n  x: 1\n';
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-
-    await component.onSaveClick();
-
-    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
-    const ownerBlocked = messageSpy.add.calls
-      .allArgs()
-      .some((args) => args[0]?.summary === 'Cannot save changes to this namespace');
-    expect(ownerBlocked).toBeFalse();
-  });
-
-  it('(14.3 AC8/AC15) namespace-change guard still wins over ownership guard', async () => {
-    // Non-owner AND namespace changed — the namespace-change guard fires
-    // first with its own message; the ownership message is never reached.
-    authStub.currentUserValue = { user_id: 'bob', roles: [] };
-    await loadedEditMode('namespace: foo\nuser_id: alice\nentries: {}\n');
-    await component.onEditClick();
+    await loaded('namespace: foo\nuser_id: alice\nentries: {}\n');
     component.buffer = 'namespace: bar\nuser_id: alice\nentries: {}\n';
 
     await component.onSaveClick();
@@ -701,66 +826,107 @@ describe('NamespacePanelComponent', () => {
     expect(apiSpy.importNamespace).not.toHaveBeenCalled();
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.summary).toBe('Cannot change namespace on Save');
-    expect(toast.severity).toBe('error');
-    expect(toast.sticky).toBeTrue();
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Save 401 silent (AC 9)
-  // ---------------------------------------------------------------------
+  // ----- Save drift check (AC20, AC21) -----
 
-  it('(11.3 AC9) Save 401 — no panel toast, mode stays edit, saving resets', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC20/AC21) Save with a matching server export imports without a drift prompt', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
-    apiSpy.importNamespace.and.returnValue(Promise.reject(makeHttpError(401)));
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     await component.onSaveClick();
 
-    expect(component.mode).toBe('edit');
+    // Drift re-export ran (one extra export beyond the mount load) but no
+    // confirm was shown.
+    expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
+  });
+
+  it('(22.1 AC20/AC21) Save with diverged server export prompts; reload-and-rebase skips the import and rebases', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    // Server has drifted since load.
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    const savePromise = component.onSaveClick();
+    // Let the drift re-export resolve so the confirm fires.
+    await flushMicrotasks();
+    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    expect(args.header).toBe('Namespace modified');
+
+    // accept = reload-and-rebase.
+    args.accept!();
+    await savePromise;
+
+    // Import was NOT performed this click.
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    // serverYaml rebased to the latest; buffer kept the operator's edit
+    // (it had diverged from the old serverYaml, so it is preserved).
+    expect(component.serverYaml).toBe('foo: server\n');
     expect(component.buffer).toBe('foo: 2\n');
-    expect(component.saving).toBe(false);
-    // The panel's handler must not add its own toast — the global toast
-    // already fires via FetchService.
-    expect(messageSpy.add).not.toHaveBeenCalled();
+    expect(component.saving).toBeFalse();
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — hasUnsavedChanges four-state matrix (AC 11)
-  // ---------------------------------------------------------------------
-
-  it('(11.3 AC11) hasUnsavedChanges truth table (view+clean, view+dirty, edit+clean, edit+dirty)', async () => {
-    await loadedEditMode('foo: 1\n');
-
-    // view + clean buffer.
-    expect(component.mode).toBe('view');
-    expect(component.buffer).toBe(component.serverYaml);
-    expect(component.hasUnsavedChanges()).toBe(false);
-
-    // view + dirty buffer — mode gate means still false.
+  it('(22.1 AC21) drift reload-and-rebase moves the buffer when it still equalled the old serverYaml', async () => {
+    await loaded('foo: 1\n');
+    // Force a dirty gate so onSaveClick runs, but keep buffer === old
+    // serverYaml at the moment the rebase fires by reverting after dirtying.
     component.buffer = 'foo: 2\n';
-    expect(component.hasUnsavedChanges()).toBe(false);
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
 
-    // Reset for edit cases.
-    component.buffer = component.serverYaml;
+    const savePromise = component.onSaveClick();
+    await flushMicrotasks();
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    // Simulate buffer back at the old serverYaml right before accept.
+    component.buffer = 'foo: 1\n';
+    args.accept!();
+    await savePromise;
 
-    // edit + clean.
-    await component.onEditClick();
-    expect(component.hasUnsavedChanges()).toBe(false);
-
-    // edit + dirty.
-    component.buffer = 'foo: 2\n';
-    expect(component.hasUnsavedChanges()).toBe(true);
+    expect(component.serverYaml).toBe('foo: server\n');
+    // buffer equalled the OLD serverYaml → moved to the fresh server YAML.
+    expect(component.buffer).toBe('foo: server\n');
   });
 
-  // ---------------------------------------------------------------------
-  // Story 11.3 — Destroy-during-save (AC 13)
-  // ---------------------------------------------------------------------
-
-  it('(11.3 AC13) destroy-during-save — late-resolving import does not write state', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC21) Save with diverged server export — overwrite choice proceeds with the operator buffer', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    const savePromise = component.onSaveClick();
+    await flushMicrotasks();
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    // reject = overwrite → import proceeds with the operator's buffer.
+    args.reject!();
+    await savePromise;
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
+    expect(component.serverYaml).toBe('foo: 2\n');
+  });
+
+  it('(22.1 AC21) drift export network error falls through to import (non-blocking)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.reject(new Error('net')));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
+  });
+
+  // ----- Destroy-during-save (AC13) -----
+
+  it('(22.1) destroy-during-save — late-resolving import does not write state', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     let resolveLate!: (value: unknown) => void;
     apiSpy.importNamespace.and.returnValue(
       new Promise<unknown>((r) => {
@@ -770,6 +936,9 @@ describe('NamespacePanelComponent', () => {
 
     const consoleErrorSpy = spyOn(console, 'error');
     const savePromise = component.onSaveClick();
+    // Drain the drift re-export microtask so importNamespace is reached.
+    await Promise.resolve();
+    await Promise.resolve();
     expect(component.saving).toBe(true);
 
     fixture.destroy();
@@ -778,14 +947,49 @@ describe('NamespacePanelComponent', () => {
     await savePromise;
     await Promise.resolve();
 
-    // No state writes on the destroyed instance.
     expect(component.serverYaml).toBe('foo: 1\n');
-    expect(component.mode).toBe('edit');
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.4 — Validate flows (buttons, handlers, state, errors)
+  // ADR-017 §2 — Reset is the only undo (AC14, AC15).
+  // ---------------------------------------------------------------------
+
+  it('(22.1 AC14) onCancelClick is removed from the component', async () => {
+    await loaded('foo: 1\n');
+    expect(
+      (component as unknown as { onCancelClick?: unknown }).onCancelClick,
+    ).toBeUndefined();
+  });
+
+  it('(22.1 AC15) onResetClick reverts behind the confirm, clearing validation state', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+    component.rawSaveError = 'raw';
+
+    component.onResetClick();
+    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
+    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
+    expect(args.message as string).toContain('Discard unsaved changes');
+
+    args.accept!();
+    expect(component.buffer).toBe('foo: 1\n');
+    expect(component.lastValidation).toBeNull();
+    expect(component.rawSaveError).toBeNull();
+    expect(component.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('(22.1 AC15) onResetClick is a no-op when clean (no confirm)', async () => {
+    await loaded('foo: 1\n');
+
+    component.onResetClick();
+
+    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------
+  // ADR-017 §4 — single Validate handler (AC17, AC18).
   // ---------------------------------------------------------------------
 
   function cleanReport(namespace = 'foo'): NamespaceValidationReport {
@@ -797,106 +1001,31 @@ describe('NamespacePanelComponent', () => {
     };
   }
 
-  // ----- Button visibility per mode (AC 1 / AC 3) -----
-
-  it('(11.4 AC1) Validate-persisted button visible in view mode, hidden in edit', async () => {
-    await loadedEditMode('foo: 1\n');
-
-    let viewBtn = fixture.nativeElement.querySelector(
-      'button[data-test="validate-persisted-btn"]',
-    );
-    expect(viewBtn).not.toBeNull();
-
-    await component.onEditClick();
-    fixture.detectChanges();
-
-    viewBtn = fixture.nativeElement.querySelector(
-      'button[data-test="validate-persisted-btn"]',
-    );
-    expect(viewBtn).toBeNull();
+  it('(22.1 AC17) onValidatePersistedClick is removed; onValidateBufferClick is the single handler', async () => {
+    await loaded('foo: 1\n');
+    expect(
+      (component as unknown as { onValidatePersistedClick?: unknown })
+        .onValidatePersistedClick,
+    ).toBeUndefined();
+    expect(typeof component.onValidateBufferClick).toBe('function');
   });
 
-  it('(11.4 AC3) Validate-buffer button visible in edit mode, hidden in view', async () => {
-    await loadedEditMode('foo: 1\n');
-
-    let editBtn = fixture.nativeElement.querySelector(
-      'button[data-test="validate-buffer-btn"]',
-    );
-    expect(editBtn).toBeNull();
-
-    await component.onEditClick();
-    fixture.detectChanges();
-
-    editBtn = fixture.nativeElement.querySelector(
-      'button[data-test="validate-buffer-btn"]',
-    );
-    expect(editBtn).not.toBeNull();
-  });
-
-  // ----- Validate-persisted click — AC 2 -----
-
-  it('(11.4 AC2) onValidatePersistedClick calls validatePersistedNamespace exactly once; clean report hides pane and flashes the view-mode button', async () => {
-    await loadedEditMode('foo: 1\n');
-    const report = cleanReport();
-    apiSpy.validatePersistedNamespace.and.returnValue(Promise.resolve(report));
-
-    await component.onValidatePersistedClick();
-
-    expect(apiSpy.validatePersistedNamespace).toHaveBeenCalledOnceWith('foo');
-    // Clean reports no longer render the "Validation passed" pane — the
-    // button-flash UX replaces it. `lastValidation` stays null.
-    expect(component.lastValidation).toBeNull();
-    expect(component.validationFlashPersisted).toBeTrue();
-    expect(component.validationFlashBuffer).toBeFalse();
-    // Save's fallback field stays untouched.
-    expect(component.rawSaveError).toBeNull();
-    // No other ApiService spy invoked on this path (beyond the load's export).
-    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
-    expect(apiSpy.validateNamespaceBuffer).not.toHaveBeenCalled();
-  });
-
-  it('onValidatePersistedClick non-clean report still populates lastValidation (findings pane renders)', async () => {
-    await loadedEditMode('foo: 1\n');
-    const report: NamespaceValidationReport = {
-      namespace: 'foo',
-      ok: false,
-      global_errors: ['schema mismatch'],
-      entry_issues: [],
-    };
-    apiSpy.validatePersistedNamespace.and.returnValue(Promise.resolve(report));
-
-    await component.onValidatePersistedClick();
-
-    expect(component.lastValidation).toEqual(report);
-    expect(component.validationFlashPersisted).toBeFalse();
-  });
-
-  it('clean-report flash on Validate auto-reverts after 2500ms', fakeAsync(() => {
-    void buildFixture('foo');
-    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
-    apiSpy.validatePersistedNamespace.and.returnValue(
+  it('(22.1 AC17) Validate validates the buffer via validateNamespaceBuffer; clean state equals persisted', async () => {
+    await loaded('foo: 1\n');
+    // Clean: buffer === serverYaml, so the buffer-validate equals a
+    // persisted-validate.
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(cleanReport()),
     );
-    fixture.detectChanges();
-    tick();
 
-    void component.onValidatePersistedClick();
-    tick();
-    expect(component.validationFlashPersisted).toBeTrue();
-    // Halfway through the window — still flashing.
-    tick(1000);
-    expect(component.validationFlashPersisted).toBeTrue();
-    // Past the 2500ms window — flag auto-reverts.
-    tick(1600);
-    expect(component.validationFlashPersisted).toBeFalse();
-    expect(component.validationFlashBuffer).toBeFalse();
-  }));
+    await component.onValidateBufferClick();
 
-  // ----- Validate-buffer click — AC 4 -----
+    expect(apiSpy.validateNamespaceBuffer).toHaveBeenCalledOnceWith('foo: 1\n');
+    expect(apiSpy.validatePersistedNamespace).not.toHaveBeenCalled();
+  });
 
-  it('(11.4 AC4) onValidateBufferClick passes snapshot-at-click buffer; live edits post-click do NOT change args', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC17) Validate passes snapshot-at-click buffer; live edits post-click do NOT change args', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
 
     let resolveValidate!: (v: NamespaceValidationReport) => void;
@@ -907,25 +1036,65 @@ describe('NamespacePanelComponent', () => {
     );
 
     const validatePromise = component.onValidateBufferClick();
-    // Simulate user typing AFTER click but BEFORE the promise resolves.
     component.buffer = 'foo: 99\n';
-
     resolveValidate(cleanReport());
     await validatePromise;
 
-    // Spy was called with the pre-edit (snapshot-at-click) buffer.
     expect(apiSpy.validateNamespaceBuffer).toHaveBeenCalledOnceWith('foo: 2\n');
-    // Clean report → pane hidden, edit-mode button flashes `success`.
     expect(component.lastValidation).toBeNull();
     expect(component.validationFlashBuffer).toBeTrue();
-    expect(component.validationFlashPersisted).toBeFalse();
-    // Validate never mutates buffer; the live edit is still present.
     expect(component.buffer).toBe('foo: 99\n');
   });
 
-  it('editing the buffer after a clean Validate-buffer clears the flash immediately', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC18) clean report flashes the Validate button green and announces; pane stays hidden', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.validateNamespaceBuffer.and.returnValue(
+      Promise.resolve(cleanReport()),
+    );
+
+    await component.onValidateBufferClick();
+    fixture.detectChanges();
+
+    expect(component.lastValidation).toBeNull();
+    expect(component.validationFlashBuffer).toBeTrue();
+    expect(component.a11yAnnouncement).toBe('Validation passed');
+    const validateBtn = fixture.nativeElement.querySelector(
+      'button[data-test="validate-btn"]',
+    ) as HTMLButtonElement;
+    expect(validateBtn.classList.contains('p-button-success')).toBeTrue();
+  });
+
+  it('(22.1 AC18) non-clean report populates lastValidation (findings pane renders)', async () => {
+    await loaded('foo: 1\n');
+    const report = failingReport(1, 0);
+    apiSpy.validateNamespaceBuffer.and.returnValue(Promise.resolve(report));
+
+    await component.onValidateBufferClick();
+
+    expect(component.lastValidation).toEqual(report);
+    expect(component.validationFlashBuffer).toBeFalse();
+  });
+
+  it('(22.1 AC18) clean-report flash auto-reverts after 2500ms', fakeAsync(() => {
+    void buildFixture('foo');
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
+    apiSpy.validateNamespaceBuffer.and.returnValue(
+      Promise.resolve(cleanReport()),
+    );
+    fixture.detectChanges();
+    tick();
+
+    void component.onValidateBufferClick();
+    tick();
+    expect(component.validationFlashBuffer).toBeTrue();
+    tick(1000);
+    expect(component.validationFlashBuffer).toBeTrue();
+    tick(1600);
+    expect(component.validationFlashBuffer).toBeFalse();
+  }));
+
+  it('(22.1 AC18) editing the buffer after a clean Validate clears the flash immediately', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(cleanReport()),
@@ -934,32 +1103,14 @@ describe('NamespacePanelComponent', () => {
     await component.onValidateBufferClick();
     expect(component.validationFlashBuffer).toBeTrue();
 
-    // User edits the YAML after the clean ack — the green state is now
-    // stale, the button must revert to secondary immediately rather than
-    // linger until the 2500ms timer elapses.
     component.onBufferChange('foo: 2\n# edited\n');
 
     expect(component.buffer).toBe('foo: 2\n# edited\n');
     expect(component.validationFlashBuffer).toBeFalse();
   });
 
-  it('editing buffer does NOT clear the flash on the view-mode persisted button (persisted validates server state, not buffer)', async () => {
-    await loadedEditMode('foo: 1\n');
-    apiSpy.validatePersistedNamespace.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-    await component.onValidatePersistedClick();
-    expect(component.validationFlashPersisted).toBeTrue();
-
-    // Even if buffer changes (e.g. user flips to edit later), the persisted
-    // flash is not bound to the buffer — it stays.
-    component.onBufferChange('foo: 99\n');
-    expect(component.validationFlashPersisted).toBeTrue();
-  });
-
-  it('(11.4 AC4) Validate-buffer does NOT mutate mode, serverYaml, buffer, or call importNamespace', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(22.1 AC17) Validate does NOT mutate serverYaml/buffer or call importNamespace', async () => {
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(cleanReport()),
@@ -967,263 +1118,112 @@ describe('NamespacePanelComponent', () => {
 
     await component.onValidateBufferClick();
 
-    expect(component.mode).toBe('edit');
     expect(component.buffer).toBe('foo: 2\n');
     expect(component.serverYaml).toBe('foo: 1\n');
     expect(apiSpy.importNamespace).not.toHaveBeenCalled();
     expect(component.rawSaveError).toBeNull();
   });
 
-  // ----- Validate does not gate Save — AC 5 -----
-
-  it('(11.4 AC5 + 11.7 AC1) Validate is not a Save trigger; a CLEAN report leaves Save enabled, importNamespace never called by Validate', async () => {
-    // Story 11.4 AC 5 — Validate flow MUST NOT call importNamespace.
-    // Story 11.7 AC 1 amends the post-Validate state: a FAILING report
-    // populates `lastValidation.ok === false` which gates Save via FR14.
-    // This test asserts the CLEAN-report variant where the Validate-Save
-    // independence still holds (no auto-Save, gate stays open).
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    fixture.detectChanges();
-
+  it('(22.1 AC18) Validate 422 structured → findings pane, no toast', async () => {
+    await loaded('foo: 1\n');
+    const report = failingReport(1, 0);
     apiSpy.validateNamespaceBuffer.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-
-    await component.onValidateBufferClick();
-    fixture.detectChanges();
-
-    // Save button still enabled (buffer !== serverYaml, saving === false,
-    // gate is not active because the report was clean).
-    const saveBtn = fixture.nativeElement.querySelector(
-      'button[data-test="save-btn"]',
-    ) as HTMLButtonElement;
-    expect(saveBtn.disabled).toBeFalse();
-    expect(component.isSaveGated).toBeFalse();
-    // importNamespace never invoked by the validate path.
-    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
-  });
-
-  // ----- lastValidation preserved across mode flips — AC 10 -----
-
-  it('(11.4 AC10) onEditClick does NOT mutate lastValidation (view → edit)', async () => {
-    await loadedEditMode('foo: 1\n');
-    const prior = cleanReport();
-    component.lastValidation = prior;
-
-    await component.onEditClick();
-
-    expect(component.mode).toBe('edit');
-    expect(component.lastValidation).toBe(prior);
-  });
-
-  it('(11.4 AC10) onCancelClick dirty-accept does NOT mutate lastValidation', async () => {
-    await loadedEditMode('foo: 1\n');
-    const prior = cleanReport();
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = prior;
-
-    component.onCancelClick();
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    args.accept!();
-
-    expect(component.mode).toBe('view');
-    expect(component.lastValidation).toBe(prior);
-  });
-
-  it('(11.4 AC10) onCancelClick clean-flip does NOT mutate lastValidation', async () => {
-    await loadedEditMode('foo: 1\n');
-    const prior = cleanReport();
-    await component.onEditClick();
-    // Clean buffer — direct flip, no confirm.
-    component.lastValidation = prior;
-
-    component.onCancelClick();
-
-    expect(component.mode).toBe('view');
-    expect(component.lastValidation).toBe(prior);
-  });
-
-  // ----- Validate 422 with structured body → findings rendered (no toast) -----
-
-  it('Validate 422 with NamespaceValidationReport body populates lastValidation (findings pane, no toast)', async () => {
-    await loadedEditMode('foo: 1\n');
-    const report: NamespaceValidationReport = {
-      namespace: 'foo',
-      ok: false,
-      global_errors: ["bundle root missing required key 'entries'"],
-      entry_issues: [],
-    };
-    apiSpy.validatePersistedNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, report)),
     );
 
-    await component.onValidatePersistedClick();
+    await component.onValidateBufferClick();
 
     expect(component.lastValidation).toEqual(report);
-    // No error toast — the pane is the UI for findings.
     expect(messageSpy.add).not.toHaveBeenCalled();
-    expect(component.validationFlashPersisted).toBeFalse();
   });
 
-  it('Validate 422 with non-report body falls through to the generic toast', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(22.1 AC18) Validate 422 non-report → generic toast', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'garbage: [\n';
     apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.reject(makeHttpError(422, 'yaml parse error at line 5')),
     );
-    await component.onEditClick();
-    component.buffer = 'garbage: [\n';
 
     await component.onValidateBufferClick();
 
-    // lastValidation untouched (no structured report to render).
     expect(component.lastValidation).toBeNull();
-    // Generic error toast fired instead.
     expect(messageSpy.add).toHaveBeenCalled();
   });
 
-  it('Validate resolved to undefined (network fallback) throws a clear toast, not TypeError', async () => {
-    await loadedEditMode('foo: 1\n');
-    // Simulate FetchService's network-fallback branch (returns undefined).
-    apiSpy.validatePersistedNamespace.and.returnValue(
+  it('(22.1 AC18) Validate resolved to undefined → clear toast, not TypeError', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(undefined as unknown as NamespaceValidationReport),
     );
 
-    await component.onValidatePersistedClick();
+    await component.onValidateBufferClick();
 
-    expect(messageSpy.add).toHaveBeenCalled();
     const call = messageSpy.add.calls.mostRecent().args[0];
     expect(call.summary).toBe('Validation failed');
-    // The detail must NOT be the cryptic TypeError message.
     expect(call.detail).not.toContain("reading 'ok'");
-    expect(component.validationFlashPersisted).toBeFalse();
   });
 
-  // ----- Validate 5xx → toast, state unchanged — AC 11 -----
-
-  it('(11.4 AC11) Validate 5xx — error toast, lastValidation unchanged, validating resets', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(22.1 AC18) Validate 5xx — error toast, lastValidation unchanged, validating resets', async () => {
+    await loaded('foo: 1\n');
     const prior = cleanReport();
     component.lastValidation = prior;
-    apiSpy.validatePersistedNamespace.and.returnValue(
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.reject(makeHttpError(500)),
     );
 
-    await component.onValidatePersistedClick();
+    await component.onValidateBufferClick();
 
     expect(component.lastValidation).toBe(prior);
     expect(component.validating).toBe(false);
-    expect(component.rawSaveError).toBeNull();
-    // One error toast fired (non-sticky).
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('error');
     expect(toast.summary).toBe('Validation failed');
     expect(toast.sticky).toBeFalsy();
   });
 
-  // ----- Validate 401 silent — AC 12 -----
-
-  it('(11.4 AC12) Validate 401 — no panel toast, state unchanged, validating resets', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(22.1 AC18) Validate 401 — no panel toast, state unchanged, validating resets', async () => {
+    await loaded('foo: 1\n');
     const prior = cleanReport();
     component.lastValidation = prior;
     messageSpy.add.calls.reset();
-    apiSpy.validatePersistedNamespace.and.returnValue(
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.reject(makeHttpError(401)),
     );
 
-    await component.onValidatePersistedClick();
+    await component.onValidateBufferClick();
 
     expect(component.lastValidation).toBe(prior);
     expect(component.validating).toBe(false);
-    expect(component.mode).toBe('view');
     expect(messageSpy.add).not.toHaveBeenCalled();
   });
 
-  // ----- Destroy-during-validate — AC 13 -----
-
-  it('(11.4 AC13) destroy-during-validate — late-resolving validate does not write state', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(22.1) destroy-during-validate — late-resolving validate does not write state', async () => {
+    await loaded('foo: 1\n');
     let resolveLate!: (v: NamespaceValidationReport) => void;
-    apiSpy.validatePersistedNamespace.and.returnValue(
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       new Promise<NamespaceValidationReport>((r) => {
         resolveLate = r;
       }),
     );
 
     const consoleErrorSpy = spyOn(console, 'error');
-    const validatePromise = component.onValidatePersistedClick();
+    const validatePromise = component.onValidateBufferClick();
     expect(component.validating).toBe(true);
 
     fixture.destroy();
 
-    resolveLate(cleanReport('bar'));
+    resolveLate(failingReport(1));
     await validatePromise;
     await Promise.resolve();
 
-    // lastValidation was not written post-destroy.
     expect(component.lastValidation).toBeNull();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  // ----- NFR7 — exact REST call budget — AC 14 -----
-
-  it('(11.4 AC14) NFR7 scenario — 2 export + 2 validate-persisted + 1 validate-buffer + 1 import = 6 calls', async () => {
-    // Arrange: load with exportSpy.
-    await loadedEditMode('foo: 1\n');
-    expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(1);
-
-    // Validate-persisted x2.
-    apiSpy.validatePersistedNamespace.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-    await component.onValidatePersistedClick();
-    await component.onValidatePersistedClick();
-
-    // Flip to edit, set dirty buffer, Validate-buffer x1.
-    // Post-review UX refinement — onEditClick now re-fetches the server
-    // namespace to detect drift; exportNamespace is called once more
-    // (returns the same YAML → no drift → immediate mode flip).
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    apiSpy.validateNamespaceBuffer.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-    await component.onValidateBufferClick();
-
-    // Save x1 (success).
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-    await component.onSaveClick();
-
-    // Tally.
-    expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
-    expect(apiSpy.validatePersistedNamespace).toHaveBeenCalledTimes(2);
-    expect(apiSpy.validateNamespaceBuffer).toHaveBeenCalledTimes(1);
-    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
-  });
-
-  // ----- editorOptions reference stability — AC 15 -----
-
-  it('(11.4 AC15) editorOptions is reference-stable on a stable mode (regression lock for the getter idiom)', async () => {
-    await loadedEditMode('foo: 1\n');
-    const first = component.editorOptions;
-    const second = component.editorOptions;
-    expect(first).toBe(second);
-
-    // Flipping mode creates exactly one new reference.
-    await component.onEditClick();
-    const afterEdit = component.editorOptions;
-    expect(afterEdit).not.toBe(first);
-    // And the field stays stable on that new mode too.
-    expect(component.editorOptions).toBe(afterEdit);
-  });
-
-  // ----- onClearValidationClick nulls both fields — AC 8 -----
+  // ----- onClearValidationClick nulls both fields -----
 
   it('(11.4 AC8) onClearValidationClick nulls lastValidation AND rawSaveError', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     component.lastValidation = cleanReport();
     component.rawSaveError = 'some raw';
 
@@ -1234,7 +1234,7 @@ describe('NamespacePanelComponent', () => {
   });
 
   it('(11.4 AC8) ValidationReportComponent clearRequested output triggers onClearValidationClick', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     component.lastValidation = cleanReport();
     component.rawSaveError = null;
     fixture.detectChanges();
@@ -1251,16 +1251,112 @@ describe('NamespacePanelComponent', () => {
   });
 
   // ---------------------------------------------------------------------
-  // Story 11.5 — Clone flow (AC 1–AC 16)
+  // ADR-017 §5 — FR14 gate retained, orthogonal to Validate (AC19).
   // ---------------------------------------------------------------------
 
-  /**
-   * Bundle YAML fixture used by the Clone-flow tests below. The bundle
-   * conforms to the v2 wire format: root `namespace` + `user_id` +
-   * `entries` map. `payload.description` deliberately mentions "src" so
-   * the rewrite helper's structured-rewrite contract is exercised — that
-   * string MUST NOT be touched.
-   */
+  /** A non-clean validation report with a known finding count. */
+  function failingReport(
+    globalCount = 1,
+    entryCount = 0,
+  ): NamespaceValidationReport {
+    return {
+      namespace: 'foo',
+      ok: false,
+      global_errors: Array.from(
+        { length: globalCount },
+        (_, i) => `global error ${i}`,
+      ),
+      entry_issues: Array.from({ length: entryCount }, (_, i) => ({
+        entry_id: `entry-${i}`,
+        kind: 'agent',
+        errors: ['bad'],
+      })),
+    };
+  }
+
+  it('(22.1 AC19) isSaveGated / isCloneGated retain their bodies (known-bad report or rawSaveError)', async () => {
+    await loaded('foo: 1\n');
+
+    expect(component.isSaveGated).toBeFalse();
+    expect(component.isCloneGated).toBeFalse();
+
+    component.lastValidation = failingReport(2, 0);
+    expect(component.isSaveGated).toBeTrue();
+    expect(component.isCloneGated).toBeTrue();
+
+    component.lastValidation = null;
+    component.rawSaveError = 'raw';
+    expect(component.isSaveGated).toBeTrue();
+    expect(component.isCloneGated).toBeTrue();
+  });
+
+  it('(22.1 AC19) onBufferChange clears rawSaveError unconditionally (gate auto-lifts)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = null;
+    component.rawSaveError = 'stale raw error';
+    expect(component.isSaveGated).toBeTrue();
+
+    component.onBufferChange('foo: 3\n');
+
+    expect(component.rawSaveError).toBeNull();
+    expect(component.isSaveGated).toBeFalse();
+    expect(component.isCloneGated).toBeFalse();
+  });
+
+  it('(22.1 AC19) onClearValidationClick lifts the gate', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+    component.rawSaveError = 'raw';
+    expect(component.isSaveGated).toBeTrue();
+
+    component.onClearValidationClick();
+
+    expect(component.isSaveGated).toBeFalse();
+    expect(component.isCloneGated).toBeFalse();
+  });
+
+  it('(22.1 AC19) a successful Save (2xx) lifts the gate', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    await component.onSaveClick();
+
+    expect(component.lastValidation).toBeNull();
+    expect(component.rawSaveError).toBeNull();
+    expect(component.serverYaml).toBe('foo: 2\n');
+    expect(component.isSaveGated).toBeFalse();
+  });
+
+  it('(22.1 AC19) saveTooltip/cloneTooltip describe the gate only when it is the active disable reason', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+
+    expect(component.saveTooltip).toBe('Fix validation issues before saving.');
+
+    // Clone tooltip surfaces in a clean state (Clone enabled only when clean).
+    component.buffer = component.serverYaml;
+    expect(component.cloneTooltip).toBe('Fix validation issues before cloning.');
+  });
+
+  it('(22.1 AC19) saveTooltip returns undefined when the gate is not the active disable reason', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = component.serverYaml; // clean — disabled by dirtiness
+    component.lastValidation = null;
+    component.rawSaveError = null;
+
+    expect(component.saveTooltip).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------
+  // Clone flow (ADR-012 modal unchanged; gated on clean — ADR-017 §3).
+  // ---------------------------------------------------------------------
+
   const cloneSrcYaml = `namespace: src
 user_id: null
 entries:
@@ -1282,56 +1378,18 @@ entries:
     fixture.detectChanges();
   }
 
-  // ----- Clone button visibility (AC 1) -----
-
-  it('(11.5 AC1) Clone button is visible in view mode', async () => {
+  it('(11.5 AC1) Clone button is present in the loaded (clean) state', async () => {
     await loadedWithCloneSrc();
     const btn = fixture.nativeElement.querySelector(
       'button[data-test="clone-btn"]',
-    );
+    ) as HTMLButtonElement;
     expect(btn).not.toBeNull();
+    expect(btn.disabled).toBeFalse();
   });
 
-  it('Clone button is hidden in edit mode (post-review UX refinement — Clone is view-mode only)', async () => {
-    await loadedWithCloneSrc();
-    await component.onEditClick();
-    fixture.detectChanges();
-    const btn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    );
-    expect(btn).toBeNull();
-  });
-
-  it('(11.5 AC1) Clone button is hidden while loading', async () => {
-    // Pending export — loading stays true.
-    apiSpy.exportNamespace.and.returnValue(new Promise<string>(() => {}));
-    await buildFixture('src');
-    fixture.detectChanges();
-    const btn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    );
-    expect(btn).toBeNull();
-  });
-
-  it('(11.5 AC1) Clone button is hidden in the empty / error state (serverYaml === "")', async () => {
-    apiSpy.exportNamespace.and.returnValue(Promise.reject(new Error('boom')));
-    await buildFixture('src');
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const btn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    );
-    expect(btn).toBeNull();
-  });
-
-  // ----- Clicking Clone opens the dialog (AC 2) -----
-
-  it('(11.5 AC2) onCloneClick opens the dialog without a network call', async () => {
+  it('(22.1 AC16) onCloneClick opens the dialog from a clean state without a network call', async () => {
     await loadedWithCloneSrc();
     const bufferBefore = component.buffer;
-    const modeBefore = component.mode;
     const serverYamlBefore = component.serverYaml;
     apiSpy.importNamespace.calls.reset();
 
@@ -1340,9 +1398,19 @@ entries:
 
     expect(component.cloneDialogVisible).toBeTrue();
     expect(component.buffer).toBe(bufferBefore);
-    expect(component.mode).toBe(modeBefore);
     expect(component.serverYaml).toBe(serverYamlBefore);
     expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+  });
+
+  it('(22.1 AC16) the outer Clone button is disabled while dirty', async () => {
+    await loadedWithCloneSrc();
+    component.buffer = cloneSrcYaml + '# dirty\n';
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBeTrue();
   });
 
   it('(11.5 AC2) onCloneClick is a no-op when cloning === true', async () => {
@@ -1355,9 +1423,9 @@ entries:
     expect(component.cloneDialogVisible).toBeFalse();
   });
 
-  // ----- Pre-flight dialog validation (AC 4) -----
+  // ----- Clone modal pre-flight validation (AC4) -----
 
-  it('(11.5 AC4) Confirm button disabled — empty destNs', async () => {
+  it('(11.5 AC4) Confirm disabled — empty destNs', async () => {
     await loadedWithCloneSrc();
     component.onCloneClick();
     component.cloneDestNs = '';
@@ -1369,7 +1437,7 @@ entries:
     );
   });
 
-  it('(11.5 AC4) Confirm button disabled — destNs equals source namespace', async () => {
+  it('(11.5 AC4) Confirm disabled — destNs equals source namespace', async () => {
     await loadedWithCloneSrc();
     component.onCloneClick();
     component.cloneDestNs = 'src';
@@ -1380,7 +1448,7 @@ entries:
     );
   });
 
-  it('(11.5 AC4) Confirm button disabled — destNs collides with existingNamespaces', async () => {
+  it('(11.5 AC4) Confirm disabled — destNs collides with existingNamespaces', async () => {
     await loadedWithCloneSrc(['src', 'already-there']);
     component.onCloneClick();
     component.cloneDestNs = 'already-there';
@@ -1391,7 +1459,7 @@ entries:
     );
   });
 
-  it('(11.5 AC4) Confirm button disabled while cloning === true', async () => {
+  it('(11.5 AC4) Confirm disabled while cloning === true', async () => {
     await loadedWithCloneSrc();
     component.onCloneClick();
     component.cloneDestNs = 'dst';
@@ -1400,7 +1468,7 @@ entries:
     expect(component.cloneConfirmDisabled).toBeTrue();
   });
 
-  it('(11.5 AC4) Confirm button enabled when all checks pass', async () => {
+  it('(11.5 AC4) Confirm enabled when all checks pass', async () => {
     await loadedWithCloneSrc();
     component.onCloneClick();
     component.cloneDestNs = 'dst';
@@ -1409,27 +1477,45 @@ entries:
     expect(component.cloneValidationError).toBeNull();
   });
 
-  // ----- Clone takes buffer, not serverYaml (AC 5) -----
+  // ----- Clone Confirm happy path -----
 
-  it('(11.5 AC5) onCloneConfirmClick captures buffer (not serverYaml) as the clone source', async () => {
+  it('(11.5 AC8+12+14) Clone Confirm happy path — import then re-export, land on destNs clean', async () => {
+    await loadedWithCloneSrc(['src']);
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    const exportedFresh = 'namespace: dst\nuser_id: null\nentries: {}\n';
+    apiSpy.exportNamespace.and.callFake((ns: string) =>
+      Promise.resolve(ns === 'dst' ? exportedFresh : cloneSrcYaml),
+    );
+    const savedEmit = spyOn(component.saved, 'emit');
+
+    component.onCloneClick();
+    component.cloneDestNs = 'dst';
+    await component.onCloneConfirmClick();
+    await fixture.whenStable();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
+    expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
+    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual([
+      'dst',
+      { all: false },
+    ]);
+    expect(component.namespace).toBe('dst');
+    expect(component.hasUnsavedChanges()).toBe(false);
+    expect(component.cloneDialogVisible).toBeFalse();
+    expect(component.cloneDestNs).toBe('');
+    expect(component.cloning).toBeFalse();
+    expect(savedEmit).toHaveBeenCalledTimes(1);
+    const toasts = messageSpy.add.calls.allArgs().map((a) => a[0]);
+    const success = toasts.find((t) => t.severity === 'success');
+    expect(success).toBeDefined();
+    expect(success!.summary).toContain("'dst'");
+  });
+
+  it('(11.5 AC5) onCloneConfirmClick captures the buffer (== server bundle when clean) as the clone source', async () => {
     await loadedWithCloneSrc();
-    await component.onEditClick();
-    // Operator edits the buffer — add an extra entry that is NOT in
-    // serverYaml to uniquely distinguish the two sources.
-    component.buffer = `namespace: src
-user_id: null
-entries:
-  team-1:
-    kind: team
-    model_type: BaseTeamModel
-    payload:
-      description: "configured for src namespace"
-  extra-entry:
-    kind: agent
-    model_type: BaseAgentModel
-    payload:
-      role: helper
-`;
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
     apiSpy.exportNamespace.and.returnValue(
       Promise.resolve('namespace: dst\nuser_id: null\nentries: {}\n'),
@@ -1445,64 +1531,12 @@ entries:
     const parsed = yaml.load(sent) as Record<string, unknown>;
     expect(parsed['namespace']).toBe('dst');
     const entries = parsed['entries'] as Record<string, unknown>;
-    expect(entries['extra-entry']).toBeDefined();
+    expect(entries['team-1']).toBeDefined();
   });
 
-  // ----- Clone Confirm happy path (AC 8, AC 12, AC 14) -----
-
-  it('(11.5 AC8+12+14) Clone Confirm happy path — import then re-export, land on destNs in view mode', async () => {
-    await loadedWithCloneSrc(['src']);
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-
-    const exportedFresh = 'namespace: dst\nuser_id: null\nentries: {}\n';
-    // After the clone re-load, exportNamespace is called with 'dst'.
-    apiSpy.exportNamespace.and.callFake((ns: string) =>
-      Promise.resolve(ns === 'dst' ? exportedFresh : cloneSrcYaml),
-    );
-    const savedEmit = spyOn(component.saved, 'emit');
-
-    component.onCloneClick();
-    component.cloneDestNs = 'dst';
-    await component.onCloneConfirmClick();
-    // onCloneConfirmClick fires `loadNamespace(destNs)` as fire-and-forget;
-    // drain microtasks so it resolves before assertions.
-    await fixture.whenStable();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(apiSpy.importNamespace).toHaveBeenCalledTimes(1);
-    // exportNamespace called twice: once on mount (cloneSrcYaml), once for
-    // the re-load (exportedFresh).
-    expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
-    expect(apiSpy.exportNamespace.calls.mostRecent().args).toEqual([
-      'dst',
-      { all: false },
-    ]);
-    expect(component.namespace).toBe('dst');
-    expect(component.mode).toBe('view');
-    expect(component.cloneDialogVisible).toBeFalse();
-    expect(component.cloneDestNs).toBe('');
-    expect(component.cloning).toBeFalse();
-    expect(savedEmit).toHaveBeenCalledTimes(1);
-    // Success toast fired exactly once with the destNs-interpolated summary.
-    const toasts = messageSpy.add.calls.allArgs().map((a) => a[0]);
-    const success = toasts.find((t) => t.severity === 'success');
-    expect(success).toBeDefined();
-    expect(success!.summary).toContain("'dst'");
-  });
-
-  // ----- Clone 422 structured (AC 9) -----
-
-  // Story 11.7 AC 20 amends this branch — the modal CLOSES on a structured
-  // 422 and the findings are surfaced in the parent panel's findings pane.
   it('(11.5 AC9 + 11.7 AC20) Clone 422 structured — lastValidation populated, modal closes, source intact', async () => {
     await loadedWithCloneSrc();
-    const report: NamespaceValidationReport = {
-      namespace: 'dst',
-      ok: false,
-      global_errors: ['invalid entry'],
-      entry_issues: [],
-    };
+    const report = failingReport(1, 0);
     apiSpy.importNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, report)),
     );
@@ -1513,23 +1547,15 @@ entries:
 
     expect(component.lastValidation).toEqual(report);
     expect(component.rawSaveError).toBeNull();
-    // Story 11.7 AC 20 — modal closes; findings render in parent pane.
     expect(component.cloneDialogVisible).toBeFalse();
     expect(component.cloneDestNs).toBe('');
     expect(component.namespace).toBe('src');
-    expect(component.mode).toBe('view');
     expect(component.buffer).toBe(cloneSrcYaml);
     expect(component.serverYaml).toBe(cloneSrcYaml);
     expect(component.cloning).toBeFalse();
   });
 
-  // ----- Clone 422 unstructured (AC 9; Story 11.7 AC 21 amends) -----
-
-  // Story 11.7 AC 21 amends this branch — instead of populating
-  // `rawSaveError`, the unstructured-422 path populates `cloneInlineError`
-  // and keeps the modal open. Parent's `rawSaveError` stays null because
-  // the FR14 gate-via-rawSaveError path is reserved for SAVE failures.
-  it('(11.5 AC9 + 11.7 AC21) Clone 422 unstructured — cloneInlineError populated, modal stays open, parent state untouched', async () => {
+  it('(11.5 AC9 + 11.7 AC21) Clone 422 unstructured — cloneInlineError populated, modal stays open', async () => {
     await loadedWithCloneSrc();
     apiSpy.importNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, 'FastAPI detail string')),
@@ -1543,19 +1569,11 @@ entries:
     expect(component.rawSaveError).toBeNull();
     expect(component.lastValidation).toBeNull();
     expect(component.cloneDialogVisible).toBeTrue();
-    expect(component.namespace).toBe('src');
     expect(component.cloning).toBeFalse();
   });
 
-  // ----- Clone 5xx (AC 9, AC 10) -----
-
   it('(11.5 AC9+10) Clone 5xx — sticky toast, lastCloneError populated, source intact', async () => {
     await loadedWithCloneSrc();
-    // Seed dirty edit state so AC 10's "source intact" check covers mode +
-    // buffer too.
-    await component.onEditClick();
-    component.buffer = cloneSrcYaml + '# edited marker\n';
-    const editedBuffer = component.buffer;
     apiSpy.importNamespace.and.returnValue(
       Promise.reject(makeHttpError(500, '')),
     );
@@ -1568,24 +1586,16 @@ entries:
     expect(component.lastCloneError).not.toBeNull();
     expect(component.cloning).toBeFalse();
     expect(component.cloneDialogVisible).toBeTrue();
-    // Source state intact.
     expect(component.namespace).toBe('src');
-    expect(component.mode).toBe('edit');
-    expect(component.buffer).toBe(editedBuffer);
     expect(component.serverYaml).toBe(cloneSrcYaml);
-    // Sticky error toast fired.
     const lastToast = messageSpy.add.calls.mostRecent().args[0];
     expect(lastToast.severity).toBe('error');
     expect(lastToast.sticky).toBeTrue();
   });
 
-  // ----- Clone 401 silent (AC 9) -----
-
   it('(11.5 AC9) Clone 401 — no panel toast, dialog stays open, cloning resets', async () => {
     await loadedWithCloneSrc();
-    apiSpy.importNamespace.and.returnValue(
-      Promise.reject(makeHttpError(401)),
-    );
+    apiSpy.importNamespace.and.returnValue(Promise.reject(makeHttpError(401)));
     messageSpy.add.calls.reset();
 
     component.onCloneClick();
@@ -1598,20 +1608,18 @@ entries:
     expect(component.lastCloneError).toBeNull();
   });
 
-  // ----- Clone CloneYamlError (AC 11) -----
-
   it('(11.5 AC11) CloneYamlError — no import call, toast fired, cloning resets, lastCloneError NOT set', async () => {
     await loadedWithCloneSrc();
-    await component.onEditClick();
-    // Buffer is NOT a valid bundle root mapping — forces
-    // rewriteNamespaceInYaml to throw CloneYamlError before the network
-    // call.
+    // A buffer that is not a valid bundle root mapping forces
+    // rewriteNamespaceInYaml to throw CloneYamlError before the network call.
+    // Set it directly (Clone reads this.buffer); the gate is bypassed by
+    // calling onCloneConfirmClick after opening the modal.
+    component.onCloneClick();
     component.buffer = '- not a mapping\n';
+    component.cloneDestNs = 'dst';
     apiSpy.importNamespace.calls.reset();
     messageSpy.add.calls.reset();
 
-    component.onCloneClick();
-    component.cloneDestNs = 'dst';
     await component.onCloneConfirmClick();
 
     expect(apiSpy.importNamespace).not.toHaveBeenCalled();
@@ -1622,11 +1630,8 @@ entries:
     expect(toast.severity).toBe('error');
   });
 
-  // ----- NFR7 budget (AC 14) -----
-
-  it('(11.5 AC14) NFR7 — clone happy path = 1 import + 2 exports total, no other spy calls', async () => {
+  it('(11.5 AC14) NFR7 — clone happy path = 1 import + 2 exports total, no validate calls', async () => {
     await loadedWithCloneSrc();
-    // 1 export fired during mount; now clone.
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
     apiSpy.exportNamespace.and.callFake((ns: string) =>
       Promise.resolve(`namespace: ${ns}\nuser_id: null\nentries: {}\n`),
@@ -1643,8 +1648,6 @@ entries:
     expect(apiSpy.validateNamespaceBuffer).not.toHaveBeenCalled();
     expect(apiSpy.validatePersistedNamespace).not.toHaveBeenCalled();
   });
-
-  // ----- Destroy-during-clone (AC 16) -----
 
   it('(11.5 AC16) destroy-during-clone — late-resolving import does not write state', async () => {
     await loadedWithCloneSrc();
@@ -1670,231 +1673,89 @@ entries:
     await clonePromise;
     await Promise.resolve();
 
-    // No state writes on the destroyed instance.
     expect(component.namespace).toBe('src');
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
-
-  // ---------------------------------------------------------------------
-  // Story 11.7 — Validation gate + a11y polish (AC 1–26)
-  // ---------------------------------------------------------------------
-
-  /** Helper: a non-clean validation report with a known finding count. */
-  function failingReport(
-    globalCount = 1,
-    entryCount = 0,
-  ): NamespaceValidationReport {
-    return {
-      namespace: 'foo',
-      ok: false,
-      global_errors: Array.from(
-        { length: globalCount },
-        (_, i) => `global error ${i}`,
-      ),
-      entry_issues: Array.from({ length: entryCount }, (_, i) => ({
-        entry_id: `entry-${i}`,
-        kind: 'agent',
-        errors: ['bad'],
-      })),
-    };
-  }
-
-  // ----- AC 1, 2, 6 — FR14 gate getters -----
-
-  it('(11.7 AC1) gate matrix branch A — lastValidation.ok=false disables Save; Clone gate covered by the view-mode test below (post-UX-refinement: Clone is view-mode only)', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = failingReport(2, 0);
-    component.rawSaveError = null;
-    fixture.detectChanges();
-
-    // Both gate flags still true regardless of mode — they track data state.
-    expect(component.isSaveGated).toBeTrue();
-    expect(component.isCloneGated).toBeTrue();
-
-    // Save is visible AND disabled in edit mode.
-    const saveBtn = fixture.nativeElement.querySelector(
-      'button[data-test="save-btn"]',
-    ) as HTMLButtonElement;
-    expect(saveBtn.disabled).toBeTrue();
-    expect(component.saveTooltip).toBe('Fix validation issues before saving.');
-
-    // Clone is NOT rendered in edit mode (post-review UX refinement).
-    const cloneBtn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    ) as HTMLButtonElement | null;
-    expect(cloneBtn).toBeNull();
-    // The gate still computes; tooltip would surface in view mode.
-    expect(component.cloneTooltip).toBe('Fix validation issues before cloning.');
-  });
-
-  it('(11.7 AC2) gate matrix branch B — rawSaveError !== null disables Save and Clone', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = null;
-    component.rawSaveError = 'FastAPI raw error string';
-    fixture.detectChanges();
-
-    expect(component.isSaveGated).toBeTrue();
-    expect(component.isCloneGated).toBeTrue();
-    expect(component.saveTooltip).toBe('Fix validation issues before saving.');
-    expect(component.cloneTooltip).toBe('Fix validation issues before cloning.');
-  });
-
-  it('(11.7 AC6) fresh untouched state is NOT pre-gated — Clone enabled by default', async () => {
-    await loadedWithCloneSrc(['src']);
-    expect(component.lastValidation).toBeNull();
-    expect(component.rawSaveError).toBeNull();
-    expect(component.isCloneGated).toBeFalse();
-    expect(component.cloneTooltip).toBeUndefined();
-
-    const cloneBtn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    ) as HTMLButtonElement;
-    expect(cloneBtn.disabled).toBeFalse();
-  });
-
-  it('(11.7 AC1) saveTooltip returns undefined when gate is NOT the active disable reason', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    // Clean buffer — Save disabled because buffer === serverYaml, NOT gate.
-    component.buffer = 'foo: 1\n';
-    component.lastValidation = null;
-    component.rawSaveError = null;
-    fixture.detectChanges();
-
-    // Tooltip is `undefined` (not null) so PrimeNG's pTooltip input
-    // (`string | TemplateRef | undefined`) accepts it under strictTemplates.
-    expect(component.saveTooltip).toBeUndefined();
-  });
-
-  // ----- AC 3 — gate auto-lifts on onBufferChange -----
-
-  it('(11.7 AC3) gate matrix branch C — onBufferChange clears rawSaveError unconditionally', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = failingReport(1);
-    component.rawSaveError = 'stale raw error';
-    expect(component.isSaveGated).toBeTrue();
-    expect(component.isCloneGated).toBeTrue();
-
-    component.onBufferChange('foo: 3\n');
-
-    // Both fields nulled → gate flips false in the same change-detection
-    // cycle. lastValidation clears via the validatedBuffer path even
-    // though validatedBuffer was null (it was already null because no
-    // green-flash was active).
-    expect(component.rawSaveError).toBeNull();
-    // lastValidation stays in this case because the validatedBuffer
-    // condition didn't trigger — but the rawSaveError clear alone is
-    // enough to lift the gate when lastValidation === null. With both
-    // signals present, the gate stays until lastValidation also clears
-    // (operator can click Clear-results or Re-validate). Verify the
-    // rawSaveError-clear path independently:
-    component.lastValidation = null;
-    expect(component.isSaveGated).toBeFalse();
-    expect(component.isCloneGated).toBeFalse();
-  });
-
-  it('(11.7 AC3) regression-lock — onBufferChange still clears validationFlashBuffer when value diverges from validatedBuffer (Story 11.4 green-flash semantics)', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    apiSpy.validateNamespaceBuffer.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-    await component.onValidateBufferClick();
-
-    // Pre-condition: green-flash on, validatedBuffer captured.
-    expect(component.validationFlashBuffer).toBeTrue();
-
-    // Change the buffer — the existing Story 11.4 invalidation must
-    // still fire.
-    component.onBufferChange('foo: 3\n');
-    expect(component.validationFlashBuffer).toBeFalse();
-  });
-
-  // ----- AC 4 — gate auto-lifts on onClearValidationClick -----
-
-  it('(11.7 AC4) gate matrix branch D — onClearValidationClick lifts the gate', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = failingReport(1);
-    component.rawSaveError = 'raw';
-    expect(component.isSaveGated).toBeTrue();
-
-    component.onClearValidationClick();
-    expect(component.lastValidation).toBeNull();
-    expect(component.rawSaveError).toBeNull();
-    expect(component.isSaveGated).toBeFalse();
-    expect(component.isCloneGated).toBeFalse();
-
-    fixture.detectChanges();
-    const saveBtn = fixture.nativeElement.querySelector(
-      'button[data-test="save-btn"]',
-    ) as HTMLButtonElement;
-    expect(saveBtn.disabled).toBeFalse();
-  });
-
-  // ----- AC 5 — gate auto-lifts on successful Save (regression-lock) -----
-
-  it('(11.7 AC5) gate matrix branch E — successful Save (2xx) lifts the gate', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    component.lastValidation = failingReport(1);
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-
-    await component.onSaveClick();
-
-    expect(component.lastValidation).toBeNull();
-    expect(component.rawSaveError).toBeNull();
-    expect(component.mode).toBe('view');
-    expect(component.serverYaml).toBe('foo: 2\n');
-    expect(component.isSaveGated).toBeFalse();
-  });
-
-  // ----- AC 7 — Clone modal Confirm gated by FR14 -----
 
   it('(11.7 AC7) Clone modal Confirm button is gated by isCloneGated', async () => {
     await loadedWithCloneSrc(['src']);
     component.onCloneClick();
     component.cloneDestNs = 'valid-new-ns';
-    // Without gate: cloneConfirmDisabled would be false (destination valid).
     expect(component.cloneConfirmDisabled).toBeFalse();
 
-    // With gate: confirmDisabled returns true.
     component.lastValidation = failingReport(1);
     expect(component.cloneConfirmDisabled).toBeTrue();
   });
 
-  // ----- AC 11–14 — aria-live announcements -----
+  // ----- Clone modal a11y handlers -----
 
-  it('(11.7 AC11) flashValidated sets a11yAnnouncement to "Validation passed"', async () => {
-    await loadedEditMode('foo: 1\n');
-    apiSpy.validatePersistedNamespace.and.returnValue(
-      Promise.resolve(cleanReport()),
-    );
-    await component.onValidatePersistedClick();
-    fixture.detectChanges();
+  it('(11.7 AC18) onCloneDialogHide clears cloneDestNs and cloneInlineError', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    component.cloneDestNs = 'something';
+    component.cloneInlineError = 'pending error';
 
-    expect(component.a11yAnnouncement).toBe('Validation passed');
-    const liveRegion = fixture.nativeElement.querySelector(
-      '[data-test="a11y-live-region"]',
-    ) as HTMLElement;
-    expect(liveRegion.textContent?.trim()).toBe('Validation passed');
+    component.onCloneDialogHide();
+
+    expect(component.cloneDestNs).toBe('');
+    expect(component.cloneInlineError).toBeNull();
   });
 
-  it('(11.7 AC12) failing Validate-persisted sets a11yAnnouncement to "Validation found N issues"', async () => {
-    await loadedEditMode('foo: 1\n');
-    apiSpy.validatePersistedNamespace.and.returnValue(
+  it('(11.7 AC19) onCloneDialogHide returns focus to the outer Clone button', fakeAsync(async () => {
+    await loadedWithCloneSrc(['src']);
+    fixture.detectChanges();
+
+    const cloneBtn = fixture.nativeElement.querySelector(
+      'button[data-test="clone-btn"]',
+    ) as HTMLButtonElement;
+    component.cloneBtnRef = {
+      nativeElement: cloneBtn,
+    } as ElementRef<HTMLButtonElement>;
+
+    component.onCloneDialogHide();
+    tick(0);
+
+    expect(document.activeElement).toBe(cloneBtn);
+  }));
+
+  it('(11.7 AC16) onCloneDialogShow focuses the destination input via cloneDestInputRef', fakeAsync(async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    fixture.detectChanges();
+
+    const stub = document.createElement('input');
+    document.body.appendChild(stub);
+    component.cloneDestInputRef = {
+      nativeElement: stub,
+    } as ElementRef<HTMLInputElement>;
+
+    component.onCloneDialogShow();
+    tick(0);
+
+    expect(document.activeElement).toBe(stub);
+    document.body.removeChild(stub);
+  }));
+
+  it('(11.7 AC21) onCloneDestNsChange clears cloneInlineError', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.cloneInlineError = 'stale error';
+
+    component.onCloneDestNsChange();
+
+    expect(component.cloneInlineError).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // a11y live region.
+  // ---------------------------------------------------------------------
+
+  it('(11.7 AC12) failing Validate sets a11yAnnouncement to "Validation found N issues"', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.validateNamespaceBuffer.and.returnValue(
       Promise.resolve(failingReport(3, 2)),
     );
-    await component.onValidatePersistedClick();
+
+    await component.onValidateBufferClick();
     fixture.detectChanges();
 
     expect(component.a11yAnnouncement).toBe('Validation found 5 issues');
@@ -1905,9 +1766,9 @@ entries:
   });
 
   it('(11.7 AC12) Save 422 structured branch announces "Validation found N issues"', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+    await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: 1\n'));
     apiSpy.importNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, failingReport(1, 0))),
     );
@@ -1915,17 +1776,6 @@ entries:
     await component.onSaveClick();
 
     expect(component.a11yAnnouncement).toBe('Validation found 1 issues');
-  });
-
-  it('(11.7 AC13) Save 2xx sets a11yAnnouncement to "Namespace saved"', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
-
-    await component.onSaveClick();
-
-    expect(component.a11yAnnouncement).toBe('Namespace saved');
   });
 
   it('(11.7 AC14) Clone Confirm 2xx sets a11yAnnouncement to "Cloned to namespace \'X\'"', async () => {
@@ -1944,7 +1794,7 @@ entries:
   });
 
   it('(11.7 AC15) live region is visually-hidden but present in the DOM', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     fixture.detectChanges();
 
     const liveRegion = fixture.nativeElement.querySelector(
@@ -1962,175 +1812,31 @@ entries:
     expect(styles.overflow).toBe('hidden');
   });
 
-  // ----- AC 18 — Escape dismisses Clone modal with Cancel semantics -----
-
-  it('(11.7 AC18) onCloneDialogHide clears cloneDestNs and cloneInlineError', async () => {
-    await loadedWithCloneSrc(['src']);
-    component.onCloneClick();
-    component.cloneDestNs = 'something';
-    component.cloneInlineError = 'pending error';
-
-    component.onCloneDialogHide();
-
-    expect(component.cloneDestNs).toBe('');
-    expect(component.cloneInlineError).toBeNull();
-  });
-
-  // ----- AC 19 — Focus returns to outer Clone button on modal close -----
-
-  it('(11.7 AC19) onCloneDialogHide returns focus to the outer Clone button', fakeAsync(async () => {
-    await loadedWithCloneSrc(['src']);
-    fixture.detectChanges();
-
-    // Wire the @ViewChild ElementRef manually with the rendered button.
-    const cloneBtn = fixture.nativeElement.querySelector(
-      'button[data-test="clone-btn"]',
-    ) as HTMLButtonElement;
-    expect(cloneBtn).not.toBeNull();
-    component.cloneBtnRef = { nativeElement: cloneBtn } as ElementRef<HTMLButtonElement>;
-
-    component.onCloneDialogHide();
-    tick(0);
-
-    expect(document.activeElement).toBe(cloneBtn);
-  }));
-
-  // ----- AC 20 — Clone Confirm 422 structured: close modal + render in parent -----
-
-  it('(11.7 AC20) Clone Confirm 422 structured — closes modal, populates lastValidation, parent buffer/mode untouched', async () => {
-    await loadedWithCloneSrc(['src']);
-    component.onCloneClick();
-    component.cloneDestNs = 'new-ns';
-    const bufferBefore = component.buffer;
-    const modeBefore = component.mode;
-
-    apiSpy.importNamespace.and.returnValue(
-      Promise.reject(makeHttpError(422, failingReport(2))),
-    );
-    await component.onCloneConfirmClick();
-
-    expect(component.cloneDialogVisible).toBeFalse();
-    expect(component.cloneDestNs).toBe('');
-    expect(component.cloneInlineError).toBeNull();
-    expect(component.lastValidation?.ok).toBeFalse();
-    expect(component.buffer).toBe(bufferBefore);
-    expect(component.mode).toBe(modeBefore);
-    expect(component.isCloneGated).toBeTrue();
-  });
-
-  // ----- AC 21 — Clone Confirm 422 unstructured: stay open, inline error -----
-
-  it('(11.7 AC21) Clone Confirm 422 unstructured — modal stays open, cloneInlineError populated, no parent state mutation', async () => {
-    await loadedWithCloneSrc(['src']);
-    component.onCloneClick();
-    component.cloneDestNs = 'new-ns';
-
-    apiSpy.importNamespace.and.returnValue(
-      Promise.reject(makeHttpError(422, 'plain error string')),
-    );
-    await component.onCloneConfirmClick();
-
-    expect(component.cloneDialogVisible).toBeTrue();
-    expect(component.cloneInlineError).toBe('plain error string');
-    expect(component.lastValidation).toBeNull();
-    expect(component.rawSaveError).toBeNull();
-  });
-
-  it('(11.7 AC21) onCloneDestNsChange clears cloneInlineError', async () => {
-    await loadedWithCloneSrc(['src']);
-    component.cloneInlineError = 'stale error';
-
-    component.onCloneDestNsChange();
-
-    expect(component.cloneInlineError).toBeNull();
-  });
-
-  // ----- AC 24 — destroy-during-write absorbs late resolutions (regression-lock) -----
-
-  it('(11.7 AC24 regression-lock) destroy-during-save absorbs late import resolution (no state writes on destroyed component)', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
-    component.buffer = 'foo: 2\n';
-
-    let resolveImport!: (value: unknown) => void;
-    apiSpy.importNamespace.and.returnValue(
-      new Promise<unknown>((r) => {
-        resolveImport = r;
-      }) as unknown as Promise<never>,
-    );
-
-    const savePromise = component.onSaveClick();
-    expect(component.saving).toBeTrue();
-
-    fixture.destroy();
-    resolveImport([]);
-    await savePromise;
-    await Promise.resolve();
-
-    // No state writes on the destroyed instance — serverYaml stays at the
-    // pre-save value (foo: 1) since the success branch never ran.
-    expect(component.serverYaml).toBe('foo: 1\n');
-  });
-
-  // ----- AC 16 — Clone modal autofocus (programmatic via onCloneDialogShow) -----
-
-  it('(11.7 AC16) onCloneDialogShow focuses the destination input via cloneDestInputRef', fakeAsync(async () => {
-    await loadedWithCloneSrc(['src']);
-    component.onCloneClick();
-    fixture.detectChanges();
-
-    // Wire the @ViewChild manually with a focusable stub element so the
-    // assertion is deterministic regardless of PrimeNG's overlay timing.
-    const stub = document.createElement('input');
-    document.body.appendChild(stub);
-    component.cloneDestInputRef = {
-      nativeElement: stub,
-    } as ElementRef<HTMLInputElement>;
-
-    component.onCloneDialogShow();
-    tick(0);
-
-    expect(document.activeElement).toBe(stub);
-    document.body.removeChild(stub);
-  }));
-
-  // Story 14.1 — Delete-namespace button + confirmation (ADR-028 frontend leg)
+  // ---------------------------------------------------------------------
+  // Delete flow (Story 14.1 / ADR-028 frontend leg) — always available.
   // ---------------------------------------------------------------------
 
-  /**
-   * Capture the config object passed to ConfirmationService.confirm and
-   * invoke its `accept` callback — drives the delete-confirm branch
-   * deterministically (mirrors the existing clone/cancel confirm tests).
-   */
-  function acceptLastConfirm(): void {
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    args.accept!();
-  }
-
-  // ----- Button render: view mode vs edit mode (AC 11) -----
-
-  it('(14.1 AC11) Delete button renders in view mode', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(14.1 AC11) Delete button renders whenever the panel has content', async () => {
+    await loaded('foo: 1\n');
     const btn = fixture.nativeElement.querySelector(
       'button[data-test="delete-ns-btn"]',
     );
     expect(btn).not.toBeNull();
   });
 
-  it('(14.1 AC11) Delete button is absent in edit mode', async () => {
-    await loadedEditMode('foo: 1\n');
-    await component.onEditClick();
+  it('(14.1 AC11) Delete button is present even when dirty (orthogonal to dirty)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
     fixture.detectChanges();
     const btn = fixture.nativeElement.querySelector(
       'button[data-test="delete-ns-btn"]',
-    );
-    expect(btn).toBeNull();
+    ) as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.disabled).toBeFalse();
   });
 
-  // ----- Confirm open + accept/cancel (AC 12) -----
-
-  it('(14.1 AC12) clicking Delete opens the confirmation; accepting calls deleteNamespace once with the current namespace', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(14.1 AC12) clicking Delete opens the confirmation; accepting calls deleteNamespace once', async () => {
+    await loaded('foo: 1\n');
     apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
 
     component.onDeleteClick();
@@ -2140,27 +1846,14 @@ entries:
     expect(args.icon).toBe('pi pi-trash');
     expect(args.message as string).toContain('foo');
 
-    acceptLastConfirm();
+    args.accept!();
     await fixture.whenStable();
 
     expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
   });
 
-  it('(14.1 AC12) cancelling the confirm does NOT call deleteNamespace (no reject side effects)', async () => {
-    await loadedEditMode('foo: 1\n');
-
-    component.onDeleteClick();
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    // No reject callback is wired — cancel = pure no-op.
-    expect(args.reject).toBeUndefined();
-    // Simulate cancel: never call accept.
-    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
-  });
-
-  // ----- 204 success path (AC 13, AC 6) -----
-
   it('(14.1 AC13) 204 success — emits saved + closed and shows a success toast', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
     const savedEmit = spyOn(component.saved, 'emit');
     const closedEmit = spyOn(component.closed, 'emit');
@@ -2173,47 +1866,31 @@ entries:
     expect(component.deleting).toBeFalse();
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('success');
-    expect(toast.summary).toContain('foo');
-    // a11y live-region announcement set.
     expect(component.a11yAnnouncement).toBe("Namespace 'foo' deleted");
   });
 
-  // ----- 403 not-authorized (AC 14) -----
-
-  it('(14.1 AC14) 403 — not-authorized toast, panel open, state unchanged, single call (not retried)', async () => {
-    await loadedEditMode('foo: 1\n');
+  it('(14.1 AC14) 403 — not-authorized toast, panel open, state unchanged, single call', async () => {
+    await loaded('foo: 1\n');
     const savedEmit = spyOn(component.saved, 'emit');
-    apiSpy.deleteNamespace.and.returnValue(
-      Promise.reject(makeHttpError(403)),
-    );
+    apiSpy.deleteNamespace.and.returnValue(Promise.reject(makeHttpError(403)));
     messageSpy.add.calls.reset();
 
     await component.onDeleteConfirm();
 
     expect(apiSpy.deleteNamespace).toHaveBeenCalledTimes(1);
     expect(savedEmit).not.toHaveBeenCalled();
-    // Panel state untouched.
-    expect(component.mode).toBe('view');
     expect(component.serverYaml).toBe('foo: 1\n');
     expect(component.buffer).toBe('foo: 1\n');
     expect(component.deleting).toBeFalse();
-    // Not-authorized error toast (non-sticky).
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('error');
     expect(toast.summary).toContain('not authorized');
     expect(toast.sticky).toBeFalsy();
   });
 
-  // ----- 409 / 422 inbound-reference blocker (AC 15) -----
-
   it('(14.1 AC15) 422 structured NamespaceValidationReport — findings surfaced, panel open', async () => {
-    await loadedEditMode('foo: 1\n');
-    const report: NamespaceValidationReport = {
-      namespace: 'foo',
-      ok: false,
-      global_errors: ["namespace 'bar' references 'foo'"],
-      entry_issues: [],
-    };
+    await loaded('foo: 1\n');
+    const report = failingReport(1, 0);
     apiSpy.deleteNamespace.and.returnValue(
       Promise.reject(makeHttpError(422, report)),
     );
@@ -2222,13 +1899,12 @@ entries:
 
     expect(component.lastValidation).toEqual(report);
     expect(component.rawSaveError).toBeNull();
-    expect(component.mode).toBe('view');
     expect(component.serverYaml).toBe('foo: 1\n');
     expect(component.a11yAnnouncement).toBe('Validation found 1 issues');
   });
 
   it('(14.1 AC15) 409 with unstructured body — error toast surfaces the detail, panel open', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     apiSpy.deleteNamespace.and.returnValue(
       Promise.reject(makeHttpError(409, 'referenced by namespace bar')),
     );
@@ -2240,30 +1916,22 @@ entries:
     const toast = messageSpy.add.calls.mostRecent().args[0];
     expect(toast.severity).toBe('error');
     expect(toast.detail).toContain('referenced by namespace bar');
-    expect(component.mode).toBe('view');
   });
 
-  // ----- 401 falls through (no panel-specific handling, AC 9) -----
-
-  it('(14.1 AC9) 401 — no panel toast, state unchanged', async () => {
-    await loadedEditMode('foo: 1\n');
-    apiSpy.deleteNamespace.and.returnValue(
-      Promise.reject(makeHttpError(401)),
-    );
+  it('(14.1 AC9) Delete 401 — no panel toast, state unchanged', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.reject(makeHttpError(401)));
     messageSpy.add.calls.reset();
 
     await component.onDeleteConfirm();
 
     expect(messageSpy.add).not.toHaveBeenCalled();
-    expect(component.mode).toBe('view');
     expect(component.serverYaml).toBe('foo: 1\n');
     expect(component.deleting).toBeFalse();
   });
 
-  // ----- In-flight guard (AC 16) -----
-
   it('(14.1 AC16) in-flight guard — button disabled while deleting; second confirm does not fire a second call', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     let resolveDelete!: () => void;
     apiSpy.deleteNamespace.and.returnValue(
       new Promise<void>((r) => {
@@ -2275,15 +1943,12 @@ entries:
     expect(component.deleting).toBeTrue();
     fixture.detectChanges();
 
-    // Button is disabled while the delete is pending.
     const btn = fixture.nativeElement.querySelector(
       'button[data-test="delete-ns-btn"]',
     ) as HTMLButtonElement;
     expect(btn.disabled).toBeTrue();
 
-    // A second confirm during the in-flight window is a no-op.
     void component.onDeleteConfirm();
-    // And clicking again is gated too.
     component.onDeleteClick();
     expect(confirmationSpy.confirm).not.toHaveBeenCalled();
 
@@ -2295,7 +1960,7 @@ entries:
   });
 
   it('(14.1 AC10) onDeleteClick is a no-op while a delete is in flight', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     component.deleting = true;
 
     component.onDeleteClick();
@@ -2303,10 +1968,8 @@ entries:
     expect(confirmationSpy.confirm).not.toHaveBeenCalled();
   });
 
-  // ----- Destroy safety — late-resolving delete does not write state -----
-
   it('(14.1 AC10) destroy-during-delete — late resolution does not write state', async () => {
-    await loadedEditMode('foo: 1\n');
+    await loaded('foo: 1\n');
     let resolveLate!: () => void;
     apiSpy.deleteNamespace.and.returnValue(
       new Promise<void>((r) => {
@@ -2329,18 +1992,15 @@ entries:
   });
 
   // ---------------------------------------------------------------------
-  // Story 12.2 — Clone modal shareable / public toggles (AC 7–AC 13)
+  // Story 12.2 — Clone modal shareable / public toggles (modal unchanged).
   // ---------------------------------------------------------------------
 
-  /** Bundle YAML carrying explicit shareable / public flags. */
   const cloneSrcYamlWithFlags = `namespace: src
 name: Src
 shareable: true
 public: false
 entries: {}
 `;
-
-  // ----- Default state + reset parity (AC 7) -----
 
   it('(12.2 AC7) cloneShareable / clonePublic initialize to false', async () => {
     await loadedWithCloneSrc();
@@ -2381,8 +2041,6 @@ entries: {}
     expect(component.clonePublic).toBeFalse();
   });
 
-  // ----- Pre-fill from buffer (AC 8) -----
-
   it('(12.2 AC8) onCloneClick pre-fills both toggles from the buffer flags', async () => {
     apiSpy.exportNamespace.and.returnValue(
       Promise.resolve(cloneSrcYamlWithFlags),
@@ -2396,13 +2054,11 @@ entries: {}
 
     expect(component.cloneShareable).toBeTrue();
     expect(component.clonePublic).toBeFalse();
-    // Story 12.1 name/namespace pre-fill remains (additive).
     expect(component.cloneDestNs).toMatch(/^src_/);
     expect(component.cloneDestName).toBe('Src_copy');
   });
 
   it('(12.2 AC8) onCloneClick defaults both toggles to false when the buffer omits the flags', async () => {
-    // cloneSrcYaml has neither shareable nor public.
     await loadedWithCloneSrc();
     component.cloneShareable = true;
     component.clonePublic = true;
@@ -2412,8 +2068,6 @@ entries: {}
     expect(component.cloneShareable).toBeFalse();
     expect(component.clonePublic).toBeFalse();
   });
-
-  // ----- Confirm wires both toggle values through (AC 9) -----
 
   it('(12.2 AC9) onCloneConfirmClick passes both toggle values into the import YAML', async () => {
     await loadedWithCloneSrc(['src']);
@@ -2438,12 +2092,9 @@ entries: {}
     expect(parsed['public']).toBe(false);
     expect(parsed['namespace']).toBe('dst');
     expect(parsed['name']).toBe('Dest');
-    // Both toggles reset after the successful import.
     expect(component.cloneShareable).toBeFalse();
     expect(component.clonePublic).toBeFalse();
   });
-
-  // ----- Toggles do NOT affect the Confirm gate (AC 10) -----
 
   it('(12.2 AC10) toggle combinations never change cloneConfirmDisabled or cloneValidationError', async () => {
     await loadedWithCloneSrc(['src']);
@@ -2465,8 +2116,6 @@ entries: {}
     }
   });
 
-  // ----- Template render + field order + hints (AC 11, AC 13) -----
-
   it('(12.2 AC11) both toggles render after the inputs with distinguishing hints', async () => {
     await loadedWithCloneSrc(['src']);
     component.onCloneClick();
@@ -2480,7 +2129,6 @@ entries: {}
     expect(shareable).not.toBeNull();
     expect(isPublic).not.toBeNull();
 
-    // Field order: name → namespace → shareable → public.
     const ordered = Array.from(
       root.querySelectorAll(
         '[data-test="clone-destname-input"],' +
@@ -2496,7 +2144,6 @@ entries: {}
       'clone-public-toggle',
     ]);
 
-    // Each toggle is name-accessible via a label/inputId pair.
     expect(
       root.querySelector('label[for="clone-shareable-toggle"]'),
     ).not.toBeNull();
@@ -2504,7 +2151,6 @@ entries: {}
       root.querySelector('label[for="clone-public-toggle"]'),
     ).not.toBeNull();
 
-    // The two hints distinguish referenceability from listing/cloning.
     const shareableHint =
       root.querySelector('#clone-shareable-hint')?.textContent?.toLowerCase() ??
       '';

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -3431,18 +3431,42 @@ entries: {}
     component.onConfirmDialogHide();
   });
 
-  it('(ADR-018 §c) confirmDiscard resolves true when Proceed is clicked', async () => {
+  it('(ADR-018 §c) confirmDiscard Proceed resolves true AND really discards (buffer reset to serverYaml)', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
+    expect(component.hasUnsavedChanges()).toBeTrue();
 
     const promise = component.confirmDiscard();
     clickConfirmProceed();
 
     await expectAsync(promise).toBeResolvedTo(true);
     expect(confirmOpen()).toBeFalse();
+    // Real discard: the buffer is reverted to the server snapshot → clean.
+    expect(component.buffer).toBe('foo: 1\n');
+    expect(component.buffer).toBe(component.serverYaml);
+    expect(component.hasUnsavedChanges()).toBeFalse();
   });
 
-  it('(ADR-018 §c) confirmDiscard resolves false when Cancel is clicked', async () => {
+  it('(ADR-018 §c) confirmDiscard Proceed clears dirty-derived state (lastValidation / rawSaveError)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = {
+      namespace: 'foo',
+      ok: false,
+      global_errors: ['bad'],
+      entry_issues: [],
+    };
+    component.rawSaveError = 'boom';
+
+    const promise = component.confirmDiscard();
+    clickConfirmProceed();
+    await promise;
+
+    expect(component.lastValidation).toBeNull();
+    expect(component.rawSaveError).toBeNull();
+  });
+
+  it('(ADR-018 §c) confirmDiscard Cancel resolves false AND leaves the buffer dirty (no reset)', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
 
@@ -3451,9 +3475,12 @@ entries: {}
 
     await expectAsync(promise).toBeResolvedTo(false);
     expect(confirmOpen()).toBeFalse();
+    // Cancel = stay: the edits are kept intact.
+    expect(component.buffer).toBe('foo: 2\n');
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
-  it('(ADR-018 §c) confirmDiscard resolves false on Esc/X dismissal (onConfirmDialogHide)', async () => {
+  it('(ADR-018 §c) confirmDiscard Esc/X dismissal resolves false AND leaves the buffer dirty', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
 
@@ -3461,6 +3488,8 @@ entries: {}
     component.onConfirmDialogHide();
 
     await expectAsync(promise).toBeResolvedTo(false);
+    expect(component.buffer).toBe('foo: 2\n');
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('(ADR-018 §d) the discard-variant Proceed button is NOT destructive (no danger class)', async () => {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -2834,6 +2834,312 @@ entries: {}
   });
 
   // ---------------------------------------------------------------------
+  // Story 22.4 (ADR-018 §5) — macOS Option-shortcut robustness
+  // (dead-key / IME composition). On some macOS layouts an ⌥-chord initiates
+  // a dead-key composition: the keydown arrives flagged composing
+  // (isComposing:true, keyCode:229, key:'Dead'). The matcher MUST still fire
+  // (it keys off altKey+code, never key) AND preventDefault to suppress the
+  // composition. The host capture-phase listener is the AUTHORITATIVE path.
+  //
+  // NOTE (NFR5): synthetic KeyboardEvents bypass the OS composition layer, so
+  // these specs prove the matcher WOULD handle a composing event (guarding a
+  // future composing-skip regression) but CANNOT reproduce the real macOS
+  // chord — that is the manual-verification gate (AC 8), left for the operator.
+  // ---------------------------------------------------------------------
+
+  /**
+   * Build a composing (dead-key / IME) keydown — the macOS failure shape:
+   * `isComposing:true`, `keyCode:229`, `key:'Dead'`. Merges any extra init
+   * (e.g. `{ shiftKey: true }` for ⌥⇧C). Reuses the Story 22-2 `keyEvent`
+   * helper (altKey:true + cancelable:true), so `evt.defaultPrevented` is
+   * observable after a direct `component.onKeydown(evt)` call.
+   */
+  function composingKeyEvent(
+    code: string,
+    init: Partial<KeyboardEventInit> = {},
+  ): KeyboardEvent {
+    return keyEvent(code, {
+      isComposing: true,
+      keyCode: 229,
+      key: 'Dead',
+      ...init,
+    });
+  }
+
+  // ----- AC 1, 2, 3 — composing-event survival + preventDefault, uniform -----
+
+  interface ComposingChordCase {
+    name: string;
+    code: string;
+    extraInit: Partial<KeyboardEventInit>;
+    handler:
+      | 'onSaveClick'
+      | 'onValidateBufferClick'
+      | 'onResetClick'
+      | 'onCloneClick'
+      | 'onDeleteClick';
+    /** Make the chord's `canX` enablement true before dispatching. */
+    enable: () => void;
+  }
+
+  const composingChordCases: ComposingChordCase[] = [
+    {
+      name: '⌥S Save',
+      code: 'KeyS',
+      extraInit: {},
+      handler: 'onSaveClick',
+      enable: (): void => {
+        component.buffer = 'foo: 2\n'; // dirty → canSave
+      },
+    },
+    {
+      name: '⌥V Validate',
+      code: 'KeyV',
+      extraInit: {},
+      handler: 'onValidateBufferClick',
+      enable: (): void => {
+        // Validate is enabled by default (clean or dirty) — no setup needed.
+      },
+    },
+    {
+      name: '⌥R Reset',
+      code: 'KeyR',
+      extraInit: {},
+      handler: 'onResetClick',
+      enable: (): void => {
+        component.buffer = 'foo: 2\n'; // dirty → canReset
+      },
+    },
+    {
+      name: '⌥⇧C Clone',
+      code: 'KeyC',
+      extraInit: { shiftKey: true },
+      handler: 'onCloneClick',
+      enable: (): void => {
+        // Clean (default loaded state) → canClone is already true.
+      },
+    },
+    {
+      name: '⌥D Delete',
+      code: 'KeyD',
+      extraInit: {},
+      handler: 'onDeleteClick',
+      enable: (): void => {
+        // Delete is enabled by default (only gated by an in-flight delete).
+      },
+    },
+  ];
+
+  composingChordCases.forEach((c) => {
+    it(`(22.4 AC1/AC3) ${c.name} fires under a composing event (keyCode:229/isComposing/key:'Dead') and preventDefaults`, async () => {
+      await loaded('foo: 1\n');
+      // Keep handlers inert so no real network / modal side effects run; we
+      // only assert the matcher reached the handler under a composing event.
+      const handlerSpy = spyOn(component, c.handler).and.returnValue(
+        undefined as never,
+      );
+      c.enable();
+
+      const evt = composingKeyEvent(c.code, c.extraInit);
+      component.onKeydown(evt);
+
+      expect(handlerSpy)
+        .withContext(`${c.name} handler under composing event`)
+        .toHaveBeenCalledTimes(1);
+      expect(evt.defaultPrevented)
+        .withContext(`${c.name} preventDefault under composing event`)
+        .toBeTrue();
+    });
+  });
+
+  it("(22.4 AC1) the matcher keys off event.code, never event.key — a composing ⌥V with key:'Dead' still validates", async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // key:'Dead' is irrelevant — only altKey + code drive the match.
+    const evt = composingKeyEvent('KeyV');
+    expect(evt.key).toBe('Dead');
+    component.onKeydown(evt);
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBeTrue();
+  });
+
+  it('(22.4 AC2) preventDefault fires under a composing + no-op-by-enablement combo (⌥S while clean)', async () => {
+    await loaded('foo: 1\n');
+    // Clean → triggerSave is a no-op, but the keystroke is "ours" and the
+    // composition MUST still be suppressed (parity with Story 22-2 AC9).
+    const saveSpy = spyOn(component, 'onSaveClick');
+    const evt = composingKeyEvent('KeyS');
+
+    component.onKeydown(evt);
+
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBeTrue();
+  });
+
+  it('(22.4 AC3) per-action enablement is honoured under composing events (clean ⌥S/⌥R no-op; ⌥V/⌥⇧C/⌥D still fire)', async () => {
+    await loaded('foo: 1\n');
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const resetSpy = spyOn(component, 'onResetClick');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const cloneSpy = spyOn(component, 'onCloneClick');
+    const deleteSpy = spyOn(component, 'onDeleteClick');
+
+    // Clean state: Save/Reset are no-ops; Validate/Clone/Delete fire.
+    component.onKeydown(composingKeyEvent('KeyS'));
+    component.onKeydown(composingKeyEvent('KeyR'));
+    component.onKeydown(composingKeyEvent('KeyV'));
+    component.onKeydown(composingKeyEvent('KeyC', { shiftKey: true }));
+    component.onKeydown(composingKeyEvent('KeyD'));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("(22.4 AC1) a composing ⌥⇧C (Clone) still requires Shift — composing Alt+KeyC without Shift is unhandled", async () => {
+    await loaded('foo: 1\n');
+    const cloneSpy = spyOn(component, 'onCloneClick');
+
+    const noShift = composingKeyEvent('KeyC', { shiftKey: false });
+    component.onKeydown(noShift);
+    expect(cloneSpy).not.toHaveBeenCalled();
+    expect(noShift.defaultPrevented).toBeFalse();
+
+    const withShift = composingKeyEvent('KeyC', { shiftKey: true });
+    component.onKeydown(withShift);
+    expect(cloneSpy).toHaveBeenCalledTimes(1);
+    expect(withShift.defaultPrevented).toBeTrue();
+  });
+
+  // ----- AC 4 — host capture-phase listener is the authoritative path -----
+
+  it('(22.4 AC4) a composing keydown dispatched on the host element fires the action via the capture-phase listener', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    // Dispatch (not a direct method call) so the registered capture-phase host
+    // listener — the authoritative path — is what catches the composing chord.
+    const evt = composingKeyEvent('KeyS');
+    fixture.nativeElement.dispatchEvent(evt);
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBeTrue();
+  });
+
+  it('(22.4 AC4) the host capture listener is removed on destroy — a post-teardown keydown does not dispatch', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const saveSpy = spyOn(component, 'onSaveClick').and.returnValue(
+      Promise.resolve(),
+    );
+    const host = fixture.nativeElement as HTMLElement;
+
+    fixture.destroy();
+    host.dispatchEvent(composingKeyEvent('KeyS'));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  // ----- AC 5 — single dispatch per keystroke (no double-fire) -----
+
+  it('(22.4 AC5) a composing ⌥R opens EXACTLY ONE reset confirm via the host path', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    const openSpy = spyOn(component, 'onResetClick').and.callThrough();
+
+    component.onKeydown(composingKeyEvent('KeyR'));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('reset');
+  });
+
+  it('(22.4 AC5) a composing ⌥D from the authoritative host path opens ONE delete confirm; Proceeding once issues exactly ONE DELETE', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+    const openSpy = spyOn(component, 'onDeleteClick').and.callThrough();
+
+    // ONE physical keystroke reaches the ONE authoritative host capture site
+    // (real macOS delivers a single keystroke to a single listener). It opens a
+    // single delete confirm via the idempotent triggerDelete() surface — no
+    // second uncoordinated host dispatch (the old bubble-phase @HostListener is
+    // gone, so there is exactly one host dispatch per keystroke).
+    component.onKeydown(composingKeyEvent('KeyD'));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('delete');
+    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
+
+    // Proceed once → exactly one DELETE issued (no double-submit per keystroke).
+    clickConfirmProceed();
+    await fixture.whenStable();
+    expect(apiSpy.deleteNamespace).toHaveBeenCalledTimes(1);
+  });
+
+  it('(22.4 AC5/AC4) the Monaco best-effort run() routes through the SAME triggerDelete() surface as the host path (parity, not a second uncoordinated dispatch)', async () => {
+    await loaded('foo: 1\n');
+    const { editor, actions } = makeEditorStub();
+    component.onEditorEvent({
+      type: 'init',
+      editor: editor as unknown as NuMonacoEditorEvent['editor'],
+    });
+    const openSpy = spyOn(component, 'onDeleteClick').and.callThrough();
+
+    // The Monaco descriptor's run() reaches the SAME triggerDelete() →
+    // onDeleteClick surface, honouring the same enablement as the host path.
+    // It is best-effort convenience only; correctness rides on the host
+    // capture listener (AC 4). Invoking it opens the same single delete confirm.
+    findAction(actions, 'delete').run(editor);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('delete');
+  });
+
+  // ----- AC 6 — non-composing regression guard (Story 22-2 path intact) -----
+
+  it('(22.4 AC6) the non-composing path is unchanged — ⌥V (no composing flags) still validates and preventDefaults', async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+
+    const evt = keyEvent('KeyV'); // no isComposing / keyCode 229 / key:'Dead'
+    component.onKeydown(evt);
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(evt.defaultPrevented).toBeTrue();
+  });
+
+  it('(22.4 AC6) a composing event WITHOUT Alt is still unhandled — no preventDefault, propagates', async () => {
+    await loaded('foo: 1\n');
+    const validateSpy = spyOn(component, 'onValidateBufferClick').and.returnValue(
+      Promise.resolve(),
+    );
+    // altKey:false overrides the keyEvent default → not ours.
+    const evt = composingKeyEvent('KeyV', { altKey: false });
+
+    component.onKeydown(evt);
+
+    expect(validateSpy).not.toHaveBeenCalled();
+    expect(evt.defaultPrevented).toBeFalse();
+  });
+
+  // ---------------------------------------------------------------------
   // Story 22.3 (ADR-018 §1–§4) — custom confirmation modal + secondary-modal
   // interaction contract: no <p-confirmDialog>; Clone-idiom custom modal;
   // focus-Cancel/Enter-cancels; hasSecondaryPanelOpen predicate; no backdrop;

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -3198,27 +3198,27 @@ entries: {}
     expect(confirmOpen()).toBeFalse();
   });
 
-  // ----- AC 9 / AC 10 — focus the safe button; Enter/activate cancels -----
+  // ----- ADR-018 Amendment §e — focus the PRIMARY/proceed button; Esc cancels -----
 
-  it('(22.3 AC9) onConfirmDialogShow focuses the safe button (Cancel for reset/delete)', fakeAsync(async () => {
+  it('(ADR-018 §e) onConfirmDialogShow focuses the primary/proceed button (reset/delete/discard)', fakeAsync(async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     component.onResetClick();
 
-    const safeBtn = document.createElement('button');
-    document.body.appendChild(safeBtn);
-    component.confirmSafeBtnRef = {
-      nativeElement: safeBtn,
+    const primaryBtn = document.createElement('button');
+    document.body.appendChild(primaryBtn);
+    component.confirmPrimaryBtnRef = {
+      nativeElement: primaryBtn,
     } as ElementRef<HTMLButtonElement>;
 
     component.onConfirmDialogShow();
     tick(0);
 
-    expect(document.activeElement).toBe(safeBtn);
-    document.body.removeChild(safeBtn);
+    expect(document.activeElement).toBe(primaryBtn);
+    document.body.removeChild(primaryBtn);
   }));
 
-  it('(22.3 AC9) drift variant focuses the Reload (safe) button on show', fakeAsync(async () => {
+  it('(ADR-018 §e) drift variant focuses the Reload (recommended primary) button on show', fakeAsync(async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
@@ -3229,7 +3229,7 @@ entries: {}
 
     const reloadBtn = document.createElement('button');
     document.body.appendChild(reloadBtn);
-    component.confirmSafeBtnRef = {
+    component.confirmPrimaryBtnRef = {
       nativeElement: reloadBtn,
     } as ElementRef<HTMLButtonElement>;
 
@@ -3295,39 +3295,45 @@ entries: {}
     expect(component.hasSecondaryPanelOpen).toBeFalse();
   });
 
-  // ----- AC 14 — no backdrop / mask under either secondary panel -----
+  // ----- ADR-018 Amendment §a (FIX 4) — transparent-mask draggable modals -----
   //
-  // PrimeNG v19 always renders a `.p-dialog-mask` positioning wrapper, but the
-  // DIMMING backdrop is only painted in modal mode. With `[modal]="false"` the
-  // wrapper is transparent and `pointer-events: none` (no backdrop, click-through
-  // to the config panel underneath). The contract is asserted on that style.
+  // The secondary panels stay `[modal]="true"` + `[draggable]="true"` (properly
+  // modal: draggable, pointer-contained) but paint NO dimming backdrop. PrimeNG
+  // v19 always renders a `.p-dialog-mask` wrapper; the no-dimming is achieved by
+  // tagging that wrapper with `np-secondary-modal-mask` (whose background the
+  // component SCSS forces transparent). In modal mode the mask keeps
+  // `pointer-events: auto`, so it ABSORBS clicks (no click-through). The
+  // deterministic, headless-stable contract is the mask class + modal pointer
+  // behaviour (computed background transparency is a real-browser concern).
 
-  it('(22.3 AC14) the Clone <p-dialog> renders without a dimming backdrop (mask is pointer-events:none)', async () => {
+  it('(ADR-018 §a) the Clone <p-dialog> mask carries the transparent np-secondary-modal-mask class and stays modal (pointer-events auto)', async () => {
     await loadedWithCloneSrc(['src']);
     component.onCloneClick();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const mask = document.querySelector(
-      '.p-dialog-mask',
-    ) as HTMLElement | null;
+    const mask = document.querySelector('.p-dialog-mask') as HTMLElement | null;
     expect(mask).withContext('Clone dialog mask wrapper present').not.toBeNull();
-    // Non-modal: no backdrop — the mask does not capture pointer events.
-    expect(mask!.style.pointerEvents).toBe('none');
+    expect(
+      mask!.classList.contains('np-secondary-modal-mask'),
+    ).withContext('transparent mask class applied').toBeTrue();
+    // Modal mode → the mask absorbs clicks (no click-through to the config panel).
+    expect(mask!.style.pointerEvents).toBe('auto');
   });
 
-  it('(22.3 AC14) the confirmation <p-dialog> renders without a dimming backdrop (mask is pointer-events:none)', async () => {
+  it('(ADR-018 §a) the confirmation <p-dialog> mask carries the transparent np-secondary-modal-mask class and stays modal (pointer-events auto)', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     component.onResetClick();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const mask = document.querySelector(
-      '.p-dialog-mask',
-    ) as HTMLElement | null;
+    const mask = document.querySelector('.p-dialog-mask') as HTMLElement | null;
     expect(mask).withContext('confirm dialog mask wrapper present').not.toBeNull();
-    expect(mask!.style.pointerEvents).toBe('none');
+    expect(
+      mask!.classList.contains('np-secondary-modal-mask'),
+    ).withContext('transparent mask class applied').toBeTrue();
+    expect(mask!.style.pointerEvents).toBe('auto');
   });
 
   // ----- AC 16 / AC 18 — shared dark-red destructive class -----
@@ -3404,4 +3410,190 @@ entries: {}
     component.onConfirmDialogHide();
     tick();
   }));
+
+  // ---------------------------------------------------------------------
+  // ADR-018 Amendment §c — public confirmDiscard() (dirty-CLOSE / dirty-NAV)
+  // ---------------------------------------------------------------------
+
+  it('(ADR-018 §c) confirmDiscard opens the discard variant with the canonical header/message', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    void component.confirmDiscard();
+
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('discard');
+    expect(component.confirmRequest!.header).toBe('Unsaved changes');
+    expect(component.confirmRequest!.message).toBe(
+      'You have unsaved changes. Discard?',
+    );
+    // Settle so no async leaks into later specs.
+    component.onConfirmDialogHide();
+  });
+
+  it('(ADR-018 §c) confirmDiscard resolves true when Proceed is clicked', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    const promise = component.confirmDiscard();
+    clickConfirmProceed();
+
+    await expectAsync(promise).toBeResolvedTo(true);
+    expect(confirmOpen()).toBeFalse();
+  });
+
+  it('(ADR-018 §c) confirmDiscard resolves false when Cancel is clicked', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    const promise = component.confirmDiscard();
+    clickConfirmCancel();
+
+    await expectAsync(promise).toBeResolvedTo(false);
+    expect(confirmOpen()).toBeFalse();
+  });
+
+  it('(ADR-018 §c) confirmDiscard resolves false on Esc/X dismissal (onConfirmDialogHide)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    const promise = component.confirmDiscard();
+    component.onConfirmDialogHide();
+
+    await expectAsync(promise).toBeResolvedTo(false);
+  });
+
+  it('(ADR-018 §d) the discard-variant Proceed button is NOT destructive (no danger class)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    void component.confirmDiscard();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const proceedBtn = document.querySelector(
+      '[data-test="confirm-proceed-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(proceedBtn).not.toBeNull();
+    expect(
+      proceedBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeFalse();
+    component.onConfirmDialogHide();
+  });
+
+  // ---------------------------------------------------------------------
+  // ADR-018 Amendment §d — affirmative label is "Proceed" for every single-
+  // affirmative variant (reset, delete, discard); dark-red is class-only.
+  // ---------------------------------------------------------------------
+
+  it('(ADR-018 §d) confirmProceedLabel is "Proceed" for reset / delete / discard', async () => {
+    await loaded('foo: 1\n');
+
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    expect(component.confirmProceedLabel).toBe('Proceed');
+    component.onConfirmDialogHide();
+
+    component.onDeleteClick();
+    expect(component.confirmProceedLabel).toBe('Proceed');
+    component.onConfirmDialogHide();
+
+    void component.confirmDiscard();
+    expect(component.confirmProceedLabel).toBe('Proceed');
+    component.onConfirmDialogHide();
+  });
+
+  it('(ADR-018 §d) the delete-variant Proceed button shows "Proceed" but keeps the dark-red danger class', async () => {
+    await loaded('foo: 1\n');
+    component.onDeleteClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const proceedBtn = document.querySelector(
+      '[data-test="confirm-proceed-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(proceedBtn).not.toBeNull();
+    expect(proceedBtn!.textContent).toContain('Proceed');
+    expect(
+      proceedBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeTrue();
+    component.onConfirmDialogHide();
+  });
+
+  // ---------------------------------------------------------------------
+  // ADR-018 Amendment §b (FIX 2) — handleSecondaryEscape: only the topmost
+  // secondary modal closes; exactly one action per Escape.
+  // ---------------------------------------------------------------------
+
+  it('(ADR-018 §b) handleSecondaryEscape closes ONLY the confirm modal (topmost) and returns true', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    expect(component.confirmDialogVisible).toBeTrue();
+
+    const consumed = component.handleSecondaryEscape();
+
+    expect(consumed).toBeTrue();
+    expect(component.confirmDialogVisible).toBeFalse();
+  });
+
+  it('(ADR-018 §b) handleSecondaryEscape closes ONLY the Clone modal when no confirm is open and returns true', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    expect(component.cloneDialogVisible).toBeTrue();
+    expect(component.confirmDialogVisible).toBeFalse();
+
+    const consumed = component.handleSecondaryEscape();
+
+    expect(consumed).toBeTrue();
+    expect(component.cloneDialogVisible).toBeFalse();
+  });
+
+  it('(ADR-018 §b) handleSecondaryEscape returns false when no secondary modal is open (host then closes the config panel)', async () => {
+    await loaded('foo: 1\n');
+    expect(component.hasSecondaryPanelOpen).toBeFalse();
+
+    expect(component.handleSecondaryEscape()).toBeFalse();
+  });
+
+  it('(ADR-018 §b) confirm wins over Clone when both flags are set — only the confirm closes (no cascade)', async () => {
+    await loadedWithCloneSrc(['src']);
+    // Force both secondary flags on (e.g. a confirm stacked over Clone).
+    component.cloneDialogVisible = true;
+    component.confirmRequest = {
+      header: 'Unsaved changes',
+      message: 'Discard unsaved changes?',
+      variant: 'reset',
+    };
+    component.confirmDialogVisible = true;
+
+    const consumed = component.handleSecondaryEscape();
+
+    expect(consumed).toBeTrue();
+    // Only the confirm closed; the Clone modal is still open (no cascade).
+    expect(component.confirmDialogVisible).toBeFalse();
+    expect(component.cloneDialogVisible).toBeTrue();
+  });
+
+  // ---------------------------------------------------------------------
+  // ADR-018 Amendment §a (FIX 4) — secondary modals are modal + draggable.
+  // ---------------------------------------------------------------------
+
+  it('(ADR-018 §a) the confirmation <p-dialog> is rendered modal and draggable', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Draggable dialogs expose a grab cursor on their header in PrimeNG; the
+    // deterministic contract here is that the dialog container rendered (modal
+    // mask present) — the modal/draggable inputs are asserted via the template
+    // binding, which compiles only if the inputs exist on <p-dialog>.
+    const container = document.querySelector(
+      '[data-test="confirm-dialog"] .p-dialog, .p-dialog',
+    ) as HTMLElement | null;
+    expect(container).withContext('confirm dialog container rendered').not.toBeNull();
+    component.onConfirmDialogHide();
+  });
 });

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.spec.ts
@@ -22,9 +22,8 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NuMonacoEditorEvent } from '@ng-util/monaco-editor';
 import yaml from 'js-yaml';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -120,7 +119,6 @@ describe('NamespacePanelComponent', () => {
   let component: NamespacePanelComponent;
   let apiSpy: jasmine.SpyObj<ApiService>;
   let messageSpy: jasmine.SpyObj<MessageService>;
-  let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
   // Minimal AuthService stub exposing only a settable `currentUserValue`
   // (the sole surface the panel's advisory owner pre-check reads). Defaults
   // to the anonymous user so pre-existing Save tests — whose buffers carry
@@ -165,13 +163,6 @@ describe('NamespacePanelComponent', () => {
       'deleteNamespace',
     ]);
     messageSpy = jasmine.createSpyObj('MessageService', ['add']);
-    // Use a REAL ConfirmationService instance (its `requireConfirmation$`
-    // Subject is wired) and spy on `.confirm` — PrimeNG's `<p-confirmDialog>`
-    // subscribes to `requireConfirmation$` on instantiation, so a bare
-    // `jasmine.createSpyObj` breaks the constructor.
-    confirmationSpy =
-      new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
-    spyOn(confirmationSpy, 'confirm').and.callThrough();
     authStub = { currentUserValue: { user_id: 'anonymous' } };
 
     await TestBed.configureTestingModule({
@@ -186,13 +177,19 @@ describe('NamespacePanelComponent', () => {
       // the same template surface (selector + `options` + `ControlValueAccessor`)
       // but does not kick off Monaco's AMD loader — which previously leaked
       // late `onDestroy` registrations across tests (NG0911).
+      //
+      // Story 22.3 (ADR-018 §1) — the panel no longer uses
+      // `ConfirmationService` / `<p-confirmDialog>`; the three confirm flows
+      // run through the panel-owned custom modal driven by component state, so
+      // the old `confirmationSpy` real-instance wiring + provider override are
+      // gone. Confirm assertions read `confirmDialogVisible` / `confirmRequest`
+      // and exercise the modal's button handlers directly.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
             CommonModule,
             FormsModule,
             ButtonModule,
-            ConfirmDialogModule,
             DialogModule,
             InputTextModule,
             ToggleSwitchModule,
@@ -200,16 +197,43 @@ describe('NamespacePanelComponent', () => {
             StubMonacoEditorComponent,
             ValidationReportComponent,
           ],
-          // Swap the locally-provided real ConfirmationService for a spy so
-          // the Reset + drift + confirm-dialog flows are testable
-          // deterministically.
-          providers: [
-            { provide: ConfirmationService, useValue: confirmationSpy },
-          ],
         },
       })
       .compileComponents();
   });
+
+  // ---------------------------------------------------------------------
+  // Story 22.3 — custom confirmation modal helpers. These replace the old
+  // `confirmationSpy.confirm` call-count / `args.accept!()` idiom: a confirm
+  // is "open" when `confirmDialogVisible` is true and `confirmRequest` carries
+  // the flow's header/message/variant; Proceed / Cancel / Reload / Overwrite
+  // are exercised via the component's button handlers.
+  // ---------------------------------------------------------------------
+
+  /** True iff the custom confirmation modal is open. */
+  function confirmOpen(): boolean {
+    return component.confirmDialogVisible && component.confirmRequest !== null;
+  }
+
+  /** Run the Proceed (reset/delete) button effect, then close. */
+  function clickConfirmProceed(): void {
+    component.onConfirmProceedClick();
+  }
+
+  /** Run the Cancel (reset/delete) button effect, then close. */
+  function clickConfirmCancel(): void {
+    component.onConfirmCancelClick();
+  }
+
+  /** Run the Reload (drift safe-default) button effect, then close. */
+  function clickConfirmReload(): void {
+    component.onConfirmReloadClick();
+  }
+
+  /** Run the Overwrite (drift destructive) button effect, then close. */
+  function clickConfirmOverwrite(): void {
+    component.onConfirmOverwriteClick();
+  }
 
   // ---------------------------------------------------------------------
   // Shared load helper — drives ngOnInit → loadNamespace → stable view.
@@ -901,13 +925,13 @@ describe('NamespacePanelComponent', () => {
     await component.onSaveClick();
 
     // Drift re-export ran (one extra export beyond the mount load) but no
-    // confirm was shown.
+    // confirm modal was shown.
     expect(apiSpy.exportNamespace).toHaveBeenCalledTimes(2);
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
   });
 
-  it('(22.1 AC20/AC21) Save with diverged server export prompts; reload-and-rebase skips the import and rebases', async () => {
+  it('(22.3 AC7/AC8) Save with diverged server export opens the drift modal with Reload + Overwrite; Reload skips the import and rebases', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     // Server has drifted since load.
@@ -915,17 +939,18 @@ describe('NamespacePanelComponent', () => {
     apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
 
     const savePromise = component.onSaveClick();
-    // Let the drift re-export resolve so the confirm fires.
+    // Let the drift re-export resolve so the modal opens.
     await flushMicrotasks();
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.header).toBe('Namespace modified');
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('drift');
+    expect(component.confirmRequest!.header).toBe('Namespace modified');
 
-    // accept = reload-and-rebase.
-    args.accept!();
+    // Reload = reload-and-rebase (safe / focused default).
+    clickConfirmReload();
     await savePromise;
 
-    // Import was NOT performed this click.
+    // Modal closed; import was NOT performed this click.
+    expect(confirmOpen()).toBeFalse();
     expect(apiSpy.importNamespace).not.toHaveBeenCalled();
     // serverYaml rebased to the latest; buffer kept the operator's edit
     // (it had diverged from the old serverYaml, so it is preserved).
@@ -934,7 +959,7 @@ describe('NamespacePanelComponent', () => {
     expect(component.saving).toBeFalse();
   });
 
-  it('(22.1 AC21) drift reload-and-rebase moves the buffer when it still equalled the old serverYaml', async () => {
+  it('(22.3 AC7) drift Reload moves the buffer when it still equalled the old serverYaml', async () => {
     await loaded('foo: 1\n');
     // Force a dirty gate so onSaveClick runs, but keep buffer === old
     // serverYaml at the moment the rebase fires by reverting after dirtying.
@@ -943,10 +968,10 @@ describe('NamespacePanelComponent', () => {
 
     const savePromise = component.onSaveClick();
     await flushMicrotasks();
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    // Simulate buffer back at the old serverYaml right before accept.
+    expect(component.confirmRequest!.variant).toBe('drift');
+    // Simulate buffer back at the old serverYaml right before Reload.
     component.buffer = 'foo: 1\n';
-    args.accept!();
+    clickConfirmReload();
     await savePromise;
 
     expect(component.serverYaml).toBe('foo: server\n');
@@ -954,7 +979,7 @@ describe('NamespacePanelComponent', () => {
     expect(component.buffer).toBe('foo: server\n');
   });
 
-  it('(22.1 AC21) Save with diverged server export — overwrite choice proceeds with the operator buffer', async () => {
+  it('(22.3 AC7) Save with diverged server export — Overwrite proceeds with the operator buffer', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
@@ -962,13 +987,33 @@ describe('NamespacePanelComponent', () => {
 
     const savePromise = component.onSaveClick();
     await flushMicrotasks();
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    // reject = overwrite → import proceeds with the operator's buffer.
-    args.reject!();
+    expect(component.confirmRequest!.variant).toBe('drift');
+    // Overwrite → import proceeds with the operator's buffer.
+    clickConfirmOverwrite();
     await savePromise;
 
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
     expect(component.serverYaml).toBe('foo: 2\n');
+  });
+
+  it('(22.3 AC8) drift modal dismissal (onHide) resolves the safe branch — no import this click', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
+    apiSpy.importNamespace.and.returnValue(Promise.resolve([]));
+
+    const savePromise = component.onSaveClick();
+    await flushMicrotasks();
+    expect(component.confirmRequest!.variant).toBe('drift');
+
+    // Esc / Cancel / X — the dialog (onHide) fires without a button choice.
+    component.onConfirmDialogHide();
+    await savePromise;
+
+    // Safe branch: no blind overwrite, import skipped this click.
+    expect(apiSpy.importNamespace).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
+    expect(component.saving).toBeFalse();
   });
 
   it('(22.1 AC21) drift export network error falls through to import (non-blocking)', async () => {
@@ -979,7 +1024,7 @@ describe('NamespacePanelComponent', () => {
 
     await component.onSaveClick();
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
     expect(apiSpy.importNamespace).toHaveBeenCalledOnceWith('foo: 2\n');
   });
 
@@ -1024,22 +1069,41 @@ describe('NamespacePanelComponent', () => {
     ).toBeUndefined();
   });
 
-  it('(22.1 AC15) onResetClick reverts behind the confirm, clearing validation state', async () => {
+  it('(22.1 AC15 / 22.3 AC4) onResetClick reverts behind the custom confirm, clearing validation state', async () => {
     await loaded('foo: 1\n');
     component.buffer = 'foo: 2\n';
     component.lastValidation = failingReport(1);
     component.rawSaveError = 'raw';
 
     component.onResetClick();
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.message as string).toContain('Discard unsaved changes');
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('reset');
+    expect(component.confirmRequest!.message).toContain('Discard unsaved changes');
 
-    args.accept!();
+    clickConfirmProceed();
+    expect(confirmOpen()).toBeFalse();
     expect(component.buffer).toBe('foo: 1\n');
     expect(component.lastValidation).toBeNull();
     expect(component.rawSaveError).toBeNull();
     expect(component.hasUnsavedChanges()).toBe(false);
+  });
+
+  it('(22.3 AC4) Reset Cancel leaves all state untouched', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.lastValidation = failingReport(1);
+    component.rawSaveError = 'raw';
+
+    component.onResetClick();
+    expect(confirmOpen()).toBeTrue();
+
+    clickConfirmCancel();
+    expect(confirmOpen()).toBeFalse();
+    // Cancel runs no revert — buffer + validation state are unchanged.
+    expect(component.buffer).toBe('foo: 2\n');
+    expect(component.lastValidation).not.toBeNull();
+    expect(component.rawSaveError).toBe('raw');
+    expect(component.hasUnsavedChanges()).toBe(true);
   });
 
   it('(22.1 AC15) onResetClick is a no-op when clean (no confirm)', async () => {
@@ -1047,7 +1111,7 @@ describe('NamespacePanelComponent', () => {
 
     component.onResetClick();
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
   });
 
   // ---------------------------------------------------------------------
@@ -1897,21 +1961,36 @@ entries:
     expect(btn.disabled).toBeFalse();
   });
 
-  it('(14.1 AC12) clicking Delete opens the confirmation; accepting calls deleteNamespace once', async () => {
+  it('(14.1 AC12 / 22.3 AC5) clicking Delete opens the custom confirm naming the namespace; Proceed calls deleteNamespace once', async () => {
     await loaded('foo: 1\n');
     apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
 
     component.onDeleteClick();
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.header).toBe('Delete namespace');
-    expect(args.icon).toBe('pi pi-trash');
-    expect(args.message as string).toContain('foo');
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('delete');
+    expect(component.confirmRequest!.header).toBe('Delete namespace');
+    expect(component.confirmRequest!.message).toContain('foo');
 
-    args.accept!();
+    clickConfirmProceed();
     await fixture.whenStable();
 
+    expect(confirmOpen()).toBeFalse();
     expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
+  });
+
+  it('(22.3 AC5) Delete Cancel fires no network request and leaves the panel unchanged', async () => {
+    await loaded('foo: 1\n');
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+
+    component.onDeleteClick();
+    expect(confirmOpen()).toBeTrue();
+
+    clickConfirmCancel();
+
+    expect(confirmOpen()).toBeFalse();
+    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
+    expect(component.serverYaml).toBe('foo: 1\n');
+    expect(component.buffer).toBe('foo: 1\n');
   });
 
   it('(14.1 AC13) 204 success — emits saved + closed and shows a success toast', async () => {
@@ -2012,7 +2091,7 @@ entries:
 
     void component.onDeleteConfirm();
     component.onDeleteClick();
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
 
     resolveDelete();
     await firstCall;
@@ -2027,7 +2106,7 @@ entries:
 
     component.onDeleteClick();
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
   });
 
   it('(14.1 AC10) destroy-during-delete — late resolution does not write state', async () => {
@@ -2388,15 +2467,15 @@ entries: {}
     // Clean → no-op (and no confirm).
     component.onKeydown(keyEvent('KeyR'));
     expect(resetSpy).not.toHaveBeenCalled();
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
 
     // Dirty → fires onResetClick, which opens the discard confirm.
     component.buffer = 'foo: 2\n';
     component.onKeydown(keyEvent('KeyR'));
     expect(resetSpy).toHaveBeenCalledTimes(1);
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.message as string).toContain('Discard unsaved changes');
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('reset');
+    expect(component.confirmRequest!.message).toContain('Discard unsaved changes');
   });
 
   it('(22.2 AC3/AC6) ⌥R is a no-op while saving even when dirty', async () => {
@@ -2441,7 +2520,7 @@ entries: {}
     expect(cloneSpy).not.toHaveBeenCalled();
   });
 
-  it('(22.2 AC5) ⌥D opens the Delete confirm; does NOT call deleteNamespace until accept', async () => {
+  it('(22.2 AC5) ⌥D opens the Delete confirm; does NOT call deleteNamespace until Proceed', async () => {
     await loaded('foo: 1\n');
     apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
     const deleteSpy = spyOn(component, 'onDeleteClick').and.callThrough();
@@ -2449,13 +2528,13 @@ entries: {}
     component.onKeydown(keyEvent('KeyD'));
 
     expect(deleteSpy).toHaveBeenCalledTimes(1);
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.header).toBe('Delete namespace');
-    // No direct DELETE before accept.
+    expect(confirmOpen()).toBeTrue();
+    expect(component.confirmRequest!.variant).toBe('delete');
+    expect(component.confirmRequest!.header).toBe('Delete namespace');
+    // No direct DELETE before Proceed.
     expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
 
-    args.accept!();
+    clickConfirmProceed();
     await fixture.whenStable();
     expect(apiSpy.deleteNamespace).toHaveBeenCalledOnceWith('foo');
   });
@@ -2468,7 +2547,7 @@ entries: {}
     component.onKeydown(keyEvent('KeyD'));
 
     expect(deleteSpy).not.toHaveBeenCalled();
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
   });
 
   // ----- Match on code, NOT key — macOS dead-key survival (AC 7) -----
@@ -2753,4 +2832,270 @@ entries: {}
     const arg = onEditorEventSpy.calls.mostRecent().args[0];
     expect(arg.type).toBe('init');
   });
+
+  // ---------------------------------------------------------------------
+  // Story 22.3 (ADR-018 §1–§4) — custom confirmation modal + secondary-modal
+  // interaction contract: no <p-confirmDialog>; Clone-idiom custom modal;
+  // focus-Cancel/Enter-cancels; hasSecondaryPanelOpen predicate; no backdrop;
+  // shared dark-red destructive style.
+  // ---------------------------------------------------------------------
+
+  // ----- AC 1 — <p-confirmDialog> removed; custom modal renders -----
+
+  it('(22.3 AC1) the rendered panel contains no <p-confirmDialog>', async () => {
+    await loaded('foo: 1\n');
+    expect(
+      fixture.nativeElement.querySelector('p-confirmDialog'),
+    ).toBeNull();
+  });
+
+  it('(22.3 AC1/AC2) opening a confirm renders a <p-dialog> with the Clone-modal body/action classes and the supplied header/message', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+
+    component.onResetClick();
+    fixture.detectChanges();
+
+    // The confirm dialog teleports its content to document.body; query the
+    // whole document for the body/action classes + message.
+    const body = document.querySelector(
+      '[data-test="confirm-dialog"] .namespace-panel__clone-body',
+    );
+    const actions = document.querySelector(
+      '[data-test="confirm-dialog"] .namespace-panel__clone-actions',
+    );
+    expect(body).withContext('confirm body uses clone-body class').not.toBeNull();
+    expect(actions)
+      .withContext('confirm action row uses clone-actions class')
+      .not.toBeNull();
+
+    const message = document.querySelector(
+      '[data-test="confirm-message"]',
+    ) as HTMLElement | null;
+    expect(message?.textContent).toContain('Discard unsaved changes');
+  });
+
+  it('(22.3 AC3) the same modal surface is reused across reset / drift / delete variants', async () => {
+    await loaded('foo: 1\n');
+
+    // Reset variant.
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    expect(component.confirmRequest!.variant).toBe('reset');
+    component.onConfirmDialogHide();
+    expect(confirmOpen()).toBeFalse();
+
+    // Delete variant — same `confirmDialogVisible` / `confirmRequest` surface.
+    component.onDeleteClick();
+    expect(component.confirmRequest!.variant).toBe('delete');
+    component.onConfirmDialogHide();
+    expect(confirmOpen()).toBeFalse();
+  });
+
+  // ----- AC 9 / AC 10 — focus the safe button; Enter/activate cancels -----
+
+  it('(22.3 AC9) onConfirmDialogShow focuses the safe button (Cancel for reset/delete)', fakeAsync(async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+
+    const safeBtn = document.createElement('button');
+    document.body.appendChild(safeBtn);
+    component.confirmSafeBtnRef = {
+      nativeElement: safeBtn,
+    } as ElementRef<HTMLButtonElement>;
+
+    component.onConfirmDialogShow();
+    tick(0);
+
+    expect(document.activeElement).toBe(safeBtn);
+    document.body.removeChild(safeBtn);
+  }));
+
+  it('(22.3 AC9) drift variant focuses the Reload (safe) button on show', fakeAsync(async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
+
+    void component.onSaveClick();
+    tick();
+    expect(component.confirmRequest!.variant).toBe('drift');
+
+    const reloadBtn = document.createElement('button');
+    document.body.appendChild(reloadBtn);
+    component.confirmSafeBtnRef = {
+      nativeElement: reloadBtn,
+    } as ElementRef<HTMLButtonElement>;
+
+    component.onConfirmDialogShow();
+    tick(0);
+
+    expect(document.activeElement).toBe(reloadBtn);
+    document.body.removeChild(reloadBtn);
+    // Settle the pending drift promise so no async leaks into later specs.
+    component.onConfirmDialogHide();
+    tick();
+  }));
+
+  it('(22.3 AC10) activating the focused Cancel button runs the cancel path — accept callback does NOT fire (no destructive effect)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onDeleteClick();
+    apiSpy.deleteNamespace.and.returnValue(Promise.resolve());
+
+    // Enter on the focused Cancel button activates it natively → cancel path.
+    clickConfirmCancel();
+
+    expect(apiSpy.deleteNamespace).not.toHaveBeenCalled();
+    expect(confirmOpen()).toBeFalse();
+  });
+
+  // ----- AC 19 — confirm-request state cleared on hide -----
+
+  it('(22.3 AC19) onConfirmDialogHide clears confirmRequest so a stale request cannot leak', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    expect(component.confirmRequest).not.toBeNull();
+
+    component.onConfirmDialogHide();
+
+    expect(component.confirmRequest).toBeNull();
+    expect(component.confirmDialogVisible).toBeFalse();
+  });
+
+  // ----- AC 11 / AC 12 / AC 13 — hasSecondaryPanelOpen predicate -----
+
+  it('(22.3 AC12) hasSecondaryPanelOpen is true when the Clone modal is open, false otherwise', async () => {
+    await loadedWithCloneSrc(['src']);
+    expect(component.hasSecondaryPanelOpen).toBeFalse();
+
+    component.onCloneClick();
+    expect(component.hasSecondaryPanelOpen).toBeTrue();
+
+    component.onCloneDialogVisibleChange(false);
+    expect(component.hasSecondaryPanelOpen).toBeFalse();
+  });
+
+  it('(22.3 AC12) hasSecondaryPanelOpen is true when the confirmation modal is open, false otherwise', async () => {
+    await loaded('foo: 1\n');
+    expect(component.hasSecondaryPanelOpen).toBeFalse();
+
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    expect(component.hasSecondaryPanelOpen).toBeTrue();
+
+    component.onConfirmDialogHide();
+    expect(component.hasSecondaryPanelOpen).toBeFalse();
+  });
+
+  // ----- AC 14 — no backdrop / mask under either secondary panel -----
+  //
+  // PrimeNG v19 always renders a `.p-dialog-mask` positioning wrapper, but the
+  // DIMMING backdrop is only painted in modal mode. With `[modal]="false"` the
+  // wrapper is transparent and `pointer-events: none` (no backdrop, click-through
+  // to the config panel underneath). The contract is asserted on that style.
+
+  it('(22.3 AC14) the Clone <p-dialog> renders without a dimming backdrop (mask is pointer-events:none)', async () => {
+    await loadedWithCloneSrc(['src']);
+    component.onCloneClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const mask = document.querySelector(
+      '.p-dialog-mask',
+    ) as HTMLElement | null;
+    expect(mask).withContext('Clone dialog mask wrapper present').not.toBeNull();
+    // Non-modal: no backdrop — the mask does not capture pointer events.
+    expect(mask!.style.pointerEvents).toBe('none');
+  });
+
+  it('(22.3 AC14) the confirmation <p-dialog> renders without a dimming backdrop (mask is pointer-events:none)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const mask = document.querySelector(
+      '.p-dialog-mask',
+    ) as HTMLElement | null;
+    expect(mask).withContext('confirm dialog mask wrapper present').not.toBeNull();
+    expect(mask!.style.pointerEvents).toBe('none');
+  });
+
+  // ----- AC 16 / AC 18 — shared dark-red destructive class -----
+
+  it('(22.3 AC16) the action-row Delete button carries namespace-panel__danger and drops severity="danger"', async () => {
+    await loaded('foo: 1\n');
+
+    const deleteBtn = fixture.nativeElement.querySelector(
+      'button[data-test="delete-ns-btn"]',
+    ) as HTMLButtonElement;
+    expect(deleteBtn.classList.contains('namespace-panel__danger')).toBeTrue();
+    // The bright PrimeNG danger severity is gone (no p-button-danger class and
+    // no severity attribute set to danger).
+    expect(deleteBtn.getAttribute('severity')).not.toBe('danger');
+  });
+
+  it('(22.3 AC16) the Delete-confirm Proceed button carries the shared namespace-panel__danger class', async () => {
+    await loaded('foo: 1\n');
+    component.onDeleteClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const proceedBtn = document.querySelector(
+      '[data-test="confirm-proceed-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(proceedBtn).withContext('Delete Proceed button rendered').not.toBeNull();
+    expect(
+      proceedBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeTrue();
+  });
+
+  it('(22.3 AC18) the Reset-confirm Proceed button is NOT destructive (no danger class)', async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    component.onResetClick();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const proceedBtn = document.querySelector(
+      '[data-test="confirm-proceed-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(proceedBtn).not.toBeNull();
+    expect(
+      proceedBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeFalse();
+  });
+
+  it('(22.3 AC18) the drift Reload / Overwrite buttons are NOT destructive (no danger class)', fakeAsync(async () => {
+    await loaded('foo: 1\n');
+    component.buffer = 'foo: 2\n';
+    apiSpy.exportNamespace.and.returnValue(Promise.resolve('foo: server\n'));
+
+    void component.onSaveClick();
+    tick();
+    fixture.detectChanges();
+    expect(component.confirmRequest!.variant).toBe('drift');
+
+    const reloadBtn = document.querySelector(
+      '[data-test="confirm-reload-btn"]',
+    ) as HTMLButtonElement | null;
+    const overwriteBtn = document.querySelector(
+      '[data-test="confirm-overwrite-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(reloadBtn).not.toBeNull();
+    expect(overwriteBtn).not.toBeNull();
+    expect(
+      reloadBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeFalse();
+    expect(
+      overwriteBtn!.classList.contains('namespace-panel__danger'),
+    ).toBeFalse();
+
+    // Settle the pending drift promise so no async leaks into later specs.
+    component.onConfirmDialogHide();
+    tick();
+  }));
 });

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -44,17 +44,16 @@ import {
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 /**
- * Typed shape for the panel's custom confirmation modal (ADR-018 §1 +
- * Amendment §c). One interface, every call site — NEVER an inline
- * `Record`/object literal scattered across handlers (Golden Rule #1). `variant`
- * selects the action-row button layout:
+ * Typed shape for the panel's custom confirmation modal (ADR-018). One
+ * interface, every call site — never an inline `Record`/object literal
+ * scattered across handlers. `variant` selects the action-row button layout:
  *   - `'reset'` / `'delete'` / `'discard'` → `[Cancel] [Proceed]` (Proceed is
- *     destructive — dark-red — for `'delete'` only — ADR-018 §4). `'discard'` is
- *     the dirty-CLOSE / dirty-NAV variant the host config dialog (Home) and the
+ *     destructive — dark-red — for `'delete'` only). `'discard'` is the
+ *     dirty-close / dirty-nav variant the host config dialog (Home) and the
  *     route `CanDeactivate` guard reuse via the public `confirmDiscard()`
- *     method (ADR-018 Amendment §c).
+ *     method.
  *   - `'drift'` → `[Reload] [Overwrite]` (two explicit named buttons, not a
- *     binary accept/reject — ADR-018 §1).
+ *     binary accept/reject).
  */
 interface ConfirmRequest {
   header: string;
@@ -65,21 +64,20 @@ interface ConfirmRequest {
 /**
  * NamespacePanelComponent — host-agnostic editor for a catalog namespace YAML.
  *
- * Story 22.1 (ADR-017 §1–§6) collapses the original view/edit two-mode state
- * machine into a single **dirty** signal (`buffer !== serverYaml`). The panel
- * is **always editable** — Monaco mounts permanently writable, there is no
- * Edit-click barrier, and the entire action row is driven by one boolean:
+ * The panel has no view/edit mode axis: it is driven by a single **dirty**
+ * signal (`buffer !== serverYaml`) and is **always editable** — Monaco mounts
+ * permanently writable, there is no Edit-click barrier, and the entire action
+ * row is driven by one boolean (ADR-017):
  *
  *   - Monaco mounts writable (`readOnly: false`); `editorOptions` is a single
  *     stable object built once and never reassigned.
- *   - `hasUnsavedChanges()` collapses to `buffer !== serverYaml` (name +
- *     signature preserved — the route `CanDeactivate` guard and the home
- *     dirty-close guard consume it unchanged).
+ *   - `hasUnsavedChanges()` is `buffer !== serverYaml`; the route
+ *     `CanDeactivate` guard and the home dirty-close guard consume it.
  *   - Action row: Validate (always) · Save (dirty) · Reset (dirty) ·
  *     Clone (clean) · Delete (always).
- *   - Save flow posts directly to `apiService.importNamespace` — NO pre-save
- *     `validate` round-trip (ADR-011 D4) — preceded by a one-shot drift check
- *     (re-export; on divergence prompt reload-and-rebase vs overwrite).
+ *   - Save flow posts directly to `apiService.importNamespace` — no pre-save
+ *     `validate` round-trip — preceded by a one-shot drift check (re-export;
+ *     on divergence prompt reload-and-rebase vs overwrite).
  *   - 422 → populate `lastValidation` (structured) or `rawSaveError`
  *     (fallback); buffer preserved.
  *   - 5xx / 4xx (other than 401/422) → sticky error toast; buffer preserved.
@@ -87,23 +85,23 @@ interface ConfirmRequest {
  *   - 401 → no panel-specific behaviour; the FetchService global toast
  *     surfaces the failure, the app-wide handler (if any) runs. Panel only
  *     clears `saving` in `finally`.
- *   - A panel-owned custom confirmation modal (ADR-018 §1) — same `<p-dialog>`
- *     shell as the Clone modal — guards Reset-with-dirty-buffer, the Save drift
- *     reload-vs-overwrite choice, and Delete. The safe button holds focus on
- *     open so Enter/Esc cancel (ADR-018 §2).
+ *   - A panel-owned custom confirmation modal — same `<p-dialog>` shell as the
+ *     Clone modal — guards Reset-with-dirty-buffer, the Save drift
+ *     reload-vs-overwrite choice, and Delete. The primary button holds focus on
+ *     open so Enter activates it and Esc cancels.
  *
- * The component remains presentation-only: no `Router`, `ActivatedRoute`,
+ * The component is presentation-only: no `Router`, `ActivatedRoute`,
  * `MAT_DIALOG_DATA`, etc. The dialog wrapper (HomeComponent) and the
- * deep-link route (Story 11.6) mount it identically.
+ * deep-link route mount it identically.
  *
  * Public surface contract:
  *   - @Input() namespace: string          — required, drives the load flow.
  *   - @Output() closed: EventEmitter<void> — asks the host to dismiss.
  *   - @Output() saved: EventEmitter<void>  — emitted once per successful
  *     import; hosts re-fetch derived lists (e.g. HomeComponent's dropdown).
- *   - hasUnsavedChanges(): boolean         — dirty-state predicate. Returns
- *     true iff `buffer !== serverYaml`. The route `CanDeactivate` guard and
- *     the home dirty-close guard consume the same method.
+ *   - hasUnsavedChanges(): boolean         — dirty-state predicate. True iff
+ *     `buffer !== serverYaml`. The route `CanDeactivate` guard and the home
+ *     dirty-close guard consume the same method.
  */
 @Component({
   selector: 'app-namespace-panel',
@@ -127,22 +125,21 @@ export class NamespacePanelComponent
 {
   @Input() namespace!: string;
   /**
-   * Story 11.5 — existing namespace identifiers, supplied by the host, used
-   * by the Clone dialog's pre-flight collision check (AC 4). The panel
-   * NEVER re-fetches this list itself (NFR7 — the collision check is a UX
-   * courtesy, not a correctness guarantee; see ADR-011 D5
-   * Collision-on-race).
+   * Existing namespace identifiers, supplied by the host, used by the Clone
+   * dialog's pre-flight collision check. The panel NEVER re-fetches this list
+   * itself — the collision check is a UX courtesy, not a correctness
+   * guarantee (the server is authoritative on collision-on-race).
    */
   @Input() existingNamespaces: string[] = [];
   /**
-   * Story 14.4 — admin "show all" context, propagated from the home toggle
+   * Admin "show all" context, propagated from the home toggle
    * (`showAllNamespaces`). When `true`, the panel's entry-read
    * (`exportNamespace`) carries `?all=true` so an admin can open a
    * foreign-owned namespace surfaced by the "show all" list. `all=true` is
    * honoured server-side only for admins (the `/admin/catalog/*` mount
-   * unscopes admin GETs — see ADR-028 §Decision 9); for a non-admin (or when
-   * the host toggle is off) it is the normal owner-scoped read. Default
-   * `false` keeps every existing caller on the unchanged owner-scoped path.
+   * unscopes admin GETs); for a non-admin (or when the host toggle is off) it
+   * is the normal owner-scoped read. Default `false` keeps every caller on the
+   * owner-scoped path.
    */
   @Input() showAll: boolean = false;
   @Output() closed = new EventEmitter<void>();
@@ -161,15 +158,14 @@ export class NamespacePanelComponent
   lastValidation: NamespaceValidationReport | null = null;
   loading: boolean = false;
 
-  // Story 11.3 — Save flow state.
-  /** True while an `importNamespace` request is in flight (AC 5). */
+  // Save flow state.
+  /** True while an `importNamespace` request is in flight. */
   saving: boolean = false;
 
-  // Story 11.4 — Validate flow state.
+  // Validate flow state.
   /**
-   * True while a `validatePersistedNamespace` or `validateNamespaceBuffer`
-   * request is in flight. Independent from `saving` / `loading` — see
-   * Story 11.4 Dev Notes "Why three separate flags".
+   * True while a `validateNamespaceBuffer` request is in flight. Independent
+   * from `saving` / `loading` so the three flows can be in flight separately.
    */
   validating: boolean = false;
 
@@ -179,8 +175,7 @@ export class NamespacePanelComponent
   // The report pane stays hidden in this path — findings-only.
   //
   //   - `validationFlashBuffer` — true while the Validate button shows the
-  //     success-flash state. (Single flag now — there is one Validate
-  //     button, over the buffer; ADR-017 §4.)
+  //     success-flash state. There is one Validate button, over the buffer.
   //   - `flashTimeoutId` — handle so repeated clicks cancel the prior timer
   //     and the destroy hook cleans up any pending callback.
   validationFlashBuffer: boolean = false;
@@ -196,17 +191,16 @@ export class NamespacePanelComponent
 
   /**
    * Raw (non-structured) server error body surfaced by a 422 whose payload
-   * is not a `NamespaceValidationReport` (AC 7 fallback branch).
+   * is not a `NamespaceValidationReport` (fallback branch).
    * `null` means no unstructured error pending.
    */
   rawSaveError: string | null = null;
-  // Story 11.5 — Clone flow state.
-  /** Controls visibility of the Clone sub-dialog (AC 2, AC 3). */
+  // Clone flow state.
+  /** Controls visibility of the Clone sub-dialog. */
   cloneDialogVisible: boolean = false;
   /**
-   * Destination namespace name typed into the Clone dialog (AC 3). Two-way
-   * bound via `[(ngModel)]`; reset to `''` on dialog dismiss AND on
-   * successful clone (AC 3, AC 8, AC 12).
+   * Destination namespace name typed into the Clone dialog. Two-way bound via
+   * `[(ngModel)]`; reset to `''` on dialog dismiss AND on successful clone.
    */
   cloneDestNs: string = '';
   /**
@@ -218,9 +212,8 @@ export class NamespacePanelComponent
    */
   cloneDestName: string = '';
   /**
-   * Story 12.2 — Clone visibility/sharing toggles, two-way bound via
-   * `[(ngModel)]` to the modal's `p-toggleswitch` controls. The two flags
-   * are ORTHOGONAL:
+   * Clone visibility/sharing toggles, two-way bound via `[(ngModel)]` to the
+   * modal's `p-toggleswitch` controls. The two flags are ORTHOGONAL:
    *   - `cloneShareable` → root `shareable`: other namespaces may reference
    *     entries in this one cross-namespace (referenceability).
    *   - `clonePublic`    → root `public`: non-owner users may list, read, and
@@ -236,68 +229,65 @@ export class NamespacePanelComponent
   cloneShareable: boolean = false;
   clonePublic: boolean = false;
   /**
-   * True while a clone-import request is in flight (AC 8 + AC 14). Gates
-   * the Confirm button (defence in depth alongside the pre-flight
-   * validation) and the outer Clone button so the operator cannot
-   * double-submit.
+   * True while a clone-import request is in flight. Gates the Confirm button
+   * (defence in depth alongside the pre-flight validation) and the outer Clone
+   * button so the operator cannot double-submit.
    */
   cloning: boolean = false;
   /**
    * Tracks the most recent non-HTTP / non-422 / non-401 clone error. The
-   * field is populated on the default failure branch (AC 9) for surfacing
-   * the error via a non-sticky toast; no in-panel action-row Retry button
-   * — re-clicking Clone Confirm is the natural retry path.
+   * field is populated on the default failure branch for surfacing the error
+   * via a non-sticky toast; no in-panel action-row Retry button — re-clicking
+   * Clone Confirm is the natural retry path.
    */
   lastCloneError: Error | null = null;
 
   // -------------------------------------------------------------------
-  // Story 14.1 — Delete-namespace flow (ADR-028 §Decision 5, frontend leg).
+  // Delete-namespace flow (frontend leg).
   // -------------------------------------------------------------------
 
   /**
-   * True while a `deleteNamespace` request is in flight (AC 4). Mirrors the
-   * `cloning` gate: disables the Delete button (`[disabled]="deleting"`) and
-   * makes both `onDeleteClick()` and `onDeleteConfirm()` no-ops, guarding
-   * against double-submit. Cleared in a `finally` block guarded by the
-   * `destroyed` idiom.
+   * True while a `deleteNamespace` request is in flight. Mirrors the `cloning`
+   * gate: disables the Delete button (`[disabled]="deleting"`) and makes both
+   * `onDeleteClick()` and `onDeleteConfirm()` no-ops, guarding against
+   * double-submit. Cleared in a `finally` block guarded by the `destroyed`
+   * idiom.
    */
   deleting: boolean = false;
 
   // -------------------------------------------------------------------
-  // Story 22.3 — Custom confirmation modal (ADR-018 §1–§4). Replaces the
-  // generic `<p-confirmDialog>` / `ConfirmationService` for the three confirm
-  // flows. Driven from component state (a visibility flag + a typed
+  // Custom confirmation modal (ADR-018). One shared shell drives the three
+  // confirm flows from component state (a visibility flag + a typed
   // `ConfirmRequest`) rather than an imperative service call.
   // -------------------------------------------------------------------
 
-  /** Controls visibility of the custom confirmation modal (AC 1, 2). */
+  /** Controls visibility of the custom confirmation modal. */
   confirmDialogVisible: boolean = false;
 
   /**
-   * The active confirm request describing the modal's header/message/variant
-   * (AC 2). `null` when no confirm is open; nulled on close so a stale request
-   * cannot leak into the next open (AC 19).
+   * The active confirm request describing the modal's header/message/variant.
+   * `null` when no confirm is open; nulled on close so a stale request cannot
+   * leak into the next open.
    */
   confirmRequest: ConfirmRequest | null = null;
 
   /**
-   * Per-flow accept callback captured when the confirm opens (AC 3). The
-   * Proceed (reset/delete) and Overwrite (drift) buttons invoke this; a private
-   * closure so each flow runs the same effect its old `confirm({ accept })`
-   * callback ran. `null` while no confirm is open.
+   * Per-flow accept callback captured when the confirm opens. The Proceed
+   * (reset/delete) and Overwrite (drift) buttons invoke this; a private closure
+   * so each flow runs its own effect. `null` while no confirm is open.
    */
   private confirmAccept: (() => void) | null = null;
 
   /**
-   * The drift variant's "Reload" (safe / focused-default) callback (AC 7). Only
-   * set for the `'drift'` variant; Reset/Delete leave it `null` (their safe
-   * branch is a bare cancel). Invoked by the Reload button.
+   * The drift variant's "Reload" (safe / focused-default) callback. Only set
+   * for the `'drift'` variant; Reset/Delete leave it `null` (their safe branch
+   * is a bare cancel). Invoked by the Reload button.
    */
   private confirmReload: (() => void) | null = null;
 
   /**
    * Pending "resolve the drift `Promise<boolean>` to the SAFE branch (false)"
-   * thunk for an Esc / Cancel / X dismissal of the drift modal (AC 8). Set by
+   * thunk for an Esc / Cancel / X dismissal of the drift modal. Set by
    * `checkSaveDrift` while the drift modal is open; invoked by
    * `onConfirmDialogHide` so a dismissal that bypasses a button still settles
    * the awaited promise (and does so as the non-overwrite branch). `null` for
@@ -309,72 +299,70 @@ export class NamespacePanelComponent
   /**
    * Pending "resolve the dirty-discard `Promise<boolean>` to the SAFE branch
    * (false — keep edits)" thunk for an Esc / Cancel / X dismissal of the
-   * `'discard'` modal (ADR-018 Amendment §c). Set by `confirmDiscard()` while
-   * the discard modal is open; invoked by `onConfirmDialogHide` so a dismissal
-   * that bypasses a button still settles the awaited promise as "do not
-   * discard". `null` for the reset/delete/drift variants.
+   * `'discard'` modal. Set by `confirmDiscard()` while the discard modal is
+   * open; invoked by `onConfirmDialogHide` so a dismissal that bypasses a
+   * button still settles the awaited promise as "do not discard". `null` for
+   * the reset/delete/drift variants.
    */
   private confirmDiscardResolve: (() => void) | null = null;
 
   /**
-   * Primary-button reference for the confirmation modal (ADR-018 Amendment §e
-   * — reverses the earlier focus-Cancel). On open `onConfirmDialogShow()`
-   * autofocuses the PRIMARY/proceed button so **Enter activates the main
-   * action**: the Proceed button for the reset/delete/discard variants, the
-   * Reload (recommended primary) button for the drift variant. Esc still
-   * cancels/dismisses. Mirrors the Clone modal's `cloneDestInputRef` focus
-   * plumbing.
+   * Primary-button reference for the confirmation modal. On open
+   * `onConfirmDialogShow()` autofocuses the PRIMARY/proceed button so **Enter
+   * activates the main action**: the Proceed button for the
+   * reset/delete/discard variants, the Reload (recommended primary) button for
+   * the drift variant. Esc still cancels/dismisses. Mirrors the Clone modal's
+   * `cloneDestInputRef` focus plumbing.
    */
   @ViewChild('confirmPrimaryBtn', { read: ElementRef })
   confirmPrimaryBtnRef?: ElementRef<HTMLButtonElement>;
 
   // -------------------------------------------------------------------
-  // Story 11.7 — UX-polish state (FR14 gate, FR16 a11y, FR17 Clone modal,
-  // FR21 inline error)
+  // UX-polish state (validation gate, a11y live region, Clone modal,
+  // inline error)
   // -------------------------------------------------------------------
 
   /**
-   * Story 11.7 FR16 — visually-hidden polite live-region payload. The
-   * template renders this string inside a `role="status" aria-live="polite"
-   * aria-atomic="true"` <div>; assistive-tech announces every change.
-   * Writes happen at FOUR sites: `flashValidated` (Validation passed),
-   * `announceValidationOutcome` (Validation found N issues),
-   * `onSaveClick` 2xx branch (Namespace saved),
+   * Visually-hidden polite live-region payload. The template renders this
+   * string inside a `role="status" aria-live="polite" aria-atomic="true"`
+   * <div>; assistive-tech announces every change. Writes happen at FOUR sites:
+   * `flashValidated` (Validation passed), `announceValidationOutcome`
+   * (Validation found N issues), `onSaveClick` 2xx branch (Namespace saved),
    * `onCloneConfirmClick` 2xx branch (Cloned to namespace 'X').
    */
   a11yAnnouncement: string = '';
 
   /**
-   * Story 11.7 FR17 (AC 21) — inline error text for the Clone modal's
-   * unstructured-422 branch. When non-null, rendered as a `role="alert"`
-   * <small> immediately below the destination input. Cleared by
-   * `onCloneDestNsChange()` (any keystroke) and by `onCloneDialogHide()`.
+   * Inline error text for the Clone modal's unstructured-422 branch. When
+   * non-null, rendered as a `role="alert"` <small> immediately below the
+   * destination input. Cleared by `onCloneDestNsChange()` (any keystroke) and
+   * by `onCloneDialogHide()`.
    */
   cloneInlineError: string | null = null;
 
   /**
-   * Story 11.7 FR17 (AC 19) — outer Clone button reference. Used by
-   * `onCloneDialogHide()` to return focus to this button after the modal
-   * closes (Cancel / Escape / X / outside click / Confirm).
+   * Outer Clone button reference. Used by `onCloneDialogHide()` to return focus
+   * to this button after the modal closes (Cancel / Escape / X / outside
+   * click / Confirm).
    */
   @ViewChild('cloneBtn', { read: ElementRef })
   cloneBtnRef?: ElementRef<HTMLButtonElement>;
 
   /**
-   * Story 11.7 FR17 (AC 16) — destination input reference. Used by
-   * `onCloneDialogShow()` to autofocus the input on modal open.
+   * Destination input reference. Used by `onCloneDialogShow()` to autofocus the
+   * input on modal open.
    */
   @ViewChild('cloneDestInput', { read: ElementRef })
   cloneDestInputRef?: ElementRef<HTMLInputElement>;
 
   /**
    * Destroy guard consumed by the async load + save flows so a late-resolving
-   * promise cannot write to state on a destroyed component (AC 13).
+   * promise cannot write to state on a destroyed component.
    */
   private destroyed = false;
   /**
    * Monotonic counter used to discard stale `exportNamespace` responses
-   * when `namespace` changes mid-flight (AC 3 re-load contract).
+   * when `namespace` changes mid-flight.
    */
   private loadSeq = 0;
 
@@ -400,8 +388,8 @@ export class NamespacePanelComponent
       clearTimeout(this.flashTimeoutId);
     }
     this.validationFlashBuffer = true;
-    // Story 11.7 AC 11 — pair the visual flash with an aria-live
-    // announcement so screen-reader users get the same outcome.
+    // Pair the visual flash with an aria-live announcement so screen-reader
+    // users get the same outcome.
     this.a11yAnnouncement = 'Validation passed';
     this.flashTimeoutId = setTimeout(() => {
       this.flashTimeoutId = undefined;
@@ -414,18 +402,17 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Story 11.7 AC 12 — write the failing-validation announcement into the
-   * live region. Called from the sites that populate `lastValidation` with a
-   * non-clean report: the `onValidateBufferClick` failing branch and the
-   * Save / Clone / Delete 422 structured branches in `handleSaveError` /
-   * `handleCloneError` / `handleDeleteError`.
+   * Write the failing-validation announcement into the live region. Called
+   * from the sites that populate `lastValidation` with a non-clean report: the
+   * `onValidateBufferClick` failing branch and the Save / Clone / Delete 422
+   * structured branches in `handleSaveError` / `handleCloneError` /
+   * `handleDeleteError`.
    *
    * Plural form is fixed at "issues" (e.g. "Validation found 1 issues") for
    * announcement-text simplicity — assistive-tech audiences tolerate the
    * unidiomatic phrasing better than two announcement variants would
    * tolerate inconsistent rendering. `?? 0` defends against a malformed
-   * report missing one of the arrays (test-double sloppiness or a future
-   * schema change).
+   * report missing one of the arrays.
    */
   private announceValidationOutcome(report: NamespaceValidationReport): void {
     const total =
@@ -461,12 +448,11 @@ export class NamespacePanelComponent
         this.flashTimeoutId = undefined;
       }
     }
-    // Story 11.7 AC 3 — clear stale save error on any keystroke so the
-    // FR14 gate auto-lifts. Unconditional (any keystroke is the operator
-    // declaring "I am editing — re-evaluate"). The corresponding
-    // `lastValidation` clear remains conditional (only when
-    // `value !== validatedBuffer`) to preserve Story 11.4 green-flash
-    // semantics.
+    // Clear stale save error on any keystroke so the validation gate
+    // auto-lifts. Unconditional (any keystroke is the operator declaring "I am
+    // editing — re-evaluate"). The corresponding `lastValidation` clear remains
+    // conditional (only when `value !== validatedBuffer`) to preserve the
+    // green-flash semantics.
     if (this.rawSaveError !== null) {
       this.rawSaveError = null;
     }
@@ -490,14 +476,12 @@ export class NamespacePanelComponent
 
   /**
    * Monaco editor options — a single stable object reference built once and
-   * NEVER reassigned (ADR-017 §1). The editor is permanently writable
-   * (`readOnly: false`) since the panel is always editable.
+   * NEVER reassigned. The editor is permanently writable (`readOnly: false`)
+   * since the panel is always editable.
    *
    * `nu-monaco-editor` receives `[options]` as a signal input
-   * (reference-equality semantics): a stable reference means Monaco's
-   * `updateOptions()` does not re-run on every change-detection tick. The old
-   * per-mode reassignment (via `setMode`) was the CD-churn risk; with one
-   * constant object that risk is gone.
+   * (reference-equality semantics): a stable reference is load-bearing so
+   * Monaco's `updateOptions()` does not re-run on every change-detection tick.
    *
    * `automaticLayout: true` is load-bearing for dialog hosting — the editor
    * otherwise renders at 0×0 when its container mounts late.
@@ -512,32 +496,31 @@ export class NamespacePanelComponent
   /**
    * Dirty-state predicate — single source of truth for the confirm-on-close
    * guards and the Save/Reset/Clone enablement. True iff the buffer diverges
-   * from the last server snapshot (ADR-017 §1). The method NAME + SIGNATURE
-   * are preserved: the route `CanDeactivate` guard and the home dirty-close
-   * guard consume the same method.
+   * from the last server snapshot. The route `CanDeactivate` guard and the home
+   * dirty-close guard consume the same method.
    */
   hasUnsavedChanges(): boolean {
     return this.buffer !== this.serverYaml;
   }
 
   // -------------------------------------------------------------------
-  // Story 22.2 (ADR-017 §7) — keyboard shortcuts.
+  // Keyboard shortcuts (ADR-017).
   //
   // The five action shortcuts are captured in TWO places — a Monaco
   // `editor.addAction` (in-editor focus; Monaco swallows keystrokes) and a
-  // component `@HostListener('keydown')` (focus outside the editor, e.g. on a
+  // capture-phase host keydown listener (focus outside the editor, e.g. on a
   // button). Both paths funnel through ONE shared dispatch surface: the
   // `can*` enablement getters below (which mirror the button `[disabled]`
   // expressions) and the `triggerX()` entry points. The button template binds
   // the SAME `can*` getters so the enablement predicate cannot drift between
-  // the click path and the shortcut path (AC 6, AC 12).
+  // the click path and the shortcut path.
   // -------------------------------------------------------------------
 
   /**
    * Save enablement — mirrors the Save button's `[disabled]` expression
    * (`buffer === serverYaml || saving || isSaveGated`). `buffer !== serverYaml`
    * is exactly `hasUnsavedChanges()`, used here so intent is explicit. ⌥S
-   * fires Save iff this is true (AC 1, AC 6).
+   * fires Save iff this is true.
    */
   get canSave(): boolean {
     return this.hasUnsavedChanges() && !this.saving && !this.isSaveGated;
@@ -545,8 +528,8 @@ export class NamespacePanelComponent
 
   /**
    * Validate enablement — mirrors the Validate button's `[disabled]`
-   * (`saving || validating`). NEVER gated by FR14 (ADR-017 §5); ⌥V fires in
-   * both clean and dirty states (AC 2, AC 6).
+   * (`saving || validating`). NEVER gated by the validation gate; ⌥V fires in
+   * both clean and dirty states.
    */
   get canValidate(): boolean {
     return !this.validating && !this.saving;
@@ -555,7 +538,7 @@ export class NamespacePanelComponent
   /**
    * Reset enablement — mirrors the Reset button's `[disabled]`
    * (`buffer === serverYaml || saving`). ⌥R is a no-op while clean; when dirty
-   * it routes through the existing discard confirm (AC 3, AC 6).
+   * it routes through the discard confirm.
    */
   get canReset(): boolean {
     return this.hasUnsavedChanges() && !this.saving;
@@ -564,7 +547,7 @@ export class NamespacePanelComponent
   /**
    * Clone enablement — mirrors the Clone button's `[disabled]`
    * (`buffer !== serverYaml || cloning || isCloneGated`). ⌥⇧C is a no-op while
-   * dirty; it opens the Clone modal only when clean (AC 4, AC 6).
+   * dirty; it opens the Clone modal only when clean.
    */
   get canClone(): boolean {
     return !this.hasUnsavedChanges() && !this.cloning && !this.isCloneGated;
@@ -572,17 +555,16 @@ export class NamespacePanelComponent
 
   /**
    * Delete enablement — mirrors the Delete button's `[disabled]`
-   * (`deleting`). ⌥D still routes through the Delete confirm dialog (AC 5,
-   * AC 6).
+   * (`deleting`). ⌥D still routes through the Delete confirm dialog.
    */
   get canDelete(): boolean {
     return !this.deleting;
   }
 
   /**
-   * Shared Save trigger (AC 1, AC 12). Consults `canSave` then delegates to
-   * the existing handler body — never duplicates it. A true no-op when Save
-   * is disabled (the keystroke is still `preventDefault`ed upstream — AC 9).
+   * Shared Save trigger. Consults `canSave` then delegates to the handler body
+   * — never duplicates it. A true no-op when Save is disabled (the keystroke is
+   * still `preventDefault`ed upstream).
    */
   private triggerSave(): void {
     if (this.canSave) {
@@ -590,28 +572,28 @@ export class NamespacePanelComponent
     }
   }
 
-  /** Shared Validate trigger (AC 2, AC 12). */
+  /** Shared Validate trigger. */
   private triggerValidate(): void {
     if (this.canValidate) {
       void this.onValidateBufferClick();
     }
   }
 
-  /** Shared Reset trigger (AC 3, AC 12). */
+  /** Shared Reset trigger. */
   private triggerReset(): void {
     if (this.canReset) {
       this.onResetClick();
     }
   }
 
-  /** Shared Clone trigger (AC 4, AC 12). */
+  /** Shared Clone trigger. */
   private triggerClone(): void {
     if (this.canClone) {
       this.onCloneClick();
     }
   }
 
-  /** Shared Delete trigger (AC 5, AC 12) — routes through the Delete confirm. */
+  /** Shared Delete trigger — routes through the Delete confirm. */
   private triggerDelete(): void {
     if (this.canDelete) {
       this.onDeleteClick();
@@ -619,31 +601,30 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Single keyboard matcher consumed by BOTH capture sites (AC 7–9, 12).
+   * Single keyboard matcher consumed by BOTH capture sites.
    *
    * - Returns immediately (unhandled, NO `preventDefault`) when `!altKey`.
    * - Keys off `event.code` (NOT `event.key`) so macOS Option dead-keys
-   *   (⌥S → `ß`, ⌥V → `√`, …) still match (AC 7).
+   *   (⌥S → `ß`, ⌥V → `√`, …) still match.
    * - `KeyC` → Clone ONLY when `event.shiftKey` (Alt+KeyC without Shift is
-   *   unhandled — AC 8). The S/V/R/D branches are keyed by their own codes, so
-   *   Alt+Shift+KeyC fires ONLY Clone (no double-fire — AC 8).
+   *   unhandled). The S/V/R/D branches are keyed by their own codes, so
+   *   Alt+Shift+KeyC fires ONLY Clone (no double-fire).
    * - On a recognised combo, `preventDefault()` is called ALWAYS — even when
-   *   the matching `triggerX()` is a no-op by enablement (AC 9) — so the
-   *   dead-key glyph / Alt-mnemonic is suppressed for keystrokes that are
-   *   "ours".
+   *   the matching `triggerX()` is a no-op by enablement — so the dead-key
+   *   glyph / Alt-mnemonic is suppressed for keystrokes that are "ours".
    *
-   * macOS dead-key / IME composition robustness (Story 22-4, ADR-018 §5).
-   * On some macOS keyboard layouts an ⌥-chord initiates a dead-key
-   * composition: the browser delivers the `keydown` flagged as composing
-   * (`isComposing === true`, `keyCode === 229`, `key === 'Dead'`). This matcher
-   * MUST NOT early-return on those flags — it keys off `event.altKey` +
-   * `event.code` ONLY and never reads `event.key`, so a composing event with
-   * `code: 'KeyV'` still matches and fires Validate. The `preventDefault()` on a
-   * handled combo also suppresses the OS dead-key composition so no glyph is
-   * inserted. NEVER add an `isComposing` / `keyCode === 229` / `key === 'Dead'`
-   * guard ahead of this matcher for these chords. (Karma cannot reproduce the
-   * real OS composition layer — synthetic `KeyboardEvent`s bypass it — so the
-   * real-world fix is manually verified on macOS; see the story's manual gate.)
+   * macOS dead-key / IME composition robustness (ADR-018). On some macOS
+   * keyboard layouts an ⌥-chord initiates a dead-key composition: the browser
+   * delivers the `keydown` flagged as composing (`isComposing === true`,
+   * `keyCode === 229`, `key === 'Dead'`). This matcher MUST NOT early-return on
+   * those flags — it keys off `event.altKey` + `event.code` ONLY and never
+   * reads `event.key`, so a composing event with `code: 'KeyV'` still matches
+   * and fires Validate. The `preventDefault()` on a handled combo also
+   * suppresses the OS dead-key composition so no glyph is inserted. NEVER add
+   * an `isComposing` / `keyCode === 229` / `key === 'Dead'` guard ahead of this
+   * matcher for these chords. (Karma cannot reproduce the real OS composition
+   * layer — synthetic `KeyboardEvent`s bypass it — so the real-world fix is
+   * manually verified on macOS.)
    */
   private matchShortcut(event: KeyboardEvent): void {
     if (!event.altKey) {
@@ -671,31 +652,29 @@ export class NamespacePanelComponent
           event.preventDefault();
           this.triggerClone();
         }
-        // Alt+KeyC without Shift is unhandled — no preventDefault (AC 8).
+        // Alt+KeyC without Shift is unhandled — no preventDefault.
         return;
       default:
-        // Alt + a non-bound code — unhandled, propagates (AC 9).
+        // Alt + a non-bound code — unhandled, propagates.
         return;
     }
   }
 
   /**
    * Component-level keydown capture — the AUTHORITATIVE shortcut path
-   * (Story 22-4, ADR-018 §5). Delegates to the shared `matchShortcut`.
+   * (ADR-018). Delegates to the shared `matchShortcut`.
    *
    * Registered as a **capture-phase** listener on the host element (see
-   * `ngAfterViewInit`), NOT a bubble-phase `@HostListener`. The capture phase
-   * runs the host handler BEFORE the event reaches Monaco's internal keydown
-   * handling, so even when focus is inside the editor (Monaco may
-   * `stopPropagation` a keydown before it would bubble back to the host) the
-   * host still sees — and acts on — the chord. The Monaco `editor.addAction`
-   * keybindings registered in `registerEditorShortcuts` are kept as a
-   * best-effort in-editor convenience ONLY; correctness does not depend on
-   * them. Single-fire-per-keystroke is preserved: there is exactly ONE host
-   * dispatch site (this listener) routing through the idempotent `triggerX()`
-   * surface — the old bubble-phase `@HostListener` is removed so no second
-   * uncoordinated host dispatch can open two confirms / submit two imports
-   * (AC 4, AC 5).
+   * `ngAfterViewInit`). The capture phase runs the host handler BEFORE the
+   * event reaches Monaco's internal keydown handling, so even when focus is
+   * inside the editor (Monaco may `stopPropagation` a keydown before it would
+   * bubble back to the host) the host still sees — and acts on — the chord. The
+   * Monaco `editor.addAction` keybindings registered in
+   * `registerEditorShortcuts` are a best-effort in-editor convenience ONLY;
+   * correctness does not depend on them. Single-fire-per-keystroke is
+   * preserved: there is exactly ONE host dispatch site (this listener) routing
+   * through the idempotent `triggerX()` surface, so no second uncoordinated
+   * host dispatch can open two confirms / submit two imports.
    */
   onKeydown(event: KeyboardEvent): void {
     this.matchShortcut(event);
@@ -712,10 +691,9 @@ export class NamespacePanelComponent
 
   /**
    * Register the authoritative capture-phase keydown listener on the host
-   * element (Story 22-4, ADR-018 §5). Capture phase is load-bearing: it lets
-   * the host see the chord BEFORE Monaco can swallow it when the editor has
-   * focus. Cleaned up via the `destroyRef` hook so no listener leaks after the
-   * panel is torn down.
+   * element. Capture phase is load-bearing: it lets the host see the chord
+   * BEFORE Monaco can swallow it when the editor has focus. Cleaned up via the
+   * `destroyRef` hook so no listener leaks after the panel is torn down.
    */
   ngAfterViewInit(): void {
     const host = this.elementRef.nativeElement;
@@ -728,11 +706,11 @@ export class NamespacePanelComponent
   }
 
   /**
-   * `(event)` handler for `<nu-monaco-editor>` (AC 10). On the `'init'` event
-   * the editor instance is available; register the five chord actions via
+   * `(event)` handler for `<nu-monaco-editor>`. On the `'init'` event the
+   * editor instance is available; register the five chord actions via
    * `editor.addAction(...)`, each `run` delegating to the SAME `triggerX()`
-   * entry point as the HostListener path (AC 12). Guarded against
-   * re-registration on a `'re-init'` event via `monacoActionsRegistered`.
+   * entry point as the host capture path. Guarded against re-registration on a
+   * `'re-init'` event via `monacoActionsRegistered`.
    */
   onEditorEvent(e: NuMonacoEditorEvent): void {
     if (e.type !== 'init' || !e.editor) {
@@ -749,9 +727,9 @@ export class NamespacePanelComponent
   /**
    * Registers the five ⌥-key chord actions on the Monaco editor. Each `run`
    * delegates to the shared `triggerX()` dispatch surface so enablement parity
-   * (AC 6) holds identically for the Monaco and HostListener capture sites.
-   * The chord constants come from the ambient `monaco` namespace
-   * (`monaco.KeyMod` / `monaco.KeyCode`) — no `monaco-editor` import.
+   * holds identically for the Monaco and host capture sites. The chord
+   * constants come from the ambient `monaco` namespace (`monaco.KeyMod` /
+   * `monaco.KeyCode`) — no `monaco-editor` import.
    */
   private registerEditorShortcuts(
     editor: monaco.editor.IStandaloneCodeEditor,
@@ -795,17 +773,17 @@ export class NamespacePanelComponent
   private monacoActionsRegistered = false;
 
   // -------------------------------------------------------------------
-  // Story 22.3 — Custom confirmation modal (ADR-018 §1–§4). One shared
-  // open/close surface reused by Reset-discard, Save-drift, and Delete; the
-  // safe button autofocuses on show so Enter/Esc cancel.
+  // Custom confirmation modal (ADR-018). One shared open/close surface reused
+  // by Reset-discard, Save-drift, and Delete; the primary button autofocuses on
+  // show so Enter activates it and Esc cancels.
   // -------------------------------------------------------------------
 
   /**
-   * Open the custom confirmation modal (AC 2, 3). Captures the typed request +
-   * the per-flow callbacks the template buttons invoke, then flips the
-   * visibility flag. For the `'drift'` variant `onReload` is the safe/focused
-   * Reload branch and `onAccept` is the Overwrite branch; for `'reset'` /
-   * `'delete'` only `onAccept` (Proceed) is supplied and `onReload` is omitted.
+   * Open the custom confirmation modal. Captures the typed request + the
+   * per-flow callbacks the template buttons invoke, then flips the visibility
+   * flag. For the `'drift'` variant `onReload` is the safe/focused Reload branch
+   * and `onAccept` is the Overwrite branch; for `'reset'` / `'delete'` only
+   * `onAccept` (Proceed) is supplied and `onReload` is omitted.
    */
   private openConfirm(
     request: ConfirmRequest,
@@ -820,8 +798,8 @@ export class NamespacePanelComponent
 
   /**
    * Close the confirmation modal and null the request + callbacks so a stale
-   * request cannot leak into the next open (AC 19). Idempotent. The pending
-   * drift resolver (`confirmDriftResolve`) is intentionally NOT cleared here —
+   * request cannot leak into the next open. Idempotent. The pending drift
+   * resolver (`confirmDriftResolve`) is intentionally NOT cleared here —
    * `onConfirmDialogHide` owns resolving it to the safe branch before this runs.
    */
   private closeConfirm(): void {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import {
+  AfterViewInit,
   Component,
   DestroyRef,
   ElementRef,
   EventEmitter,
-  HostListener,
   Input,
   OnChanges,
   OnInit,
@@ -119,7 +119,9 @@ interface ConfirmRequest {
   templateUrl: './namespace-panel.component.html',
   styleUrls: ['./namespace-panel.component.scss'],
 })
-export class NamespacePanelComponent implements OnInit, OnChanges {
+export class NamespacePanelComponent
+  implements OnInit, OnChanges, AfterViewInit
+{
   @Input() namespace!: string;
   /**
    * Story 11.5 — existing namespace identifiers, supplied by the host, used
@@ -147,6 +149,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   private messageService: MessageService = inject(MessageService);
   private authService: AuthService = inject(AuthService);
   private destroyRef: DestroyRef = inject(DestroyRef);
+  private elementRef: ElementRef<HTMLElement> = inject(ElementRef);
 
   // Internal state. The panel is always editable — there is no `mode` axis.
   // The single signal that drives the action row is `buffer !== serverYaml`.
@@ -612,6 +615,19 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    *   the matching `triggerX()` is a no-op by enablement (AC 9) — so the
    *   dead-key glyph / Alt-mnemonic is suppressed for keystrokes that are
    *   "ours".
+   *
+   * macOS dead-key / IME composition robustness (Story 22-4, ADR-018 §5).
+   * On some macOS keyboard layouts an ⌥-chord initiates a dead-key
+   * composition: the browser delivers the `keydown` flagged as composing
+   * (`isComposing === true`, `keyCode === 229`, `key === 'Dead'`). This matcher
+   * MUST NOT early-return on those flags — it keys off `event.altKey` +
+   * `event.code` ONLY and never reads `event.key`, so a composing event with
+   * `code: 'KeyV'` still matches and fires Validate. The `preventDefault()` on a
+   * handled combo also suppresses the OS dead-key composition so no glyph is
+   * inserted. NEVER add an `isComposing` / `keyCode === 229` / `key === 'Dead'`
+   * guard ahead of this matcher for these chords. (Karma cannot reproduce the
+   * real OS composition layer — synthetic `KeyboardEvent`s bypass it — so the
+   * real-world fix is manually verified on macOS; see the story's manual gate.)
    */
   private matchShortcut(event: KeyboardEvent): void {
     if (!event.altKey) {
@@ -648,16 +664,51 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Component-level keydown capture (AC 11). Mirrors the established
-   * `chat-panel.component.ts` `@HostListener` pattern. Binding on the host
-   * (`'keydown'`, not `'document:keydown'`) scopes capture to the panel
-   * subtree — the shortcuts fire only when the panel (or its editor) has
-   * focus. Catches the combos when focus sits OUTSIDE Monaco (e.g. on a
-   * button); the Monaco `addAction` path covers in-editor focus.
+   * Component-level keydown capture — the AUTHORITATIVE shortcut path
+   * (Story 22-4, ADR-018 §5). Delegates to the shared `matchShortcut`.
+   *
+   * Registered as a **capture-phase** listener on the host element (see
+   * `ngAfterViewInit`), NOT a bubble-phase `@HostListener`. The capture phase
+   * runs the host handler BEFORE the event reaches Monaco's internal keydown
+   * handling, so even when focus is inside the editor (Monaco may
+   * `stopPropagation` a keydown before it would bubble back to the host) the
+   * host still sees — and acts on — the chord. The Monaco `editor.addAction`
+   * keybindings registered in `registerEditorShortcuts` are kept as a
+   * best-effort in-editor convenience ONLY; correctness does not depend on
+   * them. Single-fire-per-keystroke is preserved: there is exactly ONE host
+   * dispatch site (this listener) routing through the idempotent `triggerX()`
+   * surface — the old bubble-phase `@HostListener` is removed so no second
+   * uncoordinated host dispatch can open two confirms / submit two imports
+   * (AC 4, AC 5).
    */
-  @HostListener('keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
     this.matchShortcut(event);
+  }
+
+  /**
+   * Bound capture-phase keydown handler reference. Stored so the exact same
+   * function identity can be passed to both `addEventListener` and
+   * `removeEventListener` (an inline arrow would not be removable).
+   */
+  private readonly captureKeydown = (event: KeyboardEvent): void => {
+    this.onKeydown(event);
+  };
+
+  /**
+   * Register the authoritative capture-phase keydown listener on the host
+   * element (Story 22-4, ADR-018 §5). Capture phase is load-bearing: it lets
+   * the host see the chord BEFORE Monaco can swallow it when the editor has
+   * focus. Cleaned up via the `destroyRef` hook so no listener leaks after the
+   * panel is torn down.
+   */
+  ngAfterViewInit(): void {
+    const host = this.elementRef.nativeElement;
+    host.addEventListener('keydown', this.captureKeydown, { capture: true });
+    this.destroyRef.onDestroy(() => {
+      host.removeEventListener('keydown', this.captureKeydown, {
+        capture: true,
+      });
+    });
   }
 
   /**

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -810,20 +810,20 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Public predicate (AC 12) — true iff ANY secondary panel (the Clone modal
-   * OR the confirmation modal) is open. The host (`HomeComponent` config dialog,
-   * and any route-shell that binds `closeOnEscape`) reads this synchronously to
+   * Public predicate — true iff ANY secondary panel (the Clone modal OR the
+   * confirmation modal) is open. The host (`HomeComponent` config dialog, and
+   * any route-shell that binds `closeOnEscape`) reads this synchronously to
    * suppress its own `closeOnEscape` while a secondary panel is open, so Esc
-   * closes only the topmost secondary panel (ADR-018 §3).
+   * closes only the topmost secondary panel (ADR-018).
    */
   get hasSecondaryPanelOpen(): boolean {
     return this.cloneDialogVisible || this.confirmDialogVisible;
   }
 
   /**
-   * Coordinated Escape for the panel's secondary modals (ADR-018 Amendment §b).
-   * Closes ONLY the topmost open secondary panel and reports whether it consumed
-   * the Escape, so EXACTLY ONE action happens per keystroke (no cascade):
+   * Coordinated Escape for the panel's secondary modals (ADR-018). Closes ONLY
+   * the topmost open secondary panel and reports whether it consumed the
+   * Escape, so EXACTLY ONE action happens per keystroke (no cascade):
    *
    *   1. confirmation modal open → cancel/close ONLY it (settling any pending
    *      drift/discard promise via `onConfirmDialogHide`), return `true`.
@@ -852,9 +852,9 @@ export class NamespacePanelComponent
   }
 
   /**
-   * PUBLIC dirty-discard confirm (ADR-018 Amendment §c). Opens the panel-owned
-   * custom confirmation modal with the `'discard'` variant ("Unsaved changes" /
-   * "You have unsaved changes. Discard?") and returns a `Promise<boolean>` that
+   * PUBLIC dirty-discard confirm (ADR-018). Opens the panel-owned custom
+   * confirmation modal with the `'discard'` variant ("Unsaved changes" / "You
+   * have unsaved changes. Discard?") and returns a `Promise<boolean>` that
    * resolves:
    *   - `true`  → the operator chose **Proceed**. The panel buffer is REALLY
    *               discarded here (`revertBufferToServer()` — buffer reset to the
@@ -867,13 +867,10 @@ export class NamespacePanelComponent
    *   - `false` → the operator **Cancelled** / dismissed (Esc / X / mask) — the
    *               buffer is left UNTOUCHED (still dirty) and the panel stays open.
    *
-   * Reused by BOTH dirty-state hosts so the LAST PrimeNG `<p-confirmDialog>`
-   * usages for the namespace panel are removed:
+   * Reused by BOTH dirty-state hosts:
    *   - the Home config-dialog close paths (`onNamespacePanelVisibleChange` and
    *     the Esc/X/mask close), and
-   *   - the deep-link route `CanDeactivate` guard (`namespacePanelCanDeactivate`),
-   *     resolving the spec-compliance route-guard BLOCKING finding (the guard
-   *     previously depended on a `<p-confirmDialog>` the panel no longer mounts).
+   *   - the deep-link route `CanDeactivate` guard (`namespacePanelCanDeactivate`).
    *
    * A dismissal that bypasses the buttons (Esc / X / mask) settles `false` via
    * `confirmDiscardResolve` in `onConfirmDialogHide` — the safe branch (keep the
@@ -911,22 +908,22 @@ export class NamespacePanelComponent
   }
 
   /**
-   * The action-row label for the confirmation modal's affirmative button
-   * (ADR-018 Amendment §d). Every single-affirmative variant — reset, delete,
-   * and discard — uses **"Proceed"** (the dark-red `__danger` class is what
-   * marks the `delete` variant as destructive, NOT a distinct label). The drift
-   * variant renders its own two explicit Reload / Overwrite buttons, so this
-   * label is never shown for it. Returned as a getter so the template need not
-   * branch on the variant.
+   * The action-row label for the confirmation modal's affirmative button. Every
+   * single-affirmative variant — reset, delete, and discard — uses
+   * **"Proceed"** (the dark-red `__danger` class is what marks the `delete`
+   * variant as destructive, NOT a distinct label). The drift variant renders
+   * its own two explicit Reload / Overwrite buttons, so this label is never
+   * shown for it. Returned as a getter so the template need not branch on the
+   * variant.
    */
   get confirmProceedLabel(): string {
     return 'Proceed';
   }
 
   /**
-   * Proceed (reset/delete/discard) button handler (AC 3, 5). Runs the captured
-   * accept callback then closes. For `'delete'` this fires `onDeleteConfirm()`;
-   * for `'reset'` the revert effect; for `'discard'` it resolves the public
+   * Proceed (reset/delete/discard) button handler. Runs the captured accept
+   * callback then closes. For `'delete'` this fires `onDeleteConfirm()`; for
+   * `'reset'` the revert effect; for `'discard'` it resolves the public
    * `confirmDiscard()` promise `true` (the accept callback settles + clears the
    * pending `confirmDiscardResolve`, so the resulting onHide is a no-op).
    */
@@ -937,23 +934,23 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Overwrite (drift) button handler (AC 7). The destructive drift branch:
-   * resolves the drift promise `true` (proceed to import the operator buffer)
-   * via the captured accept callback, then closes.
+   * Overwrite (drift) button handler. The destructive drift branch: resolves
+   * the drift promise `true` (proceed to import the operator buffer) via the
+   * captured accept callback, then closes.
    */
   onConfirmOverwriteClick(): void {
     const accept = this.confirmAccept;
     // The drift promise is settled by `accept`; clear the dismissal resolver
-    // first so the resulting onHide does not re-settle it (AC 8).
+    // first so the resulting onHide does not re-settle it.
     this.confirmDriftResolve = null;
     this.closeConfirm();
     accept?.();
   }
 
   /**
-   * Reload (drift) button handler — the safe / focused default (AC 7, 9). Runs
-   * the rebase effect and resolves the drift promise `false` (skip the import)
-   * via the captured reload callback, then closes.
+   * Reload (drift) button handler — the safe / focused default. Runs the rebase
+   * effect and resolves the drift promise `false` (skip the import) via the
+   * captured reload callback, then closes.
    */
   onConfirmReloadClick(): void {
     const reload = this.confirmReload;
@@ -963,10 +960,10 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Cancel (reset/delete/discard) button handler (AC 10). The safe branch:
-   * closes without running any accept callback — no destructive/lossy effect
-   * occurs. For the `'discard'` variant it settles the public `confirmDiscard()`
-   * promise to `false` (keep edits) directly, so the awaited promise resolves
+   * Cancel (reset/delete/discard) button handler. The safe branch: closes
+   * without running any accept callback — no destructive/lossy effect occurs.
+   * For the `'discard'` variant it settles the public `confirmDiscard()` promise
+   * to `false` (keep edits) directly, so the awaited promise resolves
    * deterministically on a button click without depending on the PrimeNG
    * `(onHide)` round-trip; the resolver is cleared so the subsequent onHide is a
    * no-op.
@@ -979,11 +976,11 @@ export class NamespacePanelComponent
   }
 
   /**
-   * `(onShow)` handler for the confirmation modal (ADR-018 Amendment §e).
-   * Mirrors `onCloneDialogShow`: defers the focus call by a microtask so PrimeNG
-   * has mounted the overlay, then focuses the PRIMARY/proceed button (Proceed
-   * for reset/delete/discard, Reload for drift) so **Enter activates the main
-   * action**. Esc still cancels. Null-safe via the `@ViewChild` ref.
+   * `(onShow)` handler for the confirmation modal. Mirrors `onCloneDialogShow`:
+   * defers the focus call by a microtask so PrimeNG has mounted the overlay,
+   * then focuses the PRIMARY/proceed button (Proceed for reset/delete/discard,
+   * Reload for drift) so **Enter activates the main action**. Esc still cancels.
+   * Null-safe via the `@ViewChild` ref.
    */
   onConfirmDialogShow(): void {
     setTimeout(() => {
@@ -992,13 +989,13 @@ export class NamespacePanelComponent
   }
 
   /**
-   * `(onHide)` handler for the confirmation modal (AC 8, 19 + ADR-018
-   * Amendment §c). Resolves a still-pending dismissal to the SAFE branch — the
-   * drift dismissal to `false` (no blind overwrite) and the dirty-discard
-   * dismissal to `false` (keep the edits) — then resets the request + callbacks
-   * so nothing leaks into the next open. Both resolvers are invoked BEFORE
-   * `closeConfirm` so the awaited `onSaveClick` / `confirmDiscard()` promise
-   * settles even on an Esc/X dismissal.
+   * `(onHide)` handler for the confirmation modal (ADR-018). Resolves a
+   * still-pending dismissal to the SAFE branch — the drift dismissal to `false`
+   * (no blind overwrite) and the dirty-discard dismissal to `false` (keep the
+   * edits) — then resets the request + callbacks so nothing leaks into the next
+   * open. Both resolvers are invoked BEFORE `closeConfirm` so the awaited
+   * `onSaveClick` / `confirmDiscard()` promise settles even on an Esc/X
+   * dismissal.
    */
   onConfirmDialogHide(): void {
     const driftResolve = this.confirmDriftResolve;
@@ -1014,10 +1011,10 @@ export class NamespacePanelComponent
    * Revert the edit buffer to the last server snapshot and clear every
    * dirty-derived signal (`lastValidation` / `rawSaveError` / `validatedBuffer`)
    * so the panel lands fully clean. Shared by the Reset button (`onResetClick`)
-   * and the dirty-CLOSE discard (`confirmDiscard` Proceed — ADR-018 Amendment
-   * §c). Load-bearing for the close path: the panel instance is kept alive
-   * across a dialog visibility toggle (not destroyed), so without this reset the
-   * abandoned edits would leak into the next open. Destroy-guarded.
+   * and the dirty-CLOSE discard (`confirmDiscard` Proceed). Load-bearing for the
+   * close path: the panel instance is kept alive across a dialog visibility
+   * toggle (not destroyed), so without this reset the abandoned edits would leak
+   * into the next open. Destroy-guarded.
    */
   private revertBufferToServer(): void {
     if (this.destroyed) {
@@ -1030,11 +1027,11 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Revert the buffer to `serverYaml` — the SOLE undo affordance now that
-   * Cancel is removed (ADR-017 §2). Guarded by the custom "Discard unsaved
-   * changes?" confirm; a no-op when clean (the Reset button is also disabled
-   * via `[disabled]="buffer === serverYaml"`). Reverts-and-STAYS (does not close
-   * the panel) — distinct from the dirty-CLOSE discard which reverts-and-closes.
+   * Revert the buffer to `serverYaml` — the undo affordance. Guarded by the
+   * custom "Discard unsaved changes?" confirm; a no-op when clean (the Reset
+   * button is also disabled via `[disabled]="buffer === serverYaml"`).
+   * Reverts-and-STAYS (does not close the panel) — distinct from the
+   * dirty-CLOSE discard which reverts-and-closes.
    */
   onResetClick(): void {
     if (this.buffer === this.serverYaml) {
@@ -1052,16 +1049,14 @@ export class NamespacePanelComponent
 
   /**
    * Save handler — posts the current buffer directly to
-   * `apiService.importNamespace` (NO pre-save validate, per ADR-011 D4),
-   * preceded by a one-shot **drift check** (ADR-017 §6).
+   * `apiService.importNamespace` (NO pre-save validate), preceded by a one-shot
+   * **drift check** (ADR-017).
    *
-   * Gated on `hasUnsavedChanges()` (and `saving`); no longer references any
-   * mode — the panel is always editable.
+   * Gated on `hasUnsavedChanges()` (and `saving`).
    *
    * Drift check: before importing, re-`exportNamespace` and, if the returned
    * YAML diverges from `serverYaml`, prompt the operator (reload-and-rebase
-   * vs overwrite) instead of importing blindly. The check is one-shot per
-   * Save; it relocates the protection the old Edit-entry drift check gave.
+   * vs overwrite) instead of importing blindly. The check is one-shot per Save.
    *
    * Success (2xx): `serverYaml` snapshots the just-saved buffer, toast
    * success, `saved` emits so the host refreshes derived lists. The buffer is
@@ -1078,19 +1073,18 @@ export class NamespacePanelComponent
    * Other (4xx/5xx/network): sticky error toast. The operator retries by
    * clicking the regular Save button again (buffer is still dirty post-
    * failure, so Save remains enabled) — there is no dedicated Retry button
-   * in the action row. `importNamespace` is NEVER auto-retried by the
-   * panel (AC 8).
+   * in the action row. `importNamespace` is NEVER auto-retried by the panel.
    */
   async onSaveClick(): Promise<void> {
     if (!this.hasUnsavedChanges() || this.saving) {
       return;
     }
     // Snapshot the buffer at click time so typing during the request does
-    // NOT race the success branch (AC 2.3 guidance).
+    // NOT race the success branch.
     const savedBuffer = this.buffer;
 
-    // Post-review guardrail — refuse to Save when the buffer's top-level
-    // `namespace:` field has been edited away from the panel's namespace.
+    // Guardrail — refuse to Save when the buffer's top-level `namespace:`
+    // field has been edited away from the panel's namespace.
     // The server's import endpoint treats the YAML's namespace as
     // authoritative, so saving here would accidentally create or overwrite
     // a DIFFERENT namespace — the operator almost certainly means to Clone.
@@ -1134,9 +1128,9 @@ export class NamespacePanelComponent
     // not display outdated issues while the request is in flight.
     this.lastValidation = null;
     try {
-      // ADR-017 §6 — one-shot drift check before importing. Returns false
-      // when the operator chose reload-and-rebase (import is skipped this
-      // click); true when the import should proceed (no drift, or overwrite).
+      // One-shot drift check before importing (ADR-017). Returns false when
+      // the operator chose reload-and-rebase (import is skipped this click);
+      // true when the import should proceed (no drift, or overwrite).
       const proceed = await this.checkSaveDrift(savedBuffer);
       if (this.destroyed || !proceed) {
         return;
@@ -1155,7 +1149,7 @@ export class NamespacePanelComponent
   }
 
   /**
-   * ADR-017 §6 — one-shot drift check folded into Save. Re-`exportNamespace`s
+   * One-shot drift check folded into Save (ADR-017). Re-`exportNamespace`s
    * (carrying `{ all: this.showAll }`) and, if the returned YAML diverges from
    * `serverYaml`, prompts the operator with a reload-and-rebase vs overwrite
    * choice. Returns:
@@ -1167,15 +1161,14 @@ export class NamespacePanelComponent
    *               server YAML so the operator can re-Save against the fresh
    *               base).
    *
-   * ADR-018 §1 — the choice is rendered as **two explicit named buttons** in
-   * the custom confirmation modal (Reload + Overwrite), not a binary
-   * accept/reject. Reload (the safe, focused default) resolves `false`;
-   * Overwrite resolves `true`. Dismissing the modal (Esc / Cancel / X) resolves
-   * `false` — the safe branch — so an accidental dismissal never lands a blind
-   * overwrite (ADR-018 §2 / AC 8). A network error during the re-export falls
-   * through to `true` (proceed) — the server still validates on import, so a
-   * genuinely-stale edit can only land a known-bad bundle, and operators should
-   * not be blocked by a hiccup.
+   * The choice is rendered as **two explicit named buttons** in the custom
+   * confirmation modal (Reload + Overwrite), not a binary accept/reject. Reload
+   * (the safe, focused default) resolves `false`; Overwrite resolves `true`.
+   * Dismissing the modal (Esc / Cancel / X) resolves `false` — the safe branch
+   * — so an accidental dismissal never lands a blind overwrite. A network error
+   * during the re-export falls through to `true` (proceed) — the server still
+   * validates on import, so a genuinely-stale edit can only land a known-bad
+   * bundle, and operators should not be blocked by a hiccup.
    */
   private async checkSaveDrift(savedBuffer: string): Promise<boolean> {
     let latestYaml: string;
@@ -1248,8 +1241,8 @@ export class NamespacePanelComponent
       return;
     }
     this.serverYaml = savedBuffer;
-    // Story 11.7 AC 13 — pair the success toast with an aria-live
-    // announcement so screen-reader users get the same outcome.
+    // Pair the success toast with an aria-live announcement so screen-reader
+    // users get the same outcome.
     this.a11yAnnouncement = 'Namespace saved';
     this.saved.emit();
     this.messageService.add({
@@ -1259,16 +1252,16 @@ export class NamespacePanelComponent
   }
 
   /**
-   * The SINGLE Validate handler (ADR-017 §4). Validates the current buffer
-   * without persisting via `apiService.validateNamespaceBuffer(buffer)`.
-   * Snapshots `this.buffer` at click time (`bufferAtClick`) so Monaco's live
+   * The Validate handler (ADR-017). Validates the current buffer without
+   * persisting via `apiService.validateNamespaceBuffer(buffer)`. Snapshots
+   * `this.buffer` at click time (`bufferAtClick`) so Monaco's live
    * `[(ngModel)]` mutation during the in-flight request cannot race the
-   * request args (mirrors Story 11.3's `savedBuffer` pattern).
+   * request args.
    *
    * When the buffer is clean (`buffer === serverYaml`), this is identical to
    * validating the persisted namespace. Validate never mutates `serverYaml`
    * or `buffer` — the handler touches only `validating` and `lastValidation`.
-   * It is never disabled by the FR14 gate (ADR-017 §5).
+   * It is never disabled by the validation gate.
    */
   async onValidateBufferClick(): Promise<void> {
     if (this.validating) {
@@ -1286,14 +1279,14 @@ export class NamespacePanelComponent
         throw new Error('Server returned no validation report.');
       }
       // Clean buffer → flash the Validate button. Non-clean → render
-      // findings via `lastValidation` as before.
+      // findings via `lastValidation`.
       if (report.ok) {
         this.lastValidation = null;
         this.validatedBuffer = bufferAtClick;
         this.flashValidated();
       } else {
         this.lastValidation = report;
-        // Story 11.7 AC 12 — announce the failing-validation outcome.
+        // Announce the failing-validation outcome.
         this.announceValidationOutcome(report);
       }
     } catch (err) {
@@ -1311,7 +1304,7 @@ export class NamespacePanelComponent
   /**
    * Parent-owned clear for the `ValidationReportComponent` output. Nulls
    * both `lastValidation` and `rawSaveError` so the sub-component emits
-   * no DOM on the next CD tick (branch (a) — AC 8).
+   * no DOM on the next CD tick.
    */
   onClearValidationClick(): void {
     this.lastValidation = null;
@@ -1329,7 +1322,7 @@ export class NamespacePanelComponent
    *   land on 422 even though the operational outcome is the same as a
    *   200 ok:false — the user wants to see the issues, not a toast.
    * - **Other statuses / errors** — non-sticky toast. Re-clicking Validate
-   *   is the natural retry, so no Retry action is attached (AC 11).
+   *   is the natural retry, so no Retry action is attached.
    *
    * Validate never writes Save's fallback fields (`rawSaveError`) — those
    * belong to the Save flow.
@@ -1346,7 +1339,7 @@ export class NamespacePanelComponent
         // Promote the 422 body into the findings pane — matches the
         // ok:false-on-200 rendering path.
         this.lastValidation = body;
-        // Story 11.7 AC 12 — announce the failing-validation outcome.
+        // Announce the failing-validation outcome.
         this.announceValidationOutcome(body);
         return;
       }
@@ -1371,7 +1364,7 @@ export class NamespacePanelComponent
     if (status === 401) {
       // Silent at the panel — FetchService already fired a global toast and
       // the app-wide 401 handler (if any) runs. The panel does not mutate
-      // `buffer` / `lastValidation` on 401 (AC 9).
+      // `buffer` / `lastValidation` on 401.
       return;
     }
     if (status === 422) {
@@ -1379,7 +1372,7 @@ export class NamespacePanelComponent
       if (this.isValidationReport(body)) {
         this.lastValidation = body;
         this.rawSaveError = null;
-        // Story 11.7 AC 12 — announce the failing-validation outcome.
+        // Announce the failing-validation outcome.
         this.announceValidationOutcome(body);
       } else {
         this.rawSaveError =
@@ -1401,15 +1394,14 @@ export class NamespacePanelComponent
   }
 
   // -------------------------------------------------------------------
-  // Story 11.5 — Clone flow (AC 1–AC 12)
+  // Clone flow
   // -------------------------------------------------------------------
 
   /**
-   * Open the Clone sub-dialog (AC 2). Pure UI flip — does NOT fire a
-   * network request, does NOT mutate `buffer` / `serverYaml` /
-   * `lastValidation` / `rawSaveError`. No-op when `cloning === true`
-   * (defence in depth — the outer Clone button is `[disabled]` in that
-   * state, so this path is unreachable in practice).
+   * Open the Clone sub-dialog. Pure UI flip — does NOT fire a network request,
+   * does NOT mutate `buffer` / `serverYaml` / `lastValidation` / `rawSaveError`.
+   * No-op when `cloning === true` (defence in depth — the outer Clone button is
+   * `[disabled]` in that state, so this path is unreachable in practice).
    */
   onCloneClick(): void {
     if (this.cloning) {
@@ -1423,17 +1415,17 @@ export class NamespacePanelComponent
     const srcName = extractYamlName(this.buffer) ?? srcNs;
     this.cloneDestNs = suggestDestNamespace(srcNs);
     this.cloneDestName = suggestDestName(srcName);
-    // Story 12.2 — pre-fill the visibility/sharing toggles from the same
-    // buffer. Absent / non-boolean / unparseable → default to false.
+    // Pre-fill the visibility/sharing toggles from the same buffer. Absent /
+    // non-boolean / unparseable → default to false.
     this.cloneShareable = extractYamlShareable(this.buffer) ?? false;
     this.clonePublic = extractYamlPublic(this.buffer) ?? false;
     this.cloneDialogVisible = true;
   }
 
   /**
-   * Cancel the Clone sub-dialog (AC 3). Resets `cloneDestNs`; does NOT
-   * mutate `cloning` — an in-flight clone request keeps settling via its
-   * own try/catch/finally (Story 11.4's destroy-guard idiom).
+   * Cancel the Clone sub-dialog. Resets `cloneDestNs`; does NOT mutate
+   * `cloning` — an in-flight clone request keeps settling via its own
+   * try/catch/finally (the destroy-guard idiom).
    */
   onCloneCancelClick(): void {
     this.cloneDialogVisible = false;
@@ -1446,9 +1438,9 @@ export class NamespacePanelComponent
   /**
    * `(visibleChange)` handler for the Clone sub-dialog. Mirrors Cancel's
    * reset: when the dialog dismisses (visible = false, e.g. ESC or the
-   * close X), we zero `cloneDestNs` so the next open starts clean (AC 3).
-   * `cloning` is intentionally unchanged — an in-flight request keeps
-   * settling regardless of dialog visibility.
+   * close X), we zero `cloneDestNs` so the next open starts clean. `cloning`
+   * is intentionally unchanged — an in-flight request keeps settling
+   * regardless of dialog visibility.
    */
   onCloneDialogVisibleChange(visible: boolean): void {
     this.cloneDialogVisible = visible;
@@ -1461,10 +1453,10 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Pre-flight predicate for the Clone Confirm button (AC 4). True iff any
-   * of: destNs is empty-trimmed, destNs equals the source namespace, destNs
-   * already appears in `existingNamespaces` (case-sensitive), or a clone is
-   * already in flight.
+   * Pre-flight predicate for the Clone Confirm button. True iff any of: destNs
+   * is empty-trimmed, destNs equals the source namespace, destNs already
+   * appears in `existingNamespaces` (case-sensitive), or a clone is already in
+   * flight.
    */
   get cloneConfirmDisabled(): boolean {
     const trimmed = this.cloneDestNs.trim();
@@ -1483,16 +1475,16 @@ export class NamespacePanelComponent
     if (this.cloning) {
       return true;
     }
-    // Story 11.7 AC 7 — the Clone modal Confirm button inherits the
-    // FR14 gate so an operator cannot bypass the outer Clone button's
-    // disabled state by opening the modal first.
+    // The Clone modal Confirm button inherits the validation gate so an
+    // operator cannot bypass the outer Clone button's disabled state by opening
+    // the modal first.
     return this.isCloneGated;
   }
 
   /**
-   * Inline validation message for the Clone dialog (AC 4). Returns `null`
-   * while the destNs is an unused, non-colliding value — so the template
-   * can gate the error block with `*ngIf`.
+   * Inline validation message for the Clone dialog. Returns `null` while the
+   * destNs is an unused, non-colliding value — so the template can gate the
+   * error block with `*ngIf`.
    */
   get cloneValidationError(): string | null {
     const trimmed = this.cloneDestNs.trim();
@@ -1512,23 +1504,21 @@ export class NamespacePanelComponent
   }
 
   // -------------------------------------------------------------------
-  // Story 11.7 — FR14 Save/Clone gate getters + tooltip helpers
+  // Save/Clone validation-gate getters + tooltip helpers
   // -------------------------------------------------------------------
 
   /**
-   * Story 11.7 AC 1, 2, 6 — Save gate predicate. True iff the panel has
-   * a known-bad signal: either a structured-422 / 200-with-issues report
-   * (`lastValidation.ok === false`) or an unstructured-422 raw-error
-   * fallback (`rawSaveError !== null`).
+   * Save gate predicate. True iff the panel has a known-bad signal: either a
+   * structured-422 / 200-with-issues report (`lastValidation.ok === false`) or
+   * an unstructured-422 raw-error fallback (`rawSaveError !== null`).
    *
-   * Fresh untouched state (`lastValidation === null && rawSaveError ===
-   * null`) returns `false` — Save / Clone are enabled by default.
-   * Option B (gate-on-known-bad) is the explicit UX choice; see story
-   * Dev Notes "Why option B".
+   * Fresh untouched state (`lastValidation === null && rawSaveError === null`)
+   * returns `false` — Save / Clone are enabled by default. The gate fires only
+   * on a known-bad signal.
    *
-   * Two getters (`isSaveGated` + `isCloneGated`) instead of one shared
-   * getter so call-site tooltips can be specific (Save's tooltip says
-   * "saving"; Clone's says "cloning") without leaking unrelated logic.
+   * Two getters (`isSaveGated` + `isCloneGated`) instead of one shared getter
+   * so call-site tooltips can be specific (Save's tooltip says "saving";
+   * Clone's says "cloning") without leaking unrelated logic.
    */
   get isSaveGated(): boolean {
     return (
@@ -1537,7 +1527,7 @@ export class NamespacePanelComponent
     );
   }
 
-  /** Story 11.7 AC 1, 2, 6 — Clone gate predicate (same body as Save). */
+  /** Clone gate predicate (same body as Save). */
   get isCloneGated(): boolean {
     return (
       (this.lastValidation !== null && !this.lastValidation.ok) ||
@@ -1546,13 +1536,12 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Story 11.7 AC 1 — Save tooltip text. Returns the explanatory string
-   * ONLY when the gate is the active reason for disabling; returns
-   * `undefined` otherwise so PrimeNG's `pTooltip` input (whose type is
-   * `string | TemplateRef | undefined`) accepts it under strictTemplates.
-   * PrimeNG suppresses the tooltip on `undefined` / empty string, so
-   * unrelated disable reasons (clean buffer, in-flight save) get no
-   * tooltip — avoiding contradictory messaging.
+   * Save tooltip text. Returns the explanatory string ONLY when the gate is the
+   * active reason for disabling; returns `undefined` otherwise so PrimeNG's
+   * `pTooltip` input (whose type is `string | TemplateRef | undefined`) accepts
+   * it under strictTemplates. PrimeNG suppresses the tooltip on `undefined` /
+   * empty string, so unrelated disable reasons (clean buffer, in-flight save)
+   * get no tooltip — avoiding contradictory messaging.
    */
   get saveTooltip(): string | undefined {
     if (
@@ -1566,9 +1555,9 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Story 11.7 AC 1 — Clone tooltip text. Same idiom as `saveTooltip`:
-   * returns the gate-explanatory string only when the gate is the active
-   * reason for disabling; `undefined` otherwise (pTooltip-type-compatible).
+   * Clone tooltip text. Same idiom as `saveTooltip`: returns the
+   * gate-explanatory string only when the gate is the active reason for
+   * disabling; `undefined` otherwise (pTooltip-type-compatible).
    */
   get cloneTooltip(): string | undefined {
     if (this.isCloneGated && !this.cloning && !this.saving) {
@@ -1578,13 +1567,13 @@ export class NamespacePanelComponent
   }
 
   // -------------------------------------------------------------------
-  // Story 11.7 — Clone modal a11y handlers (FR17 + FR21)
+  // Clone modal a11y handlers
   // -------------------------------------------------------------------
 
   /**
-   * Story 11.7 AC 16 — `(onShow)` handler for the Clone modal. Defers
-   * the focus call to the next microtask so PrimeNG has time to mount
-   * the input element in its overlay. Idempotent + null-safe.
+   * `(onShow)` handler for the Clone modal. Defers the focus call to the next
+   * microtask so PrimeNG has time to mount the input element in its overlay.
+   * Idempotent + null-safe.
    */
   onCloneDialogShow(): void {
     setTimeout(() => {
@@ -1593,11 +1582,10 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Story 11.7 AC 18, 19, 21 — `(onHide)` handler for the Clone modal.
-   * Runs the same cleanup as `onCloneCancelClick` PLUS clears
-   * `cloneInlineError` and returns focus to the outer Clone button.
-   * Defers the focus call by one microtask so any post-hide CD settles
-   * (and PrimeNG's exit animation completes) before the focus moves.
+   * `(onHide)` handler for the Clone modal. Runs the same cleanup as
+   * `onCloneCancelClick` PLUS clears `cloneInlineError` and returns focus to the
+   * outer Clone button. Defers the focus call by one microtask so any post-hide
+   * CD settles (and PrimeNG's exit animation completes) before the focus moves.
    */
   onCloneDialogHide(): void {
     this.cloneDestNs = '';
@@ -1611,11 +1599,10 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Story 11.7 AC 21 — destination-input change handler. Clears the
-   * unstructured-422 inline error so the operator can edit and retry
-   * without first dismissing a stale alert. The existing
-   * `cloneValidationError` getter (Story 11.5) is computed-on-getter and
-   * does not need a separate clear-on-input handler.
+   * Destination-input change handler. Clears the unstructured-422 inline error
+   * so the operator can edit and retry without first dismissing a stale alert.
+   * The `cloneValidationError` getter is computed-on-getter and does not need a
+   * separate clear-on-input handler.
    */
   onCloneDestNsChange(): void {
     if (this.cloneInlineError !== null) {
@@ -1624,17 +1611,17 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Clone handler — "duplicate the saved bundle" semantics (ADR-017 §3). The
-   * outer Clone button is gated on a **clean** panel (`buffer === serverYaml`),
-   * so the captured buffer is the persisted bundle, never a half-edited draft.
+   * Clone handler — "duplicate the saved bundle" semantics (ADR-017). The outer
+   * Clone button is gated on a **clean** panel (`buffer === serverYaml`), so the
+   * captured buffer is the persisted bundle, never a half-edited draft.
    * Rewrites the root `namespace` field via {@link rewriteNamespaceInYaml},
    * then reuses the Save path (`apiService.importNamespace`) — no new endpoint.
    *
-   * Branches (AC 8–AC 12):
+   * Branches:
    *   - `CloneYamlError` before the network call → toast + dialog stays
    *     open, `cloning` resets, `importNamespace` NEVER called.
    *   - 2xx → dismiss dialog, emit `(saved)`, switch to destNs, re-load via
-   *     `loadNamespace(destNs)` (Story 11.2 contract — lands clean).
+   *     `loadNamespace(destNs)` — lands clean.
    *   - 401 silent (FetchService surfaces the global toast).
    *   - 422 structured → populate `lastValidation`; dialog stays open.
    *   - 422 unstructured → stash raw body in `rawSaveError`; dialog stays
@@ -1643,7 +1630,7 @@ export class NamespacePanelComponent
    *     dialog stays open.
    *
    * In every failure branch: `namespace` / `serverYaml` / `buffer` are
-   * unchanged (AC 10). Destroy-guard mirrors Story 11.3's `onSaveClick`.
+   * unchanged. Destroy-guard mirrors `onSaveClick`.
    */
   async onCloneConfirmClick(): Promise<void> {
     if (this.cloneConfirmDisabled) {
@@ -1651,9 +1638,9 @@ export class NamespacePanelComponent
     }
     const destNs = this.cloneDestNs.trim();
     const destName = this.cloneDestName.trim();
-    // Story 12.2 — capture the toggle values once at the top (mirroring the
-    // destNs / destName trim-once capture) so they are stable across the
-    // async boundary. `isPublic` avoids the reserved-ish local name `public`.
+    // Capture the toggle values once at the top (mirroring the destNs /
+    // destName trim-once capture) so they are stable across the async boundary.
+    // `isPublic` avoids the reserved-ish local name `public`.
     const shareable = this.cloneShareable;
     const isPublic = this.clonePublic;
     const sourceYaml = this.buffer;
@@ -1674,7 +1661,7 @@ export class NamespacePanelComponent
       // 2xx happy path: dismiss dialog, emit saved, switch namespace +
       // re-load. Programmatic self-writes to an @Input() field do NOT
       // trigger ngOnChanges, so we invoke loadNamespace explicitly — it
-      // re-exports the bundle and lands the panel clean (Story 11.2).
+      // re-exports the bundle and lands the panel clean.
       this.cloneDialogVisible = false;
       this.cloneDestNs = '';
       this.cloneDestName = '';
@@ -1684,11 +1671,11 @@ export class NamespacePanelComponent
       this.saved.emit();
       this.namespace = destNs;
       // Fire-and-forget: loadNamespace owns its own loading flag and
-      // destroy guard. AC 14 budgets this second fetch explicitly.
+      // destroy guard.
       void this.loadNamespace(destNs);
-      // Story 11.7 AC 14 — pair the success toast with an aria-live
-      // announcement using the captured destNs (avoids racing with
-      // any later mutation of `this.cloneDestNs`).
+      // Pair the success toast with an aria-live announcement using the
+      // captured destNs (avoids racing with any later mutation of
+      // `this.cloneDestNs`).
       this.a11yAnnouncement = `Cloned to namespace '${destNs}'`;
       this.messageService.add({
         severity: 'success',
@@ -1707,10 +1694,9 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Narrow the caught Clone error (AC 9 + AC 11). Branch order MUST match
-   * AC 11 exactly: `CloneYamlError` FIRST (client-side rewrite failure,
-   * `importNamespace` never fired), then 401 silent, then 422 structured /
-   * 422 unstructured, then default sticky toast.
+   * Narrow the caught Clone error. Branch order: `CloneYamlError` FIRST
+   * (client-side rewrite failure, `importNamespace` never fired), then 401
+   * silent, then 422 structured / 422 unstructured, then default sticky toast.
    */
   private handleCloneError(err: unknown): void {
     if (err instanceof CloneYamlError) {
@@ -1732,33 +1718,31 @@ export class NamespacePanelComponent
     if (status === 422) {
       const body = (err as HttpError).body;
       if (this.isValidationReport(body)) {
-        // Story 11.7 AC 20 — structured 422 closes the Clone modal and
-        // surfaces the findings in the parent panel's findings pane (the
-        // single canonical findings surface). The outer Clone button is
-        // then gated by FR14.
+        // Structured 422 closes the Clone modal and surfaces the findings in
+        // the parent panel's findings pane (the single canonical findings
+        // surface). The outer Clone button is then gated by validation.
         this.lastValidation = body;
         this.rawSaveError = null;
         this.cloneDialogVisible = false;
         this.cloneDestNs = '';
         this.cloneInlineError = null;
-        // AC 12 — announce the failing-validation outcome.
+        // Announce the failing-validation outcome.
         this.announceValidationOutcome(body);
       } else {
-        // Story 11.7 AC 21 — unstructured 422 keeps the modal open with
-        // an inline `role="alert"` error. We deliberately do NOT touch
-        // `lastValidation` or `rawSaveError` (the parent's FR14 gate is
-        // reserved for SAVE failures). The inline alert handles its own
-        // assistive-tech announcement, so no live-region write here
-        // (avoids duplicate announcements).
+        // Unstructured 422 keeps the modal open with an inline `role="alert"`
+        // error. We deliberately do NOT touch `lastValidation` or
+        // `rawSaveError` (the parent's validation gate is reserved for SAVE
+        // failures). The inline alert handles its own assistive-tech
+        // announcement, so no live-region write here (avoids duplicate
+        // announcements).
         this.cloneInlineError =
           typeof body === 'string' ? body : JSON.stringify(body, null, 2);
       }
       return;
     }
-    // Default: 4xx / 5xx / network. Sticky toast + `lastCloneError` so a
-    // future story could wire an in-panel Retry-Clone button. This story
-    // deliberately does NOT add a Retry button — re-clicking Clone Confirm
-    // is the natural retry path, and the action row is already dense.
+    // Default: 4xx / 5xx / network. Sticky toast + `lastCloneError`. There is
+    // no in-panel Retry-Clone button — re-clicking Clone Confirm is the natural
+    // retry path, and the action row is already dense.
     this.lastCloneError = err instanceof Error ? err : new Error(String(err));
     this.messageService.add({
       severity: 'error',
@@ -1769,18 +1753,17 @@ export class NamespacePanelComponent
   }
 
   // -------------------------------------------------------------------
-  // Story 14.1 — Delete flow (ADR-028 §Decision 5, frontend leg). The
-  // backend authorizes the request (owner-or-admin); this client only
-  // issues the DELETE and reacts to the status code — no role/ownership
-  // logic lives here (ADR-028 §Decision 6).
+  // Delete flow (frontend leg). The backend authorizes the request
+  // (owner-or-admin); this client only issues the DELETE and reacts to the
+  // status code — no role/ownership logic lives here.
   // -------------------------------------------------------------------
 
   /**
-   * Delete handler (AC 3). Always available (only gated by an in-flight
-   * `deleting`). No-op while a delete is in flight (defence in depth alongside
+   * Delete handler. Always available (only gated by an in-flight `deleting`).
+   * No-op while a delete is in flight (defence in depth alongside
    * `[disabled]="deleting"`). Opens the custom confirmation modal naming the
    * current namespace; the Proceed (destructive) button runs `onDeleteConfirm()`.
-   * Cancelling is a no-op (panel unchanged, no network call — AC 5).
+   * Cancelling is a no-op (panel unchanged, no network call).
    */
   onDeleteClick(): void {
     if (this.deleting) {
@@ -1799,13 +1782,13 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Issues the DELETE and runs the result paths (AC 6–AC 10). No-op while a
-   * delete is in flight. Success (`204`): emit `saved` (host refreshes the
-   * namespace list) AND `closed` (Home dialog dismisses; route-shell ignores
-   * `closed` harmlessly) — Option A, zero host edits. Failure branches
-   * delegate to `handleDeleteError`; in every failure branch `namespace`,
-   * `serverYaml`, `buffer`, and `mode` are unchanged. The `deleting` flag is
-   * always cleared in `finally`, guarded by the `destroyed` idiom.
+   * Issues the DELETE and runs the result paths. No-op while a delete is in
+   * flight. Success (`204`): emit `saved` (host refreshes the namespace list)
+   * AND `closed` (Home dialog dismisses; route-shell ignores `closed`
+   * harmlessly). Failure branches delegate to `handleDeleteError`; in every
+   * failure branch `namespace`, `serverYaml`, and `buffer` are unchanged. The
+   * `deleting` flag is always cleared in `finally`, guarded by the `destroyed`
+   * idiom.
    */
   async onDeleteConfirm(): Promise<void> {
     if (this.deleting) {
@@ -1817,7 +1800,7 @@ export class NamespacePanelComponent
       if (this.destroyed) {
         return;
       }
-      // Success path mirrors the Clone-success UX (AC 6).
+      // Success path mirrors the Clone-success UX.
       this.a11yAnnouncement = `Namespace '${this.namespace}' deleted`;
       this.saved.emit();
       this.closed.emit();
@@ -1838,7 +1821,7 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Narrow the caught Delete error (AC 7–AC 9). Branches:
+   * Narrow the caught Delete error. Branches:
    *   - `401` → silent return (FetchService already fired the global toast;
    *     the panel does not mutate `buffer` / `serverYaml`).
    *   - `403` → non-sticky not-authorized toast; panel stays open. NOT
@@ -1914,13 +1897,13 @@ export class NamespacePanelComponent
     const seq = ++this.loadSeq;
     this.loading = true;
     // Reset buffer/serverYaml at the start of each reload so the empty
-    // state renders (AC 3 step 1 + AC 5) while the fetch is in flight.
+    // state renders while the fetch is in flight.
     this.serverYaml = '';
     this.buffer = '';
     try {
-      // Story 14.4 — carry the admin "show all" flag so an admin opening a
-      // foreign-owned namespace from the home "show all" list can read it
-      // (the export GET is unscoped server-side for admins when all=true).
+      // Carry the admin "show all" flag so an admin opening a foreign-owned
+      // namespace from the home "show all" list can read it (the export GET is
+      // unscoped server-side for admins when all=true).
       const yaml = await this.apiService.exportNamespace(namespace, {
         all: this.showAll,
       });
@@ -1930,8 +1913,7 @@ export class NamespacePanelComponent
       this.serverYaml = yaml;
       this.buffer = yaml;
       // buffer === serverYaml ⇒ the panel lands clean (Save/Reset disabled,
-      // Clone enabled). There is no mode to set — the editor is always
-      // writable.
+      // Clone enabled). The editor is always writable.
       this.lastValidation = null;
       this.rawSaveError = null;
     } catch (err) {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -41,34 +41,45 @@ import {
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 /**
- * NamespacePanelComponent — host-agnostic view of a catalog namespace YAML.
+ * NamespacePanelComponent — host-agnostic editor for a catalog namespace YAML.
  *
- * Story 11.2 delivered the read-only scaffold. Story 11.3 adds:
- *   - Edit / Cancel / Save action row (Edit replaced by Cancel+Save in edit mode).
- *   - `hasUnsavedChanges()` is now a real buffer-vs-serverYaml comparison.
- *   - Save flow posts directly to `apiService.importNamespace` — NO
- *     pre-save `validate` round-trip (ADR-011 D4).
+ * Story 22.1 (ADR-017 §1–§6) collapses the original view/edit two-mode state
+ * machine into a single **dirty** signal (`buffer !== serverYaml`). The panel
+ * is **always editable** — Monaco mounts permanently writable, there is no
+ * Edit-click barrier, and the entire action row is driven by one boolean:
+ *
+ *   - Monaco mounts writable (`readOnly: false`); `editorOptions` is a single
+ *     stable object built once and never reassigned.
+ *   - `hasUnsavedChanges()` collapses to `buffer !== serverYaml` (name +
+ *     signature preserved — the route `CanDeactivate` guard and the home
+ *     dirty-close guard consume it unchanged).
+ *   - Action row: Validate (always) · Save (dirty) · Reset (dirty) ·
+ *     Clone (clean) · Delete (always).
+ *   - Save flow posts directly to `apiService.importNamespace` — NO pre-save
+ *     `validate` round-trip (ADR-011 D4) — preceded by a one-shot drift check
+ *     (re-export; on divergence prompt reload-and-rebase vs overwrite).
  *   - 422 → populate `lastValidation` (structured) or `rawSaveError`
- *     (fallback); stay in edit mode, buffer preserved.
- *   - 5xx / 4xx (other than 401/422) → sticky error toast + in-panel Retry
- *     button; stay in edit mode, buffer preserved.
+ *     (fallback); buffer preserved.
+ *   - 5xx / 4xx (other than 401/422) → sticky error toast; buffer preserved.
+ *     Re-clicking Save retries.
  *   - 401 → no panel-specific behaviour; the FetchService global toast
  *     surfaces the failure, the app-wide handler (if any) runs. Panel only
  *     clears `saving` in `finally`.
- *   - PrimeNG `ConfirmDialog` guards Cancel-with-dirty-buffer.
+ *   - PrimeNG `ConfirmDialog` guards Reset-with-dirty-buffer and the Save
+ *     drift reload-vs-overwrite choice.
  *
  * The component remains presentation-only: no `Router`, `ActivatedRoute`,
- * `MAT_DIALOG_DATA`, etc. The dialog wrapper (HomeComponent) and the future
+ * `MAT_DIALOG_DATA`, etc. The dialog wrapper (HomeComponent) and the
  * deep-link route (Story 11.6) mount it identically.
  *
- * Public surface contract (stable across Epic 11):
+ * Public surface contract:
  *   - @Input() namespace: string          — required, drives the load flow.
  *   - @Output() closed: EventEmitter<void> — asks the host to dismiss.
  *   - @Output() saved: EventEmitter<void>  — emitted once per successful
  *     import; hosts re-fetch derived lists (e.g. HomeComponent's dropdown).
  *   - hasUnsavedChanges(): boolean         — dirty-state predicate. Returns
- *     true iff `mode === 'edit' && buffer !== serverYaml`. Story 11.6's
- *     `CanDeactivate` guard consumes the same method.
+ *     true iff `buffer !== serverYaml`. The route `CanDeactivate` guard and
+ *     the home dirty-close guard consume the same method.
  */
 @Component({
   selector: 'app-namespace-panel',
@@ -122,10 +133,10 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   private authService: AuthService = inject(AuthService);
   private destroyRef: DestroyRef = inject(DestroyRef);
 
-  // Internal state — initial values per AC 2.
+  // Internal state. The panel is always editable — there is no `mode` axis.
+  // The single signal that drives the action row is `buffer !== serverYaml`.
   serverYaml: string = '';
   buffer: string = '';
-  mode: 'view' | 'edit' = 'view';
   lastValidation: NamespaceValidationReport | null = null;
   loading: boolean = false;
 
@@ -142,27 +153,17 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   validating: boolean = false;
 
   // UX polish: replaces the intrusive "Validation passed" panel on clean
-  // reports. When a Validate click returns `ok: true`, the clicked button
+  // reports. When a Validate click returns `ok: true`, the Validate button
   // briefly flips to PrimeNG's `success` severity (green) and then reverts.
   // The report pane stays hidden in this path — findings-only.
   //
-  //   - `validationFlashPersisted` — true while the view-mode Validate button
-  //     shows the success-flash state.
-  //   - `validationFlashBuffer`    — same, for the edit-mode Validate button.
+  //   - `validationFlashBuffer` — true while the Validate button shows the
+  //     success-flash state. (Single flag now — there is one Validate
+  //     button, over the buffer; ADR-017 §4.)
   //   - `flashTimeoutId` — handle so repeated clicks cancel the prior timer
   //     and the destroy hook cleans up any pending callback.
-  validationFlashPersisted: boolean = false;
   validationFlashBuffer: boolean = false;
   private flashTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-
-  /**
-   * Post-review UX refinement — set while the Edit button's drift check
-   * is in flight (one `exportNamespace` call before flipping to edit
-   * mode). Gates the Edit button's `[disabled]` + spinner-icon swap so
-   * the operator cannot double-click during the async round trip. See
-   * `onEditClick()`.
-   */
-  refreshingForEdit: boolean = false;
 
   /**
    * Snapshot of the buffer value at the moment a Validate-buffer request
@@ -302,18 +303,17 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Briefly flash the clicked Validate button as `success` (green) — the
-   * UX-light alternative to rendering a "Validation passed" panel for clean
-   * reports. Repeated clicks during the flash window cancel the pending
-   * timer and restart fresh. The destroyed guard prevents a post-destroy
-   * write if the timer fires after teardown.
+   * Briefly flash the Validate button as `success` (green) — the UX-light
+   * alternative to rendering a "Validation passed" panel for clean reports.
+   * Repeated clicks during the flash window cancel the pending timer and
+   * restart fresh. The destroyed guard prevents a post-destroy write if the
+   * timer fires after teardown.
    */
-  private flashValidated(target: 'persisted' | 'buffer'): void {
+  private flashValidated(): void {
     if (this.flashTimeoutId !== undefined) {
       clearTimeout(this.flashTimeoutId);
     }
-    this.validationFlashPersisted = target === 'persisted';
-    this.validationFlashBuffer = target === 'buffer';
+    this.validationFlashBuffer = true;
     // Story 11.7 AC 11 — pair the visual flash with an aria-live
     // announcement so screen-reader users get the same outcome.
     this.a11yAnnouncement = 'Validation passed';
@@ -322,7 +322,6 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       if (this.destroyed) {
         return;
       }
-      this.validationFlashPersisted = false;
       this.validationFlashBuffer = false;
       this.validatedBuffer = null;
     }, 2500);
@@ -330,10 +329,10 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
 
   /**
    * Story 11.7 AC 12 — write the failing-validation announcement into the
-   * live region. Called from THREE sites that populate `lastValidation`
-   * with a non-clean report: `onValidatePersistedClick` failing branch,
-   * `onValidateBufferClick` failing branch, and the Save / Clone 422
-   * structured branches in `handleSaveError` / `handleCloneError`.
+   * live region. Called from the sites that populate `lastValidation` with a
+   * non-clean report: the `onValidateBufferClick` failing branch and the
+   * Save / Clone / Delete 422 structured branches in `handleSaveError` /
+   * `handleCloneError` / `handleDeleteError`.
    *
    * Plural form is fixed at "issues" (e.g. "Validation found 1 issues") for
    * announcement-text simplicity — assistive-tech audiences tolerate the
@@ -352,7 +351,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   /**
    * Single write path for `buffer` driven from the Monaco editor's
    * `(ngModelChange)`. Writes-through to `this.buffer` AND invalidates the
-   * edit-mode Validate-buffer flash when the value diverges from the
+   * Validate success-flash when the value diverges from the
    * snapshot captured at the last successful validate. Modifying the YAML
    * after a clean ack makes the ack stale — the button must revert to
    * secondary immediately rather than keep its green state for the full
@@ -404,136 +403,42 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Monaco editor options.
+   * Monaco editor options — a single stable object reference built once and
+   * NEVER reassigned (ADR-017 §1). The editor is permanently writable
+   * (`readOnly: false`) since the panel is always editable.
    *
-   * MUST be a stable object reference between mode changes. `nu-monaco-editor`
-   * receives `[options]` as a signal input (reference-equality semantics) —
-   * returning a fresh object every change-detection tick (the previous getter
-   * implementation) fires the input on every CD, causes `updateOptions()` to
-   * run repeatedly, and drives a CD / layout feedback loop that freezes the
-   * tab. The field is reassigned ONLY when `mode` flips (via `setMode`).
+   * `nu-monaco-editor` receives `[options]` as a signal input
+   * (reference-equality semantics): a stable reference means Monaco's
+   * `updateOptions()` does not re-run on every change-detection tick. The old
+   * per-mode reassignment (via `setMode`) was the CD-churn risk; with one
+   * constant object that risk is gone.
    *
    * `automaticLayout: true` is load-bearing for dialog hosting — the editor
    * otherwise renders at 0×0 when its container mounts late.
    */
-  editorOptions: Record<string, unknown> = this.buildEditorOptions();
-
-  private buildEditorOptions(): Record<string, unknown> {
-    return {
-      theme: 'vs',
-      language: 'yaml',
-      automaticLayout: true,
-      readOnly: this.mode === 'view',
-    };
-  }
+  readonly editorOptions: Record<string, unknown> = {
+    theme: 'vs',
+    language: 'yaml',
+    automaticLayout: true,
+    readOnly: false,
+  };
 
   /**
-   * Single write path for `mode` — keeps `editorOptions` in lock-step so the
-   * Monaco signal input sees exactly one new reference per real mode flip.
-   */
-  private setMode(next: 'view' | 'edit'): void {
-    if (this.mode === next) {
-      return;
-    }
-    this.mode = next;
-    this.editorOptions = this.buildEditorOptions();
-  }
-
-  /**
-   * Dirty-state predicate — single source of truth for confirm-on-close
-   * and Save-enabled checks. True iff the panel is in edit mode AND the
-   * buffer diverges from the last server snapshot. Method NAME + SIGNATURE
-   * are part of Epic 11's stable surface (Story 11.6's `CanDeactivate`
-   * guard consumes the same method).
+   * Dirty-state predicate — single source of truth for the confirm-on-close
+   * guards and the Save/Reset/Clone enablement. True iff the buffer diverges
+   * from the last server snapshot (ADR-017 §1). The method NAME + SIGNATURE
+   * are preserved: the route `CanDeactivate` guard and the home dirty-close
+   * guard consume the same method.
    */
   hasUnsavedChanges(): boolean {
-    return this.mode === 'edit' && this.buffer !== this.serverYaml;
+    return this.buffer !== this.serverYaml;
   }
 
   /**
-   * Enter edit mode.
-   *
-   * Post-review refinement — re-fetches the server namespace (single
-   * `exportNamespace` call) before flipping to `edit`. If the server has
-   * drifted since the initial load, prompts the operator to reload;
-   * accept replaces `serverYaml` + `buffer` with the latest and enters
-   * edit mode against the fresh state, reject stays in view mode with
-   * the stale state visible (operator can re-click Edit or close).
-   *
-   * On network error the drift check falls through to edit mode with a
-   * warning toast — operators shouldn't be blocked by a hiccup from
-   * editing their last-known version; the server still validates on
-   * save, so a genuinely-stale edit can only land a known-bad bundle.
-   *
-   * Monaco's `readOnly` flips via the `editorOptions` field (reassigned
-   * in `setMode`). Save / Reset / Cancel replace the Edit / Clone pair
-   * in the action row.
-   */
-  async onEditClick(): Promise<void> {
-    if (this.refreshingForEdit) {
-      return;
-    }
-    this.refreshingForEdit = true;
-    try {
-      // Story 14.4 — the Edit drift-check re-read must also carry the admin
-      // "show all" flag, else an admin editing a foreign-owned namespace would
-      // hit an owner-scoped read here and fail the drift check.
-      const latestYaml = await this.apiService.exportNamespace(this.namespace, {
-        all: this.showAll,
-      });
-      if (this.destroyed) {
-        return;
-      }
-      if (latestYaml === this.serverYaml) {
-        this.setMode('edit');
-        return;
-      }
-      // Drift detected — prompt the operator before silently replacing
-      // the snapshot the panel is showing.
-      this.confirmationService.confirm({
-        header: 'Namespace modified',
-        icon: 'pi pi-exclamation-triangle',
-        message:
-          'The namespace was modified on the server since it was loaded. Reload the latest version to edit?',
-        accept: () => {
-          if (this.destroyed) {
-            return;
-          }
-          this.serverYaml = latestYaml;
-          this.buffer = latestYaml;
-          this.lastValidation = null;
-          this.rawSaveError = null;
-          this.validatedBuffer = null;
-          this.setMode('edit');
-        },
-        // reject intentionally omitted — dismissing keeps the operator
-        // in view mode with the stale state visible; re-clicking Edit
-        // will re-check.
-      });
-    } catch (err) {
-      if (this.destroyed) {
-        return;
-      }
-      // Non-blocking: warn and proceed to edit against last-known state.
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Could not verify namespace state',
-        detail: 'Editing against the last-known version. Save will re-validate on the server.',
-      });
-      this.setMode('edit');
-    } finally {
-      if (!this.destroyed) {
-        this.refreshingForEdit = false;
-      }
-    }
-  }
-
-  /**
-   * Post-review new feature — revert the buffer to `serverYaml` without
-   * exiting edit mode. Mirrors Cancel's dirty-state guard (confirm
-   * "Discard unsaved changes?") but keeps `mode === 'edit'` on accept
-   * so the operator can keep working. Clean buffer path is guarded at
-   * the template level (`[disabled]="buffer === serverYaml"`).
+   * Revert the buffer to `serverYaml` — the SOLE undo affordance now that
+   * Cancel is removed (ADR-017 §2). Guarded by the existing "Discard unsaved
+   * changes?" confirm; a no-op when clean (the Reset button is also disabled
+   * via `[disabled]="buffer === serverYaml"`).
    */
   onResetClick(): void {
     if (this.buffer === this.serverYaml) {
@@ -551,49 +456,30 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
         this.lastValidation = null;
         this.rawSaveError = null;
         this.validatedBuffer = null;
-        // Stay in edit mode — Reset differs from Cancel here.
       },
-    });
-  }
-
-  /**
-   * Cancel the edit. Clean buffer → flip to view directly. Dirty buffer →
-   * PrimeNG confirm dialog; on accept revert buffer + flip to view, on
-   * reject keep state unchanged (AC 3 + AC 4).
-   */
-  onCancelClick(): void {
-    if (this.buffer === this.serverYaml) {
-      this.setMode('view');
-      return;
-    }
-    this.confirmationService.confirm({
-      header: 'Unsaved changes',
-      icon: 'pi pi-exclamation-triangle',
-      message: 'Discard unsaved changes?',
-      accept: () => {
-        if (this.destroyed) {
-          return;
-        }
-        this.buffer = this.serverYaml;
-        this.setMode('view');
-      },
-      // `reject` intentionally omitted — dismissing the confirm leaves the
-      // panel exactly as it was (AC 3 dismiss branch).
     });
   }
 
   /**
    * Save handler — posts the current buffer directly to
-   * `apiService.importNamespace` (NO pre-save validate, per ADR-011 D4).
+   * `apiService.importNamespace` (NO pre-save validate, per ADR-011 D4),
+   * preceded by a one-shot **drift check** (ADR-017 §6).
    *
-   * Success (2xx): `serverYaml` snapshots the just-saved buffer, mode flips
-   * to view, toast success, `saved` emits so the host refreshes derived
-   * lists.
+   * Gated on `hasUnsavedChanges()` (and `saving`); no longer references any
+   * mode — the panel is always editable.
+   *
+   * Drift check: before importing, re-`exportNamespace` and, if the returned
+   * YAML diverges from `serverYaml`, prompt the operator (reload-and-rebase
+   * vs overwrite) instead of importing blindly. The check is one-shot per
+   * Save; it relocates the protection the old Edit-entry drift check gave.
+   *
+   * Success (2xx): `serverYaml` snapshots the just-saved buffer, toast
+   * success, `saved` emits so the host refreshes derived lists. The buffer is
+   * unchanged, so the panel is now clean (Save/Reset disable, Clone enables).
    *
    * 422: populate `lastValidation` when the body is structurally a
-   * `NamespaceValidationReport`, else stash the raw body into
-   * `rawSaveError` for a verbatim `<pre>` rendering. Stay in edit mode,
-   * buffer preserved, saving resets.
+   * `NamespaceValidationReport`, else stash the raw body into `rawSaveError`
+   * for a verbatim `<pre>` rendering. Buffer preserved, saving resets.
    *
    * 401: silent at the panel level. FetchService has already surfaced a
    * global toast; the app-wide 401 handler (if any) runs. The panel only
@@ -658,20 +544,14 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     // not display outdated issues while the request is in flight.
     this.lastValidation = null;
     try {
-      await this.apiService.importNamespace(savedBuffer);
-      if (this.destroyed) {
+      // ADR-017 §6 — one-shot drift check before importing. Returns false
+      // when the operator chose reload-and-rebase (import is skipped this
+      // click); true when the import should proceed (no drift, or overwrite).
+      const proceed = await this.checkSaveDrift(savedBuffer);
+      if (this.destroyed || !proceed) {
         return;
       }
-      this.serverYaml = savedBuffer;
-      this.setMode('view');
-      // Story 11.7 AC 13 — pair the success toast with an aria-live
-      // announcement so screen-reader users get the same outcome.
-      this.a11yAnnouncement = 'Namespace saved';
-      this.saved.emit();
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Namespace saved successfully',
-      });
+      await this.performSaveImport(savedBuffer);
     } catch (err) {
       if (this.destroyed) {
         return;
@@ -685,61 +565,99 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Validate the persisted namespace (view mode). Calls
-   * `apiService.validatePersistedNamespace(this.namespace)` exactly once,
-   * populates `this.lastValidation` on success, never mutates
-   * `serverYaml` / `mode` / `buffer` / `rawSaveError` (Validate is never
-   * a Save gate — ADR-011 D3 / D4).
+   * ADR-017 §6 — one-shot drift check folded into Save. Re-`exportNamespace`s
+   * (carrying `{ all: this.showAll }`) and, if the returned YAML diverges from
+   * `serverYaml`, prompts the operator with a reload-and-rebase vs overwrite
+   * choice. Returns:
+   *   - `true`  → proceed with the import (no drift detected, OR the operator
+   *               chose **overwrite**).
+   *   - `false` → skip the import this click (the operator chose
+   *               **reload-and-rebase**: `serverYaml`, and `buffer` if it
+   *               equalled the old `serverYaml`, are replaced with the latest
+   *               server YAML so the operator can re-Save against the fresh
+   *               base).
+   *
+   * PrimeNG's `confirmationService.confirm` is binary, so the affordance is
+   * mapped: `accept` = reload-and-rebase (resolve false), `reject` =
+   * overwrite (resolve true). A network error during the re-export falls
+   * through to `true` (proceed) — the server still validates on import, so a
+   * genuinely-stale edit can only land a known-bad bundle, and operators
+   * should not be blocked by a hiccup.
    */
-  async onValidatePersistedClick(): Promise<void> {
-    if (this.validating) {
-      return;
-    }
-    this.validating = true;
+  private async checkSaveDrift(savedBuffer: string): Promise<boolean> {
+    let latestYaml: string;
     try {
-      const report = await this.apiService.validatePersistedNamespace(
-        this.namespace,
-      );
-      if (this.destroyed) {
-        return;
-      }
-      // Defensive: if the API layer resolved to undefined (e.g. network
-      // fallback in FetchService) or an unexpected shape, surface a clear
-      // toast instead of throwing a TypeError on `report.ok`.
-      if (!this.isValidationReport(report)) {
-        throw new Error('Server returned no validation report.');
-      }
-      // Clean report → keep the pane hidden and flash the button green for a
-      // brief ack. Non-clean report → populate `lastValidation` so the
-      // ValidationReportComponent renders the findings.
-      if (report.ok) {
-        this.lastValidation = null;
-        this.flashValidated('persisted');
-      } else {
-        this.lastValidation = report;
-        // Story 11.7 AC 12 — announce the failing-validation outcome.
-        this.announceValidationOutcome(report);
-      }
-    } catch (err) {
-      if (this.destroyed) {
-        return;
-      }
-      this.handleValidateError(err);
-    } finally {
-      if (!this.destroyed) {
-        this.validating = false;
-      }
+      latestYaml = await this.apiService.exportNamespace(this.namespace, {
+        all: this.showAll,
+      });
+    } catch {
+      // Non-blocking: proceed to import against last-known server state.
+      return true;
     }
+    if (this.destroyed) {
+      return false;
+    }
+    if (latestYaml === this.serverYaml) {
+      return true;
+    }
+    return new Promise<boolean>((resolve) => {
+      this.confirmationService.confirm({
+        header: 'Namespace modified',
+        icon: 'pi pi-exclamation-triangle',
+        message:
+          'The namespace was modified on the server since it was loaded. ' +
+          'Reload the latest version (discarding this Save), or overwrite it ' +
+          'with your changes?',
+        acceptLabel: 'Reload',
+        rejectLabel: 'Overwrite',
+        accept: () => {
+          if (!this.destroyed) {
+            // Rebase onto the fresh server YAML; only move the buffer if it
+            // was still pinned to the old snapshot (no local edits to lose).
+            if (this.buffer === this.serverYaml) {
+              this.buffer = latestYaml;
+            }
+            this.serverYaml = latestYaml;
+          }
+          resolve(false);
+        },
+        reject: () => resolve(true),
+      });
+    });
   }
 
   /**
-   * Validate the current edit buffer without persisting. Snapshots
-   * `this.buffer` at click time (`bufferAtClick`) so Monaco's live
+   * Issues the import and runs the success branch. Extracted from
+   * `onSaveClick` so the handler stays within the method-length budget. The
+   * caller owns `saving` / the destroy guard / the catch branch.
+   */
+  private async performSaveImport(savedBuffer: string): Promise<void> {
+    await this.apiService.importNamespace(savedBuffer);
+    if (this.destroyed) {
+      return;
+    }
+    this.serverYaml = savedBuffer;
+    // Story 11.7 AC 13 — pair the success toast with an aria-live
+    // announcement so screen-reader users get the same outcome.
+    this.a11yAnnouncement = 'Namespace saved';
+    this.saved.emit();
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Namespace saved successfully',
+    });
+  }
+
+  /**
+   * The SINGLE Validate handler (ADR-017 §4). Validates the current buffer
+   * without persisting via `apiService.validateNamespaceBuffer(buffer)`.
+   * Snapshots `this.buffer` at click time (`bufferAtClick`) so Monaco's live
    * `[(ngModel)]` mutation during the in-flight request cannot race the
    * request args (mirrors Story 11.3's `savedBuffer` pattern).
    *
-   * Validate never mutates `mode`, `serverYaml`, or `buffer` — the
-   * handler touches only `validating` and `lastValidation`.
+   * When the buffer is clean (`buffer === serverYaml`), this is identical to
+   * validating the persisted namespace. Validate never mutates `serverYaml`
+   * or `buffer` — the handler touches only `validating` and `lastValidation`.
+   * It is never disabled by the FR14 gate (ADR-017 §5).
    */
   async onValidateBufferClick(): Promise<void> {
     if (this.validating) {
@@ -756,12 +674,12 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       if (!this.isValidationReport(report)) {
         throw new Error('Server returned no validation report.');
       }
-      // Clean buffer → flash the edit-mode Validate button. Non-clean →
-      // render findings via `lastValidation` as before.
+      // Clean buffer → flash the Validate button. Non-clean → render
+      // findings via `lastValidation` as before.
       if (report.ok) {
         this.lastValidation = null;
         this.validatedBuffer = bufferAtClick;
-        this.flashValidated('buffer');
+        this.flashValidated();
       } else {
         this.lastValidation = report;
         // Story 11.7 AC 12 — announce the failing-validation outcome.
@@ -842,7 +760,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     if (status === 401) {
       // Silent at the panel — FetchService already fired a global toast and
       // the app-wide 401 handler (if any) runs. The panel does not mutate
-      // `mode` / `buffer` / `lastValidation` on 401 (AC 9).
+      // `buffer` / `lastValidation` on 401 (AC 9).
       return;
     }
     if (status === 422) {
@@ -877,7 +795,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
 
   /**
    * Open the Clone sub-dialog (AC 2). Pure UI flip — does NOT fire a
-   * network request, does NOT mutate `buffer` / `serverYaml` / `mode` /
+   * network request, does NOT mutate `buffer` / `serverYaml` /
    * `lastValidation` / `rawSaveError`. No-op when `cloning === true`
    * (defence in depth — the outer Clone button is `[disabled]` in that
    * state, so this path is unreachable in practice).
@@ -1095,17 +1013,17 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Clone handler — "Save As" semantics (AC 5). Captures the CURRENT buffer
-   * (NOT `serverYaml`) so an operator editing mid-view and clicking Clone
-   * sees their dirty edits in the rewritten bundle. Rewrites the root
-   * `namespace` field via {@link rewriteNamespaceInYaml}, then reuses the
-   * Save path (`apiService.importNamespace`) — no new endpoint.
+   * Clone handler — "duplicate the saved bundle" semantics (ADR-017 §3). The
+   * outer Clone button is gated on a **clean** panel (`buffer === serverYaml`),
+   * so the captured buffer is the persisted bundle, never a half-edited draft.
+   * Rewrites the root `namespace` field via {@link rewriteNamespaceInYaml},
+   * then reuses the Save path (`apiService.importNamespace`) — no new endpoint.
    *
    * Branches (AC 8–AC 12):
    *   - `CloneYamlError` before the network call → toast + dialog stays
    *     open, `cloning` resets, `importNamespace` NEVER called.
    *   - 2xx → dismiss dialog, emit `(saved)`, switch to destNs, re-load via
-   *     `loadNamespace(destNs)` (Story 11.2 contract — lands in view mode).
+   *     `loadNamespace(destNs)` (Story 11.2 contract — lands clean).
    *   - 401 silent (FetchService surfaces the global toast).
    *   - 422 structured → populate `lastValidation`; dialog stays open.
    *   - 422 unstructured → stash raw body in `rawSaveError`; dialog stays
@@ -1113,8 +1031,8 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    *   - Other (4xx / 5xx / network) → sticky error toast + `lastCloneError`;
    *     dialog stays open.
    *
-   * In every failure branch: `namespace` / `serverYaml` / `buffer` / `mode`
-   * are unchanged (AC 10). Destroy-guard mirrors Story 11.3's `onSaveClick`.
+   * In every failure branch: `namespace` / `serverYaml` / `buffer` are
+   * unchanged (AC 10). Destroy-guard mirrors Story 11.3's `onSaveClick`.
    */
   async onCloneConfirmClick(): Promise<void> {
     if (this.cloneConfirmDisabled) {
@@ -1145,7 +1063,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       // 2xx happy path: dismiss dialog, emit saved, switch namespace +
       // re-load. Programmatic self-writes to an @Input() field do NOT
       // trigger ngOnChanges, so we invoke loadNamespace explicitly — it
-      // re-exports the bundle and flips mode to view (Story 11.2).
+      // re-exports the bundle and lands the panel clean (Story 11.2).
       this.cloneDialogVisible = false;
       this.cloneDestNs = '';
       this.cloneDestName = '';
@@ -1247,10 +1165,11 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   // -------------------------------------------------------------------
 
   /**
-   * View-mode Delete handler (AC 3). No-op while a delete is in flight
-   * (defence in depth alongside `[disabled]="deleting"`). Opens the PrimeNG
-   * confirm naming the current namespace; `accept` runs `onDeleteConfirm()`.
-   * No `reject` — cancelling is a no-op (panel unchanged, no network call).
+   * Delete handler (AC 3). Always available (only gated by an in-flight
+   * `deleting`). No-op while a delete is in flight (defence in depth alongside
+   * `[disabled]="deleting"`). Opens the PrimeNG confirm naming the current
+   * namespace; `accept` runs `onDeleteConfirm()`. No `reject` — cancelling is
+   * a no-op (panel unchanged, no network call).
    */
   onDeleteClick(): void {
     if (this.deleting) {
@@ -1310,7 +1229,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   /**
    * Narrow the caught Delete error (AC 7–AC 9). Branches:
    *   - `401` → silent return (FetchService already fired the global toast;
-   *     the panel does not mutate `mode` / `buffer` / `serverYaml`).
+   *     the panel does not mutate `buffer` / `serverYaml`).
    *   - `403` → non-sticky not-authorized toast; panel stays open. NOT
    *     retried. (Community never returns 403; gated tiers do.)
    *   - `409` / `422` → inbound-reference blocker. If the body is a
@@ -1399,7 +1318,9 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       }
       this.serverYaml = yaml;
       this.buffer = yaml;
-      this.setMode('view');
+      // buffer === serverYaml ⇒ the panel lands clean (Save/Reset disabled,
+      // Clone enabled). There is no mode to set — the editor is always
+      // writable.
       this.lastValidation = null;
       this.rawSaveError = null;
     } catch (err) {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -44,19 +44,22 @@ import {
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 /**
- * Typed shape for the panel's custom confirmation modal (ADR-018 §1). One
- * interface, three call sites — NEVER an inline `Record`/object literal
- * scattered across handlers (Golden Rule #1). `variant` selects the action-row
- * button layout:
- *   - `'reset'` / `'delete'` → `[Cancel] [Proceed]` (Proceed is destructive for
- *     `'delete'` only — ADR-018 §4).
+ * Typed shape for the panel's custom confirmation modal (ADR-018 §1 +
+ * Amendment §c). One interface, every call site — NEVER an inline
+ * `Record`/object literal scattered across handlers (Golden Rule #1). `variant`
+ * selects the action-row button layout:
+ *   - `'reset'` / `'delete'` / `'discard'` → `[Cancel] [Proceed]` (Proceed is
+ *     destructive — dark-red — for `'delete'` only — ADR-018 §4). `'discard'` is
+ *     the dirty-CLOSE / dirty-NAV variant the host config dialog (Home) and the
+ *     route `CanDeactivate` guard reuse via the public `confirmDiscard()`
+ *     method (ADR-018 Amendment §c).
  *   - `'drift'` → `[Reload] [Overwrite]` (two explicit named buttons, not a
  *     binary accept/reject — ADR-018 §1).
  */
 interface ConfirmRequest {
   header: string;
   message: string;
-  variant: 'reset' | 'drift' | 'delete';
+  variant: 'reset' | 'drift' | 'delete' | 'discard';
 }
 
 /**
@@ -304,13 +307,26 @@ export class NamespacePanelComponent
   private confirmDriftResolve: (() => void) | null = null;
 
   /**
-   * Safe-button reference for the confirmation modal — the Cancel button for
-   * the reset/delete variants, the Reload button for the drift variant. Used by
-   * `onConfirmDialogShow()` to autofocus it on open so Enter cancels (AC 9, 10),
-   * mirroring the Clone modal's `cloneDestInputRef` focus plumbing.
+   * Pending "resolve the dirty-discard `Promise<boolean>` to the SAFE branch
+   * (false — keep edits)" thunk for an Esc / Cancel / X dismissal of the
+   * `'discard'` modal (ADR-018 Amendment §c). Set by `confirmDiscard()` while
+   * the discard modal is open; invoked by `onConfirmDialogHide` so a dismissal
+   * that bypasses a button still settles the awaited promise as "do not
+   * discard". `null` for the reset/delete/drift variants.
    */
-  @ViewChild('confirmSafeBtn', { read: ElementRef })
-  confirmSafeBtnRef?: ElementRef<HTMLButtonElement>;
+  private confirmDiscardResolve: (() => void) | null = null;
+
+  /**
+   * Primary-button reference for the confirmation modal (ADR-018 Amendment §e
+   * — reverses the earlier focus-Cancel). On open `onConfirmDialogShow()`
+   * autofocuses the PRIMARY/proceed button so **Enter activates the main
+   * action**: the Proceed button for the reset/delete/discard variants, the
+   * Reload (recommended primary) button for the drift variant. Esc still
+   * cancels/dismisses. Mirrors the Clone modal's `cloneDestInputRef` focus
+   * plumbing.
+   */
+  @ViewChild('confirmPrimaryBtn', { read: ElementRef })
+  confirmPrimaryBtnRef?: ElementRef<HTMLButtonElement>;
 
   // -------------------------------------------------------------------
   // Story 11.7 — UX-polish state (FR14 gate, FR16 a11y, FR17 Clone modal,
@@ -827,19 +843,102 @@ export class NamespacePanelComponent
   }
 
   /**
-   * The action-row label for the confirmation modal's affirmative button. The
-   * drift variant uses "Overwrite" (its Reload button is rendered separately);
-   * reset/delete use "Proceed". Returned as a getter so the template need not
-   * branch on the variant in three places.
+   * Coordinated Escape for the panel's secondary modals (ADR-018 Amendment §b).
+   * Closes ONLY the topmost open secondary panel and reports whether it consumed
+   * the Escape, so EXACTLY ONE action happens per keystroke (no cascade):
+   *
+   *   1. confirmation modal open → cancel/close ONLY it (settling any pending
+   *      drift/discard promise via `onConfirmDialogHide`), return `true`.
+   *   2. else Clone modal open → close ONLY it, return `true`.
+   *   3. else no secondary panel open → return `false` (the host then runs the
+   *      configuration panel's own close flow).
+   *
+   * PrimeNG attaches `closeOnEscape` as a DOCUMENT-level listener per dialog, so
+   * a child `stopPropagation()` cannot stop the host config dialog's listener —
+   * that is why ALL THREE dialogs set `[closeOnEscape]="false"` and a single
+   * coordinator (the host's capture-phase keydown) delegates here first. Order
+   * is deterministic: confirm is always stacked above Clone, so it wins.
    */
-  get confirmProceedLabel(): string {
-    return this.confirmRequest?.variant === 'delete' ? 'Delete' : 'Proceed';
+  handleSecondaryEscape(): boolean {
+    if (this.confirmDialogVisible) {
+      // Route through onConfirmDialogHide so a pending drift/discard promise
+      // settles to its safe branch (mirrors a Cancel/X dismissal).
+      this.onConfirmDialogHide();
+      return true;
+    }
+    if (this.cloneDialogVisible) {
+      this.onCloneDialogVisibleChange(false);
+      return true;
+    }
+    return false;
   }
 
   /**
-   * Proceed (reset/delete) button handler (AC 3, 5). Runs the captured accept
-   * callback then closes. For `'delete'` this fires `onDeleteConfirm()`; for
-   * `'reset'` the revert effect.
+   * PUBLIC dirty-discard confirm (ADR-018 Amendment §c). Opens the panel-owned
+   * custom confirmation modal with the `'discard'` variant ("Unsaved changes" /
+   * "You have unsaved changes. Discard?") and returns a `Promise<boolean>` that
+   * resolves:
+   *   - `true`  → the operator chose **Proceed** (discard the buffer / let the
+   *               close or navigation continue), and
+   *   - `false` → the operator **Cancelled** / dismissed (Esc / X) — keep the
+   *               panel open with the buffer intact.
+   *
+   * Reused by BOTH dirty-state hosts so the LAST PrimeNG `<p-confirmDialog>`
+   * usages for the namespace panel are removed:
+   *   - the Home config-dialog close paths (`onNamespacePanelVisibleChange` and
+   *     the Esc/X close), and
+   *   - the deep-link route `CanDeactivate` guard (`namespacePanelCanDeactivate`),
+   *     resolving the spec-compliance route-guard BLOCKING finding (the guard
+   *     previously depended on a `<p-confirmDialog>` the panel no longer mounts).
+   *
+   * A dismissal that bypasses the buttons (Esc / X / mask) settles `false` via
+   * `confirmDiscardResolve` in `onConfirmDialogHide` — the safe branch (keep the
+   * edits), mirroring the drift modal's safe-dismissal contract.
+   */
+  confirmDiscard(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (value: boolean): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.confirmDiscardResolve = null;
+        resolve(value);
+      };
+      // Esc / Cancel / X dismissal resolves the SAFE branch (false — keep edits).
+      this.confirmDiscardResolve = () => settle(false);
+      this.openConfirm(
+        {
+          header: 'Unsaved changes',
+          message: 'You have unsaved changes. Discard?',
+          variant: 'discard',
+        },
+        // Proceed → discard / allow the close-or-navigation.
+        () => settle(true),
+      );
+    });
+  }
+
+  /**
+   * The action-row label for the confirmation modal's affirmative button
+   * (ADR-018 Amendment §d). Every single-affirmative variant — reset, delete,
+   * and discard — uses **"Proceed"** (the dark-red `__danger` class is what
+   * marks the `delete` variant as destructive, NOT a distinct label). The drift
+   * variant renders its own two explicit Reload / Overwrite buttons, so this
+   * label is never shown for it. Returned as a getter so the template need not
+   * branch on the variant.
+   */
+  get confirmProceedLabel(): string {
+    return 'Proceed';
+  }
+
+  /**
+   * Proceed (reset/delete/discard) button handler (AC 3, 5). Runs the captured
+   * accept callback then closes. For `'delete'` this fires `onDeleteConfirm()`;
+   * for `'reset'` the revert effect; for `'discard'` it resolves the public
+   * `confirmDiscard()` promise `true` (the accept callback settles + clears the
+   * pending `confirmDiscardResolve`, so the resulting onHide is a no-op).
    */
   onConfirmProceedClick(): void {
     const accept = this.confirmAccept;
@@ -874,36 +973,50 @@ export class NamespacePanelComponent
   }
 
   /**
-   * Cancel (reset/delete) button handler (AC 10). The safe branch: closes
-   * without running any accept callback — no destructive/lossy effect occurs.
+   * Cancel (reset/delete/discard) button handler (AC 10). The safe branch:
+   * closes without running any accept callback — no destructive/lossy effect
+   * occurs. For the `'discard'` variant it settles the public `confirmDiscard()`
+   * promise to `false` (keep edits) directly, so the awaited promise resolves
+   * deterministically on a button click without depending on the PrimeNG
+   * `(onHide)` round-trip; the resolver is cleared so the subsequent onHide is a
+   * no-op.
    */
   onConfirmCancelClick(): void {
+    const discardResolve = this.confirmDiscardResolve;
+    this.confirmDiscardResolve = null;
     this.closeConfirm();
+    discardResolve?.();
   }
 
   /**
-   * `(onShow)` handler for the confirmation modal (AC 9). Mirrors
-   * `onCloneDialogShow`: defers the focus call by a microtask so PrimeNG has
-   * mounted the overlay, then focuses the safe button (Cancel for reset/delete,
-   * Reload for drift). Null-safe via the `@ViewChild` ref.
+   * `(onShow)` handler for the confirmation modal (ADR-018 Amendment §e).
+   * Mirrors `onCloneDialogShow`: defers the focus call by a microtask so PrimeNG
+   * has mounted the overlay, then focuses the PRIMARY/proceed button (Proceed
+   * for reset/delete/discard, Reload for drift) so **Enter activates the main
+   * action**. Esc still cancels. Null-safe via the `@ViewChild` ref.
    */
   onConfirmDialogShow(): void {
     setTimeout(() => {
-      this.confirmSafeBtnRef?.nativeElement.focus();
+      this.confirmPrimaryBtnRef?.nativeElement.focus();
     }, 0);
   }
 
   /**
-   * `(onHide)` handler for the confirmation modal (AC 8, 19). Resolves a
-   * still-pending drift dismissal to the SAFE branch (false — no blind
-   * overwrite), then resets the request + callbacks so nothing leaks into the
-   * next open. The drift resolver is invoked BEFORE `closeConfirm` so the
-   * awaited `onSaveClick` promise settles even on an Esc/X dismissal.
+   * `(onHide)` handler for the confirmation modal (AC 8, 19 + ADR-018
+   * Amendment §c). Resolves a still-pending dismissal to the SAFE branch — the
+   * drift dismissal to `false` (no blind overwrite) and the dirty-discard
+   * dismissal to `false` (keep the edits) — then resets the request + callbacks
+   * so nothing leaks into the next open. Both resolvers are invoked BEFORE
+   * `closeConfirm` so the awaited `onSaveClick` / `confirmDiscard()` promise
+   * settles even on an Esc/X dismissal.
    */
   onConfirmDialogHide(): void {
     const driftResolve = this.confirmDriftResolve;
+    const discardResolve = this.confirmDiscardResolve;
     this.confirmDriftResolve = null;
+    this.confirmDiscardResolve = null;
     driftResolve?.();
+    discardResolve?.();
     this.closeConfirm();
   }
 

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -19,9 +19,8 @@ import {
   NuMonacoEditorEvent,
   NuMonacoEditorModule,
 } from '@ng-util/monaco-editor';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -43,6 +42,22 @@ import {
   suggestDestNamespace,
 } from '../yaml-clone.helper';
 import { ValidationReportComponent } from './validation-report/validation-report.component';
+
+/**
+ * Typed shape for the panel's custom confirmation modal (ADR-018 §1). One
+ * interface, three call sites — NEVER an inline `Record`/object literal
+ * scattered across handlers (Golden Rule #1). `variant` selects the action-row
+ * button layout:
+ *   - `'reset'` / `'delete'` → `[Cancel] [Proceed]` (Proceed is destructive for
+ *     `'delete'` only — ADR-018 §4).
+ *   - `'drift'` → `[Reload] [Overwrite]` (two explicit named buttons, not a
+ *     binary accept/reject — ADR-018 §1).
+ */
+interface ConfirmRequest {
+  header: string;
+  message: string;
+  variant: 'reset' | 'drift' | 'delete';
+}
 
 /**
  * NamespacePanelComponent — host-agnostic editor for a catalog namespace YAML.
@@ -69,8 +84,10 @@ import { ValidationReportComponent } from './validation-report/validation-report
  *   - 401 → no panel-specific behaviour; the FetchService global toast
  *     surfaces the failure, the app-wide handler (if any) runs. Panel only
  *     clears `saving` in `finally`.
- *   - PrimeNG `ConfirmDialog` guards Reset-with-dirty-buffer and the Save
- *     drift reload-vs-overwrite choice.
+ *   - A panel-owned custom confirmation modal (ADR-018 §1) — same `<p-dialog>`
+ *     shell as the Clone modal — guards Reset-with-dirty-buffer, the Save drift
+ *     reload-vs-overwrite choice, and Delete. The safe button holds focus on
+ *     open so Enter/Esc cancel (ADR-018 §2).
  *
  * The component remains presentation-only: no `Router`, `ActivatedRoute`,
  * `MAT_DIALOG_DATA`, etc. The dialog wrapper (HomeComponent) and the
@@ -92,7 +109,6 @@ import { ValidationReportComponent } from './validation-report/validation-report
     CommonModule,
     FormsModule,
     ButtonModule,
-    ConfirmDialogModule,
     DialogModule,
     InputTextModule,
     NuMonacoEditorModule,
@@ -100,10 +116,6 @@ import { ValidationReportComponent } from './validation-report/validation-report
     TooltipModule,
     ValidationReportComponent,
   ],
-  // ConfirmationService is provided locally per PrimeNG v19 pattern — scopes
-  // the confirm dialog to this component (dialog + future route both get
-  // their own scoped instance).
-  providers: [ConfirmationService],
   templateUrl: './namespace-panel.component.html',
   styleUrls: ['./namespace-panel.component.scss'],
 })
@@ -133,7 +145,6 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
 
   private apiService: ApiService = inject(ApiService);
   private messageService: MessageService = inject(MessageService);
-  private confirmationService: ConfirmationService = inject(ConfirmationService);
   private authService: AuthService = inject(AuthService);
   private destroyRef: DestroyRef = inject(DestroyRef);
 
@@ -245,6 +256,58 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    * `destroyed` idiom.
    */
   deleting: boolean = false;
+
+  // -------------------------------------------------------------------
+  // Story 22.3 — Custom confirmation modal (ADR-018 §1–§4). Replaces the
+  // generic `<p-confirmDialog>` / `ConfirmationService` for the three confirm
+  // flows. Driven from component state (a visibility flag + a typed
+  // `ConfirmRequest`) rather than an imperative service call.
+  // -------------------------------------------------------------------
+
+  /** Controls visibility of the custom confirmation modal (AC 1, 2). */
+  confirmDialogVisible: boolean = false;
+
+  /**
+   * The active confirm request describing the modal's header/message/variant
+   * (AC 2). `null` when no confirm is open; nulled on close so a stale request
+   * cannot leak into the next open (AC 19).
+   */
+  confirmRequest: ConfirmRequest | null = null;
+
+  /**
+   * Per-flow accept callback captured when the confirm opens (AC 3). The
+   * Proceed (reset/delete) and Overwrite (drift) buttons invoke this; a private
+   * closure so each flow runs the same effect its old `confirm({ accept })`
+   * callback ran. `null` while no confirm is open.
+   */
+  private confirmAccept: (() => void) | null = null;
+
+  /**
+   * The drift variant's "Reload" (safe / focused-default) callback (AC 7). Only
+   * set for the `'drift'` variant; Reset/Delete leave it `null` (their safe
+   * branch is a bare cancel). Invoked by the Reload button.
+   */
+  private confirmReload: (() => void) | null = null;
+
+  /**
+   * Pending "resolve the drift `Promise<boolean>` to the SAFE branch (false)"
+   * thunk for an Esc / Cancel / X dismissal of the drift modal (AC 8). Set by
+   * `checkSaveDrift` while the drift modal is open; invoked by
+   * `onConfirmDialogHide` so a dismissal that bypasses a button still settles
+   * the awaited promise (and does so as the non-overwrite branch). `null` for
+   * the reset/delete variants (their dismissal is a bare cancel with no
+   * pending promise).
+   */
+  private confirmDriftResolve: (() => void) | null = null;
+
+  /**
+   * Safe-button reference for the confirmation modal — the Cancel button for
+   * the reset/delete variants, the Reload button for the drift variant. Used by
+   * `onConfirmDialogShow()` to autofocus it on open so Enter cancels (AC 9, 10),
+   * mirroring the Clone modal's `cloneDestInputRef` focus plumbing.
+   */
+  @ViewChild('confirmSafeBtn', { read: ElementRef })
+  confirmSafeBtnRef?: ElementRef<HTMLButtonElement>;
 
   // -------------------------------------------------------------------
   // Story 11.7 — UX-polish state (FR14 gate, FR16 a11y, FR17 Clone modal,
@@ -664,9 +727,138 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    */
   private monacoActionsRegistered = false;
 
+  // -------------------------------------------------------------------
+  // Story 22.3 — Custom confirmation modal (ADR-018 §1–§4). One shared
+  // open/close surface reused by Reset-discard, Save-drift, and Delete; the
+  // safe button autofocuses on show so Enter/Esc cancel.
+  // -------------------------------------------------------------------
+
+  /**
+   * Open the custom confirmation modal (AC 2, 3). Captures the typed request +
+   * the per-flow callbacks the template buttons invoke, then flips the
+   * visibility flag. For the `'drift'` variant `onReload` is the safe/focused
+   * Reload branch and `onAccept` is the Overwrite branch; for `'reset'` /
+   * `'delete'` only `onAccept` (Proceed) is supplied and `onReload` is omitted.
+   */
+  private openConfirm(
+    request: ConfirmRequest,
+    onAccept: () => void,
+    onReload?: () => void,
+  ): void {
+    this.confirmRequest = request;
+    this.confirmAccept = onAccept;
+    this.confirmReload = onReload ?? null;
+    this.confirmDialogVisible = true;
+  }
+
+  /**
+   * Close the confirmation modal and null the request + callbacks so a stale
+   * request cannot leak into the next open (AC 19). Idempotent. The pending
+   * drift resolver (`confirmDriftResolve`) is intentionally NOT cleared here —
+   * `onConfirmDialogHide` owns resolving it to the safe branch before this runs.
+   */
+  private closeConfirm(): void {
+    this.confirmDialogVisible = false;
+    this.confirmRequest = null;
+    this.confirmAccept = null;
+    this.confirmReload = null;
+  }
+
+  /**
+   * Public predicate (AC 12) — true iff ANY secondary panel (the Clone modal
+   * OR the confirmation modal) is open. The host (`HomeComponent` config dialog,
+   * and any route-shell that binds `closeOnEscape`) reads this synchronously to
+   * suppress its own `closeOnEscape` while a secondary panel is open, so Esc
+   * closes only the topmost secondary panel (ADR-018 §3).
+   */
+  get hasSecondaryPanelOpen(): boolean {
+    return this.cloneDialogVisible || this.confirmDialogVisible;
+  }
+
+  /**
+   * The action-row label for the confirmation modal's affirmative button. The
+   * drift variant uses "Overwrite" (its Reload button is rendered separately);
+   * reset/delete use "Proceed". Returned as a getter so the template need not
+   * branch on the variant in three places.
+   */
+  get confirmProceedLabel(): string {
+    return this.confirmRequest?.variant === 'delete' ? 'Delete' : 'Proceed';
+  }
+
+  /**
+   * Proceed (reset/delete) button handler (AC 3, 5). Runs the captured accept
+   * callback then closes. For `'delete'` this fires `onDeleteConfirm()`; for
+   * `'reset'` the revert effect.
+   */
+  onConfirmProceedClick(): void {
+    const accept = this.confirmAccept;
+    this.closeConfirm();
+    accept?.();
+  }
+
+  /**
+   * Overwrite (drift) button handler (AC 7). The destructive drift branch:
+   * resolves the drift promise `true` (proceed to import the operator buffer)
+   * via the captured accept callback, then closes.
+   */
+  onConfirmOverwriteClick(): void {
+    const accept = this.confirmAccept;
+    // The drift promise is settled by `accept`; clear the dismissal resolver
+    // first so the resulting onHide does not re-settle it (AC 8).
+    this.confirmDriftResolve = null;
+    this.closeConfirm();
+    accept?.();
+  }
+
+  /**
+   * Reload (drift) button handler — the safe / focused default (AC 7, 9). Runs
+   * the rebase effect and resolves the drift promise `false` (skip the import)
+   * via the captured reload callback, then closes.
+   */
+  onConfirmReloadClick(): void {
+    const reload = this.confirmReload;
+    this.confirmDriftResolve = null;
+    this.closeConfirm();
+    reload?.();
+  }
+
+  /**
+   * Cancel (reset/delete) button handler (AC 10). The safe branch: closes
+   * without running any accept callback — no destructive/lossy effect occurs.
+   */
+  onConfirmCancelClick(): void {
+    this.closeConfirm();
+  }
+
+  /**
+   * `(onShow)` handler for the confirmation modal (AC 9). Mirrors
+   * `onCloneDialogShow`: defers the focus call by a microtask so PrimeNG has
+   * mounted the overlay, then focuses the safe button (Cancel for reset/delete,
+   * Reload for drift). Null-safe via the `@ViewChild` ref.
+   */
+  onConfirmDialogShow(): void {
+    setTimeout(() => {
+      this.confirmSafeBtnRef?.nativeElement.focus();
+    }, 0);
+  }
+
+  /**
+   * `(onHide)` handler for the confirmation modal (AC 8, 19). Resolves a
+   * still-pending drift dismissal to the SAFE branch (false — no blind
+   * overwrite), then resets the request + callbacks so nothing leaks into the
+   * next open. The drift resolver is invoked BEFORE `closeConfirm` so the
+   * awaited `onSaveClick` promise settles even on an Esc/X dismissal.
+   */
+  onConfirmDialogHide(): void {
+    const driftResolve = this.confirmDriftResolve;
+    this.confirmDriftResolve = null;
+    driftResolve?.();
+    this.closeConfirm();
+  }
+
   /**
    * Revert the buffer to `serverYaml` — the SOLE undo affordance now that
-   * Cancel is removed (ADR-017 §2). Guarded by the existing "Discard unsaved
+   * Cancel is removed (ADR-017 §2). Guarded by the custom "Discard unsaved
    * changes?" confirm; a no-op when clean (the Reset button is also disabled
    * via `[disabled]="buffer === serverYaml"`).
    */
@@ -674,11 +866,13 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
     if (this.buffer === this.serverYaml) {
       return;
     }
-    this.confirmationService.confirm({
-      header: 'Unsaved changes',
-      icon: 'pi pi-exclamation-triangle',
-      message: 'Discard unsaved changes?',
-      accept: () => {
+    this.openConfirm(
+      {
+        header: 'Unsaved changes',
+        message: 'Discard unsaved changes?',
+        variant: 'reset',
+      },
+      () => {
         if (this.destroyed) {
           return;
         }
@@ -687,7 +881,7 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
         this.rawSaveError = null;
         this.validatedBuffer = null;
       },
-    });
+    );
   }
 
   /**
@@ -807,12 +1001,15 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
    *               server YAML so the operator can re-Save against the fresh
    *               base).
    *
-   * PrimeNG's `confirmationService.confirm` is binary, so the affordance is
-   * mapped: `accept` = reload-and-rebase (resolve false), `reject` =
-   * overwrite (resolve true). A network error during the re-export falls
+   * ADR-018 §1 — the choice is rendered as **two explicit named buttons** in
+   * the custom confirmation modal (Reload + Overwrite), not a binary
+   * accept/reject. Reload (the safe, focused default) resolves `false`;
+   * Overwrite resolves `true`. Dismissing the modal (Esc / Cancel / X) resolves
+   * `false` — the safe branch — so an accidental dismissal never lands a blind
+   * overwrite (ADR-018 §2 / AC 8). A network error during the re-export falls
    * through to `true` (proceed) — the server still validates on import, so a
-   * genuinely-stale edit can only land a known-bad bundle, and operators
-   * should not be blocked by a hiccup.
+   * genuinely-stale edit can only land a known-bad bundle, and operators should
+   * not be blocked by a hiccup.
    */
   private async checkSaveDrift(savedBuffer: string): Promise<boolean> {
     let latestYaml: string;
@@ -831,16 +1028,35 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
       return true;
     }
     return new Promise<boolean>((resolve) => {
-      this.confirmationService.confirm({
-        header: 'Namespace modified',
-        icon: 'pi pi-exclamation-triangle',
-        message:
-          'The namespace was modified on the server since it was loaded. ' +
-          'Reload the latest version (discarding this Save), or overwrite it ' +
-          'with your changes?',
-        acceptLabel: 'Reload',
-        rejectLabel: 'Overwrite',
-        accept: () => {
+      // Guard against double-resolution: a button click resolves and closes;
+      // the resulting onHide must NOT resolve a second time. `settle` clears
+      // the pending resolver so `onConfirmDialogHide` becomes a no-op once a
+      // button has chosen.
+      let settled = false;
+      const settle = (value: boolean): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.confirmDriftResolve = null;
+        resolve(value);
+      };
+      // Esc / Cancel / X dismissal resolves the SAFE branch (false). Registered
+      // so `onConfirmDialogHide` can settle a dismissal that bypasses a button.
+      this.confirmDriftResolve = () => settle(false);
+      this.openConfirm(
+        {
+          header: 'Namespace modified',
+          message:
+            'The namespace was modified on the server since it was loaded. ' +
+            'Reload the latest version (discarding this Save), or overwrite it ' +
+            'with your changes?',
+          variant: 'drift',
+        },
+        // Overwrite (the destructive branch) → proceed with the operator buffer.
+        () => settle(true),
+        // Reload (the safe, focused default) → rebase + skip this import.
+        () => {
           if (!this.destroyed) {
             // Rebase onto the fresh server YAML; only move the buffer if it
             // was still pinned to the old snapshot (no local edits to lose).
@@ -849,10 +1065,9 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
             }
             this.serverYaml = latestYaml;
           }
-          resolve(false);
+          settle(false);
         },
-        reject: () => resolve(true),
-      });
+      );
     });
   }
 
@@ -1397,24 +1612,24 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   /**
    * Delete handler (AC 3). Always available (only gated by an in-flight
    * `deleting`). No-op while a delete is in flight (defence in depth alongside
-   * `[disabled]="deleting"`). Opens the PrimeNG confirm naming the current
-   * namespace; `accept` runs `onDeleteConfirm()`. No `reject` — cancelling is
-   * a no-op (panel unchanged, no network call).
+   * `[disabled]="deleting"`). Opens the custom confirmation modal naming the
+   * current namespace; the Proceed (destructive) button runs `onDeleteConfirm()`.
+   * Cancelling is a no-op (panel unchanged, no network call — AC 5).
    */
   onDeleteClick(): void {
     if (this.deleting) {
       return;
     }
-    this.confirmationService.confirm({
-      header: 'Delete namespace',
-      icon: 'pi pi-trash',
-      message: `Delete namespace "${this.namespace}" and all its entries? This cannot be undone.`,
-      accept: () => {
+    this.openConfirm(
+      {
+        header: 'Delete namespace',
+        message: `Delete namespace "${this.namespace}" and all its entries? This cannot be undone.`,
+        variant: 'delete',
+      },
+      () => {
         void this.onDeleteConfirm();
       },
-      // `reject` intentionally omitted — cancelling leaves the panel exactly
-      // as it was and fires no network request (AC 3).
-    });
+    );
   }
 
   /**

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -4,6 +4,7 @@ import {
   DestroyRef,
   ElementRef,
   EventEmitter,
+  HostListener,
   Input,
   OnChanges,
   OnInit,
@@ -14,7 +15,10 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { NuMonacoEditorModule } from '@ng-util/monaco-editor';
+import {
+  NuMonacoEditorEvent,
+  NuMonacoEditorModule,
+} from '@ng-util/monaco-editor';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -433,6 +437,232 @@ export class NamespacePanelComponent implements OnInit, OnChanges {
   hasUnsavedChanges(): boolean {
     return this.buffer !== this.serverYaml;
   }
+
+  // -------------------------------------------------------------------
+  // Story 22.2 (ADR-017 §7) — keyboard shortcuts.
+  //
+  // The five action shortcuts are captured in TWO places — a Monaco
+  // `editor.addAction` (in-editor focus; Monaco swallows keystrokes) and a
+  // component `@HostListener('keydown')` (focus outside the editor, e.g. on a
+  // button). Both paths funnel through ONE shared dispatch surface: the
+  // `can*` enablement getters below (which mirror the button `[disabled]`
+  // expressions) and the `triggerX()` entry points. The button template binds
+  // the SAME `can*` getters so the enablement predicate cannot drift between
+  // the click path and the shortcut path (AC 6, AC 12).
+  // -------------------------------------------------------------------
+
+  /**
+   * Save enablement — mirrors the Save button's `[disabled]` expression
+   * (`buffer === serverYaml || saving || isSaveGated`). `buffer !== serverYaml`
+   * is exactly `hasUnsavedChanges()`, used here so intent is explicit. ⌥S
+   * fires Save iff this is true (AC 1, AC 6).
+   */
+  get canSave(): boolean {
+    return this.hasUnsavedChanges() && !this.saving && !this.isSaveGated;
+  }
+
+  /**
+   * Validate enablement — mirrors the Validate button's `[disabled]`
+   * (`saving || validating`). NEVER gated by FR14 (ADR-017 §5); ⌥V fires in
+   * both clean and dirty states (AC 2, AC 6).
+   */
+  get canValidate(): boolean {
+    return !this.validating && !this.saving;
+  }
+
+  /**
+   * Reset enablement — mirrors the Reset button's `[disabled]`
+   * (`buffer === serverYaml || saving`). ⌥R is a no-op while clean; when dirty
+   * it routes through the existing discard confirm (AC 3, AC 6).
+   */
+  get canReset(): boolean {
+    return this.hasUnsavedChanges() && !this.saving;
+  }
+
+  /**
+   * Clone enablement — mirrors the Clone button's `[disabled]`
+   * (`buffer !== serverYaml || cloning || isCloneGated`). ⌥⇧C is a no-op while
+   * dirty; it opens the Clone modal only when clean (AC 4, AC 6).
+   */
+  get canClone(): boolean {
+    return !this.hasUnsavedChanges() && !this.cloning && !this.isCloneGated;
+  }
+
+  /**
+   * Delete enablement — mirrors the Delete button's `[disabled]`
+   * (`deleting`). ⌥D still routes through the Delete confirm dialog (AC 5,
+   * AC 6).
+   */
+  get canDelete(): boolean {
+    return !this.deleting;
+  }
+
+  /**
+   * Shared Save trigger (AC 1, AC 12). Consults `canSave` then delegates to
+   * the existing handler body — never duplicates it. A true no-op when Save
+   * is disabled (the keystroke is still `preventDefault`ed upstream — AC 9).
+   */
+  private triggerSave(): void {
+    if (this.canSave) {
+      void this.onSaveClick();
+    }
+  }
+
+  /** Shared Validate trigger (AC 2, AC 12). */
+  private triggerValidate(): void {
+    if (this.canValidate) {
+      void this.onValidateBufferClick();
+    }
+  }
+
+  /** Shared Reset trigger (AC 3, AC 12). */
+  private triggerReset(): void {
+    if (this.canReset) {
+      this.onResetClick();
+    }
+  }
+
+  /** Shared Clone trigger (AC 4, AC 12). */
+  private triggerClone(): void {
+    if (this.canClone) {
+      this.onCloneClick();
+    }
+  }
+
+  /** Shared Delete trigger (AC 5, AC 12) — routes through the Delete confirm. */
+  private triggerDelete(): void {
+    if (this.canDelete) {
+      this.onDeleteClick();
+    }
+  }
+
+  /**
+   * Single keyboard matcher consumed by BOTH capture sites (AC 7–9, 12).
+   *
+   * - Returns immediately (unhandled, NO `preventDefault`) when `!altKey`.
+   * - Keys off `event.code` (NOT `event.key`) so macOS Option dead-keys
+   *   (⌥S → `ß`, ⌥V → `√`, …) still match (AC 7).
+   * - `KeyC` → Clone ONLY when `event.shiftKey` (Alt+KeyC without Shift is
+   *   unhandled — AC 8). The S/V/R/D branches are keyed by their own codes, so
+   *   Alt+Shift+KeyC fires ONLY Clone (no double-fire — AC 8).
+   * - On a recognised combo, `preventDefault()` is called ALWAYS — even when
+   *   the matching `triggerX()` is a no-op by enablement (AC 9) — so the
+   *   dead-key glyph / Alt-mnemonic is suppressed for keystrokes that are
+   *   "ours".
+   */
+  private matchShortcut(event: KeyboardEvent): void {
+    if (!event.altKey) {
+      return; // not ours — let it propagate, no preventDefault.
+    }
+    switch (event.code) {
+      case 'KeyS':
+        event.preventDefault();
+        this.triggerSave();
+        return;
+      case 'KeyV':
+        event.preventDefault();
+        this.triggerValidate();
+        return;
+      case 'KeyR':
+        event.preventDefault();
+        this.triggerReset();
+        return;
+      case 'KeyD':
+        event.preventDefault();
+        this.triggerDelete();
+        return;
+      case 'KeyC':
+        if (event.shiftKey) {
+          event.preventDefault();
+          this.triggerClone();
+        }
+        // Alt+KeyC without Shift is unhandled — no preventDefault (AC 8).
+        return;
+      default:
+        // Alt + a non-bound code — unhandled, propagates (AC 9).
+        return;
+    }
+  }
+
+  /**
+   * Component-level keydown capture (AC 11). Mirrors the established
+   * `chat-panel.component.ts` `@HostListener` pattern. Binding on the host
+   * (`'keydown'`, not `'document:keydown'`) scopes capture to the panel
+   * subtree — the shortcuts fire only when the panel (or its editor) has
+   * focus. Catches the combos when focus sits OUTSIDE Monaco (e.g. on a
+   * button); the Monaco `addAction` path covers in-editor focus.
+   */
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    this.matchShortcut(event);
+  }
+
+  /**
+   * `(event)` handler for `<nu-monaco-editor>` (AC 10). On the `'init'` event
+   * the editor instance is available; register the five chord actions via
+   * `editor.addAction(...)`, each `run` delegating to the SAME `triggerX()`
+   * entry point as the HostListener path (AC 12). Guarded against
+   * re-registration on a `'re-init'` event via `monacoActionsRegistered`.
+   */
+  onEditorEvent(e: NuMonacoEditorEvent): void {
+    if (e.type !== 'init' || !e.editor) {
+      return;
+    }
+    if (this.monacoActionsRegistered) {
+      return;
+    }
+    const editor = e.editor as monaco.editor.IStandaloneCodeEditor;
+    this.registerEditorShortcuts(editor);
+    this.monacoActionsRegistered = true;
+  }
+
+  /**
+   * Registers the five ⌥-key chord actions on the Monaco editor. Each `run`
+   * delegates to the shared `triggerX()` dispatch surface so enablement parity
+   * (AC 6) holds identically for the Monaco and HostListener capture sites.
+   * The chord constants come from the ambient `monaco` namespace
+   * (`monaco.KeyMod` / `monaco.KeyCode`) — no `monaco-editor` import.
+   */
+  private registerEditorShortcuts(
+    editor: monaco.editor.IStandaloneCodeEditor,
+  ): void {
+    editor.addAction({
+      id: 'namespace-panel.save',
+      label: 'Save namespace',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyS],
+      run: () => this.triggerSave(),
+    });
+    editor.addAction({
+      id: 'namespace-panel.validate',
+      label: 'Validate namespace',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyV],
+      run: () => this.triggerValidate(),
+    });
+    editor.addAction({
+      id: 'namespace-panel.reset',
+      label: 'Reset namespace buffer',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyR],
+      run: () => this.triggerReset(),
+    });
+    editor.addAction({
+      id: 'namespace-panel.clone',
+      label: 'Clone namespace',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyC],
+      run: () => this.triggerClone(),
+    });
+    editor.addAction({
+      id: 'namespace-panel.delete',
+      label: 'Delete namespace',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyD],
+      run: () => this.triggerDelete(),
+    });
+  }
+
+  /**
+   * Guards `onEditorEvent` against double-registering the Monaco actions if a
+   * `'re-init'` event follows the initial `'init'`.
+   */
+  private monacoActionsRegistered = false;
 
   /**
    * Revert the buffer to `serverYaml` — the SOLE undo affordance now that

--- a/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.component.ts
@@ -878,15 +878,21 @@ export class NamespacePanelComponent
    * custom confirmation modal with the `'discard'` variant ("Unsaved changes" /
    * "You have unsaved changes. Discard?") and returns a `Promise<boolean>` that
    * resolves:
-   *   - `true`  → the operator chose **Proceed** (discard the buffer / let the
-   *               close or navigation continue), and
-   *   - `false` → the operator **Cancelled** / dismissed (Esc / X) — keep the
-   *               panel open with the buffer intact.
+   *   - `true`  → the operator chose **Proceed**. The panel buffer is REALLY
+   *               discarded here (`revertBufferToServer()` — buffer reset to the
+   *               server snapshot, dirty-derived state cleared) BEFORE the
+   *               promise resolves, then the host closes the panel. Because the
+   *               panel instance is kept alive across a dialog visibility toggle
+   *               (not destroyed), resetting on this path is what stops the
+   *               abandoned edits from leaking into the next open — reopening
+   *               shows the clean server YAML.
+   *   - `false` → the operator **Cancelled** / dismissed (Esc / X / mask) — the
+   *               buffer is left UNTOUCHED (still dirty) and the panel stays open.
    *
    * Reused by BOTH dirty-state hosts so the LAST PrimeNG `<p-confirmDialog>`
    * usages for the namespace panel are removed:
    *   - the Home config-dialog close paths (`onNamespacePanelVisibleChange` and
-   *     the Esc/X close), and
+   *     the Esc/X/mask close), and
    *   - the deep-link route `CanDeactivate` guard (`namespacePanelCanDeactivate`),
    *     resolving the spec-compliance route-guard BLOCKING finding (the guard
    *     previously depended on a `<p-confirmDialog>` the panel no longer mounts).
@@ -914,8 +920,14 @@ export class NamespacePanelComponent
           message: 'You have unsaved changes. Discard?',
           variant: 'discard',
         },
-        // Proceed → discard / allow the close-or-navigation.
-        () => settle(true),
+        // Proceed → REALLY discard (revert the buffer to the server snapshot,
+        // clear dirty-derived state) then allow the close-or-navigation. The
+        // reset happens on BOTH the Esc and the X/mask close paths because they
+        // all route Proceed through this same accept callback.
+        () => {
+          this.revertBufferToServer();
+          settle(true);
+        },
       );
     });
   }
@@ -1021,10 +1033,30 @@ export class NamespacePanelComponent
   }
 
   /**
+   * Revert the edit buffer to the last server snapshot and clear every
+   * dirty-derived signal (`lastValidation` / `rawSaveError` / `validatedBuffer`)
+   * so the panel lands fully clean. Shared by the Reset button (`onResetClick`)
+   * and the dirty-CLOSE discard (`confirmDiscard` Proceed — ADR-018 Amendment
+   * §c). Load-bearing for the close path: the panel instance is kept alive
+   * across a dialog visibility toggle (not destroyed), so without this reset the
+   * abandoned edits would leak into the next open. Destroy-guarded.
+   */
+  private revertBufferToServer(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.buffer = this.serverYaml;
+    this.lastValidation = null;
+    this.rawSaveError = null;
+    this.validatedBuffer = null;
+  }
+
+  /**
    * Revert the buffer to `serverYaml` — the SOLE undo affordance now that
    * Cancel is removed (ADR-017 §2). Guarded by the custom "Discard unsaved
    * changes?" confirm; a no-op when clean (the Reset button is also disabled
-   * via `[disabled]="buffer === serverYaml"`).
+   * via `[disabled]="buffer === serverYaml"`). Reverts-and-STAYS (does not close
+   * the panel) — distinct from the dirty-CLOSE discard which reverts-and-closes.
    */
   onResetClick(): void {
     if (this.buffer === this.serverYaml) {
@@ -1036,15 +1068,7 @@ export class NamespacePanelComponent
         message: 'Discard unsaved changes?',
         variant: 'reset',
       },
-      () => {
-        if (this.destroyed) {
-          return;
-        }
-        this.buffer = this.serverYaml;
-        this.lastValidation = null;
-        this.rawSaveError = null;
-        this.validatedBuffer = null;
-      },
+      () => this.revertBufferToServer(),
     );
   }
 

--- a/src/app/components/catalog/namespace-panel/namespace-panel.guard.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.guard.spec.ts
@@ -1,32 +1,20 @@
 import { TestBed } from '@angular/core/testing';
-import { ConfirmationService } from 'primeng/api';
 
 import { NamespacePanelComponent } from './namespace-panel.component';
 import { NamespacePanelRouteComponent } from './namespace-panel-route.component';
 import { namespacePanelCanDeactivate } from './namespace-panel.guard';
 
 /**
- * Story 11.6 — functional `CanDeactivate` guard tests.
+ * Story 11.6 + ADR-018 Amendment §c — functional `CanDeactivate` guard tests.
  *
- * The guard runs inside a router-owned injection context at navigation time.
- * In tests we invoke it via `TestBed.runInInjectionContext(() => ...)` so
- * `inject(ConfirmationService)` resolves correctly against the test module's
- * providers.
+ * The guard delegates its dirty-navigation prompt to the panel's custom confirm
+ * modal via `panel.confirmDiscard()` (no more PrimeNG `ConfirmationService` /
+ * `<p-confirmDialog>`). Tests stub `panel.confirmDiscard()` to resolve true
+ * (Proceed) / false (Cancel/dismiss) and assert the guard relays that verbatim.
  */
-describe('namespacePanelCanDeactivate (Story 11.6 CanDeactivate guard)', () => {
-  let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
-
+describe('namespacePanelCanDeactivate (CanDeactivate guard)', () => {
   beforeEach(() => {
-    // Real service instance + spy on `.confirm` — matches the panel's unit
-    // tests (a bare `createSpyObj` breaks PrimeNG's internal
-    // `requireConfirmation$` subject).
-    confirmationSpy =
-      new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
-    spyOn(confirmationSpy, 'confirm').and.callThrough();
-
-    TestBed.configureTestingModule({
-      providers: [{ provide: ConfirmationService, useValue: confirmationSpy }],
-    });
+    TestBed.configureTestingModule({ providers: [] });
   });
 
   // Helper — invoke the functional guard in an injection context.
@@ -52,46 +40,47 @@ describe('namespacePanelCanDeactivate (Story 11.6 CanDeactivate guard)', () => {
     expect(typeof namespacePanelCanDeactivate).toBe('function');
   });
 
-  it('(AC4, AC8) clean buffer → returns true synchronously, no prompt', () => {
+  it('(AC4, AC8) clean buffer → returns true synchronously, no confirmDiscard call', () => {
+    const confirmDiscard = jasmine.createSpy('confirmDiscard');
     const panel = {
-      hasUnsavedChanges: jasmine.createSpy('hasUnsavedChanges').and.returnValue(false),
+      hasUnsavedChanges: jasmine
+        .createSpy('hasUnsavedChanges')
+        .and.returnValue(false),
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
     const component = { panel } as NamespacePanelRouteComponent;
 
     const result = invokeGuard(component);
 
     expect(result).toBe(true);
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmDiscard).not.toHaveBeenCalled();
   });
 
-  it('(AC4) dirty buffer + confirm-accept → resolves true with exact message', async () => {
+  it('(ADR-018 §c) dirty buffer + Proceed → delegates to confirmDiscard, resolves true', async () => {
+    const confirmDiscard = jasmine
+      .createSpy('confirmDiscard')
+      .and.returnValue(Promise.resolve(true));
     const panel = {
       hasUnsavedChanges: () => true,
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
     const component = { panel } as NamespacePanelRouteComponent;
-    // Auto-accept the first confirm call.
-    confirmationSpy.confirm.and.callFake((cfg) => {
-      cfg.accept!();
-      return confirmationSpy;
-    });
 
     const result = invokeGuard(component);
 
-    expect(result).toEqual(jasmine.any(Promise));
+    expect(confirmDiscard).toHaveBeenCalledTimes(1);
     await expectAsync(result as Promise<boolean>).toBeResolvedTo(true);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.message).toBe('You have unsaved changes. Discard?');
   });
 
-  it('(AC4) dirty buffer + confirm-reject → resolves false', async () => {
+  it('(ADR-018 §c) dirty buffer + Cancel/dismiss → confirmDiscard resolves false', async () => {
+    const confirmDiscard = jasmine
+      .createSpy('confirmDiscard')
+      .and.returnValue(Promise.resolve(false));
     const panel = {
       hasUnsavedChanges: () => true,
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
     const component = { panel } as NamespacePanelRouteComponent;
-    confirmationSpy.confirm.and.callFake((cfg) => {
-      cfg.reject!();
-      return confirmationSpy;
-    });
 
     const result = invokeGuard(component);
 
@@ -104,6 +93,5 @@ describe('namespacePanelCanDeactivate (Story 11.6 CanDeactivate guard)', () => {
     const result = invokeGuard(component);
 
     expect(result).toBe(true);
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
   });
 });

--- a/src/app/components/catalog/namespace-panel/namespace-panel.guard.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.guard.spec.ts
@@ -5,12 +5,12 @@ import { NamespacePanelRouteComponent } from './namespace-panel-route.component'
 import { namespacePanelCanDeactivate } from './namespace-panel.guard';
 
 /**
- * Story 11.6 + ADR-018 Amendment §c — functional `CanDeactivate` guard tests.
+ * Functional `CanDeactivate` guard tests.
  *
  * The guard delegates its dirty-navigation prompt to the panel's custom confirm
- * modal via `panel.confirmDiscard()` (no more PrimeNG `ConfirmationService` /
- * `<p-confirmDialog>`). Tests stub `panel.confirmDiscard()` to resolve true
- * (Proceed) / false (Cancel/dismiss) and assert the guard relays that verbatim.
+ * modal via `panel.confirmDiscard()`. Tests stub `panel.confirmDiscard()` to
+ * resolve true (Proceed) / false (Cancel/dismiss) and assert the guard relays
+ * that verbatim.
  */
 describe('namespacePanelCanDeactivate (CanDeactivate guard)', () => {
   beforeEach(() => {

--- a/src/app/components/catalog/namespace-panel/namespace-panel.guard.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.guard.ts
@@ -1,6 +1,4 @@
-import { inject } from '@angular/core';
 import { CanDeactivateFn } from '@angular/router';
-import { ConfirmationService } from 'primeng/api';
 
 import { NamespacePanelRouteComponent } from './namespace-panel-route.component';
 
@@ -21,27 +19,34 @@ import { NamespacePanelRouteComponent } from './namespace-panel-route.component'
  *   `true` synchronously. No buffer state to lose.
  * - `component.panel.hasUnsavedChanges()` false → return `true`
  *   synchronously. No prompt shown.
- * - `component.panel.hasUnsavedChanges()` true → return a
- *   `Promise<boolean>` that resolves via the PrimeNG `ConfirmationService`:
- *     * confirm (accept)  → resolve(true), navigation proceeds.
- *     * reject / dismiss  → resolve(false), navigation is aborted and the
- *       panel's edit buffer is preserved.
+ * - `component.panel.hasUnsavedChanges()` true → delegate to the panel's
+ *   custom confirmation modal via `panel.confirmDiscard()`, which returns a
+ *   `Promise<boolean>`:
+ *     * Proceed → resolve(true), navigation proceeds.
+ *     * Cancel / dismiss (Esc / X) → resolve(false), navigation is aborted and
+ *       the panel's edit buffer is preserved.
  *
- * Prompt wording is the EXACT string `"You have unsaved changes. Discard?"` —
- * identical to the dialog presentation's close confirm (see
- * `home.component.ts` `onNamespacePanelVisibleChange`). UX consistency across
- * the two presentations is a hard requirement of Epic 11.
+ * ADR-018 Amendment §c — the guard reuses the SAME panel-owned custom modal as
+ * the Home config-dialog close confirm (`confirmDiscard()`), removing the last
+ * PrimeNG `<p-confirmDialog>` / `ConfirmationService` dependency from the
+ * namespace-panel dirty-state path. This resolves the spec-compliance BLOCKING
+ * finding: the guard previously called `inject(ConfirmationService).confirm(...)`
+ * whose accept/reject callbacks only fired when a `<p-confirmDialog>` element was
+ * mounted — but the panel dropped that element, so the Promise never resolved
+ * (Router navigation hung) and the service was no longer resolvable in the
+ * router injection context (`NullInjectorError`).
+ *
+ * Prompt wording is the EXACT string `"You have unsaved changes. Discard?"`
+ * (defined once in `panel.confirmDiscard()`) — identical to the dialog
+ * presentation's close confirm. UX consistency across the two presentations is
+ * a hard requirement of Epic 11.
  *
  * Implementation notes:
  * - Functional guard (not class-based). Matches Angular v16+ idiom and the
  *   rest of this repo's route configuration.
- * - `inject(ConfirmationService)` MUST be called inside the guard body —
- *   functional guards run in a router-owned injection context at navigation
- *   time. Capturing the service via a module-level `inject()` would fail at
- *   module load outside any injection context.
- * - The `ConfirmationService` instance is resolved from the panel's scoped
- *   `providers: [ConfirmationService]` via ancestor-chain DI lookup (the same
- *   `<p-confirmDialog>` the panel already mounts renders the prompt).
+ * - No `inject()` needed: the confirm surface lives on the panel instance the
+ *   route shell exposes via `@ViewChild`, so the guard reads it directly off
+ *   `component.panel`.
  */
 export const namespacePanelCanDeactivate: CanDeactivateFn<
   NamespacePanelRouteComponent
@@ -50,14 +55,5 @@ export const namespacePanelCanDeactivate: CanDeactivateFn<
   if (!panel || !panel.hasUnsavedChanges()) {
     return true;
   }
-  const confirmation = inject(ConfirmationService);
-  return new Promise<boolean>((resolve) => {
-    confirmation.confirm({
-      header: 'Unsaved changes',
-      icon: 'pi pi-exclamation-triangle',
-      message: 'You have unsaved changes. Discard?',
-      accept: () => resolve(true),
-      reject: () => resolve(false),
-    });
-  });
+  return panel.confirmDiscard();
 };

--- a/src/app/components/catalog/namespace-panel/namespace-panel.guard.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.guard.ts
@@ -5,14 +5,12 @@ import { NamespacePanelRouteComponent } from './namespace-panel-route.component'
 /**
  * `CanDeactivate` guard for the namespace-panel route presentation.
  *
- * Story 11.6 — protects the deep-link route
- * `/admin/catalog/namespace/:namespace` from losing an operator's unsaved
- * edit buffer during an internal Angular Router navigation (clicks on
- * `routerLink`, programmatic `router.navigateByUrl`, browser back/forward via
- * Angular's `popstate` binding). Does NOT intercept tab close / hard reload /
- * address-bar edits — those are the browser's `beforeunload` territory and
- * explicitly out of scope here (see the story's Dev Notes §"Dirty-state guard
- * vs. browser's native beforeunload").
+ * Protects the deep-link route `/admin/catalog/namespace/:namespace` from
+ * losing an operator's unsaved edit buffer during an internal Angular Router
+ * navigation (clicks on `routerLink`, programmatic `router.navigateByUrl`,
+ * browser back/forward via Angular's `popstate` binding). Does NOT intercept
+ * tab close / hard reload / address-bar edits — those are the browser's
+ * `beforeunload` territory and out of scope here.
  *
  * Contract:
  * - `component.panel` undefined (panel not yet mounted / race) → return
@@ -26,20 +24,13 @@ import { NamespacePanelRouteComponent } from './namespace-panel-route.component'
  *     * Cancel / dismiss (Esc / X) → resolve(false), navigation is aborted and
  *       the panel's edit buffer is preserved.
  *
- * ADR-018 Amendment §c — the guard reuses the SAME panel-owned custom modal as
- * the Home config-dialog close confirm (`confirmDiscard()`), removing the last
- * PrimeNG `<p-confirmDialog>` / `ConfirmationService` dependency from the
- * namespace-panel dirty-state path. This resolves the spec-compliance BLOCKING
- * finding: the guard previously called `inject(ConfirmationService).confirm(...)`
- * whose accept/reject callbacks only fired when a `<p-confirmDialog>` element was
- * mounted — but the panel dropped that element, so the Promise never resolved
- * (Router navigation hung) and the service was no longer resolvable in the
- * router injection context (`NullInjectorError`).
+ * The guard reuses the SAME panel-owned custom modal as the Home config-dialog
+ * close confirm (`confirmDiscard()`) (ADR-018).
  *
  * Prompt wording is the EXACT string `"You have unsaved changes. Discard?"`
  * (defined once in `panel.confirmDiscard()`) — identical to the dialog
- * presentation's close confirm. UX consistency across the two presentations is
- * a hard requirement of Epic 11.
+ * presentation's close confirm, keeping UX consistent across both
+ * presentations.
  *
  * Implementation notes:
  * - Functional guard (not class-based). Matches Angular v16+ idiom and the

--- a/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
@@ -20,10 +20,11 @@ import { NamespacePanelComponent } from './namespace-panel.component';
 import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 /**
- * Story 11.3 AC 12 — import-atomicity focused spec (NFR5 / ADR-011 D4).
- * Updated for ADR-017 (always-editable single-mode panel): there is no
- * `mode` / `onEditClick`; the buffer is dirtied directly and Save runs a
- * one-shot drift re-export before importing.
+ * Import-atomicity focused spec (NFR5).
+ *
+ * The panel is always-editable single-mode: there is no `mode` / `onEditClick`;
+ * the buffer is dirtied directly and Save runs a one-shot drift re-export
+ * before importing.
  *
  * This spec verifies the FRONTEND-SIDE contract of the atomicity guarantee:
  * when `importNamespace` rejects with a 422, the panel MUST leave its
@@ -120,8 +121,7 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
         { provide: MessageService, useValue: messageSpy },
       ],
     })
-      // Story 22.3 — the panel no longer wires ConfirmationService /
-      // <p-confirmDialog>; the override just swaps Monaco for the stub.
+      // The override just swaps Monaco for the stub.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
@@ -161,7 +161,7 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
       component.buffer = INVALID_YAML;
       expect(component.hasUnsavedChanges()).toBe(true);
 
-      // Save runs a drift re-export first (ADR-017 §6); it returns the same
+      // Save runs a drift re-export first (see ADR-017); it returns the same
       // baseline ⇒ no drift prompt, the import proceeds.
       apiSpy.exportNamespace.and.returnValue(Promise.resolve(BASELINE_YAML));
 

--- a/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
@@ -22,6 +22,9 @@ import { ValidationReportComponent } from './validation-report/validation-report
 
 /**
  * Story 11.3 AC 12 — import-atomicity focused spec (NFR5 / ADR-011 D4).
+ * Updated for ADR-017 (always-editable single-mode panel): there is no
+ * `mode` / `onEditClick`; the buffer is dirtied directly and Save runs a
+ * one-shot drift re-export before importing.
  *
  * This spec verifies the FRONTEND-SIDE contract of the atomicity guarantee:
  * when `importNamespace` rejects with a 422, the panel MUST leave its
@@ -163,10 +166,14 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
       expect(component.serverYaml).toBe(BASELINE_YAML);
       expect(component.buffer).toBe(BASELINE_YAML);
 
-      // User flips into edit mode and types in the INVALID bundle.
-      await component.onEditClick();
+      // The editor is always writable — the user types in the INVALID bundle
+      // directly (no Edit click / mode flip exists).
       component.buffer = INVALID_YAML;
-      expect(component.mode).toBe('edit');
+      expect(component.hasUnsavedChanges()).toBe(true);
+
+      // Save runs a drift re-export first (ADR-017 §6); it returns the same
+      // baseline ⇒ no drift prompt, the import proceeds.
+      apiSpy.exportNamespace.and.returnValue(Promise.resolve(BASELINE_YAML));
 
       // importNamespace rejects with a 422 carrying a structured report.
       apiSpy.importNamespace.and.returnValue(
@@ -184,12 +191,10 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
       await component.onSaveClick();
 
       // Post-422 assertions:
-      //  - mode stays edit,
       //  - buffer is preserved (user's invalid YAML is not lost),
       //  - serverYaml is UNCHANGED — still the pre-save baseline.
       // This is the frontend-testable equivalent of "the server did not
       // persist a partial write".
-      expect(component.mode).toBe('edit');
       expect(component.buffer).toBe(INVALID_YAML);
       expect(component.serverYaml).toBe(BASELINE_YAML);
 

--- a/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
+++ b/src/app/components/catalog/namespace-panel/namespace-panel.import-atomicity.spec.ts
@@ -7,9 +7,8 @@ import {
   NG_VALUE_ACCESSOR,
 } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
@@ -106,7 +105,6 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
   let component: NamespacePanelComponent;
   let apiSpy: jasmine.SpyObj<ApiService>;
   let messageSpy: jasmine.SpyObj<MessageService>;
-  let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
 
   beforeEach(async () => {
     apiSpy = jasmine.createSpyObj('ApiService', [
@@ -114,12 +112,6 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
       'importNamespace',
     ]);
     messageSpy = jasmine.createSpyObj('MessageService', ['add']);
-    // Real ConfirmationService instance + spy on .confirm — see
-    // `namespace-panel.component.spec.ts` for the rationale (PrimeNG's
-    // `<p-confirmDialog>` constructor subscribes to `requireConfirmation$`).
-    confirmationSpy =
-      new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
-    spyOn(confirmationSpy, 'confirm').and.callThrough();
 
     await TestBed.configureTestingModule({
       imports: [NamespacePanelComponent, NoopAnimationsModule],
@@ -128,22 +120,20 @@ describe('NamespacePanelComponent — import atomicity (NFR5)', () => {
         { provide: MessageService, useValue: messageSpy },
       ],
     })
+      // Story 22.3 — the panel no longer wires ConfirmationService /
+      // <p-confirmDialog>; the override just swaps Monaco for the stub.
       .overrideComponent(NamespacePanelComponent, {
         set: {
           imports: [
             CommonModule,
             FormsModule,
             ButtonModule,
-            ConfirmDialogModule,
             DialogModule,
             InputTextModule,
             ToggleSwitchModule,
             TooltipModule,
             StubMonacoEditorComponent,
             ValidationReportComponent,
-          ],
-          providers: [
-            { provide: ConfirmationService, useValue: confirmationSpy },
           ],
         },
       })

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -241,13 +241,21 @@
   cloning). Reads (validate / load) stay dismissable — `isWriteInFlight`
   intentionally excludes `validating` / `loading`.
 -->
+<!--
+  Story 22.3 (ADR-018 §3) — suppress the host config dialog's `closeOnEscape`
+  while ANY secondary panel (Clone modal or confirmation modal) is open, so Esc
+  closes only the topmost secondary panel and does NOT bubble through to close
+  the config panel. `namespacePanel?.hasSecondaryPanelOpen !== true` keeps the
+  existing close-on-escape behaviour when no secondary panel is open (and the
+  panel may be undefined before the @defer block mounts it).
+-->
 <p-dialog
   [visible]="namespacePanelVisible"
   (visibleChange)="onNamespacePanelVisibleChange($event)"
   [modal]="true"
   [style]="{ width: '90vw', height: '90vh' }"
   [closable]="!isWriteInFlight"
-  [closeOnEscape]="!isWriteInFlight"
+  [closeOnEscape]="!isWriteInFlight && namespacePanel?.hasSecondaryPanelOpen !== true"
   [dismissableMask]="!isWriteInFlight"
 >
   <ng-template pTemplate="header">

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -18,13 +18,13 @@
     </p-select>
     &nbsp;
     <!--
-      Story 14.4 — admin-only "show all namespaces" toggle (ADR-028 §Decision 9).
-      Admin-gated UX affordance only; NOT the security boundary (the infra
-      unscoping of admin reads is authoritative). `*ngIf="(isAdmin$ | async)"`
-      so non-admins (incl. anonymous, no roles) never see it — hidden, not
-      merely disabled. Default off (firehose is opt-in). Flips
-      `showAllNamespaces` via `onToggleShowAll`, which re-runs the single
-      `loadNamespaces()` path so `?all=true` flows through it.
+      Admin-only "show all namespaces" toggle (ADR-028). Admin-gated UX
+      affordance only; NOT the security boundary (the infra unscoping of admin
+      reads is authoritative). `*ngIf="(isAdmin$ | async)"` so non-admins (incl.
+      anonymous, no roles) never see it — hidden, not merely disabled. Default
+      off (firehose is opt-in). Flips `showAllNamespaces` via `onToggleShowAll`,
+      which re-runs the single `loadNamespaces()` path so `?all=true` flows
+      through it.
     -->
     <span
       *ngIf="(isAdmin$ | async)"
@@ -50,7 +50,7 @@
       class="extra-small-button"
     ></button>
     &nbsp;
-    <!-- Story 11.2 — Edit Configuration button; opens the Monaco panel in a dialog. -->
+    <!-- Edit Configuration button; opens the Monaco panel in a dialog. -->
     <button
       pButton
       size="small"
@@ -219,36 +219,31 @@
 </section>
 
 <!--
-  Story 11.2 — Namespace Panel dialog wrapper.
+  Namespace Panel dialog wrapper.
 
-  `@defer (when namespacePanelVisible)` guarantees the NamespacePanelComponent
-  (and its Monaco-editor chunk) is fetched only on first open. The initial
-  home-page bundle stays Monaco-free.
--->
-<!--
-  Story 11.3 — split [(visible)] into [visible] + (visibleChange) so the
-  dirty-close guard can intercept dismissals. The dirty-close prompt is now
-  rendered by the panel's own custom confirm modal via `panel.confirmDiscard()`
-  (ADR-018 Amendment §c), so there is NO more `<p-confirmDialog>` here.
--->
-<!--
-  Story 11.7 AC 8, 9, 10 — replace the [header]="..." string binding with
-  a <ng-template pTemplate="header"> block so we can render the namespace
-  name AND the conditional FR15 dirty indicator inside the same header.
-  Story 11.7 AC 22, 23 — lock the X / dismissable-mask dismissal channels
-  during an in-flight write (saving OR cloning). Reads (validate / load) stay
-  dismissable — `isWriteInFlight` intentionally excludes `validating` /
-  `loading`.
--->
-<!--
-  Story 22 (ADR-018 Amendment §b) — `[closeOnEscape]="false"` on ALL THREE
-  dialogs (this config host + the panel's Clone + confirm modals). PrimeNG
-  attaches `closeOnEscape` as a DOCUMENT-level listener per dialog, so a
-  secondary modal's stopPropagation cannot stop this host's listener (Esc closed
-  both in turn). Instead the host owns ONE coordinated Escape handler
-  (`onConfigDialogEscape`, a `document:keydown.escape` HostListener) that closes
-  only the topmost secondary modal, or — when none is open — runs the config
-  panel close flow.
+  `@defer (when namespacePanelVisible)` fetches the NamespacePanelComponent
+  (and its Monaco-editor chunk) only on first open. The initial home-page
+  bundle stays Monaco-free.
+
+  [(visible)] is split into [visible] + (visibleChange) so the dirty-close
+  guard can intercept dismissals; the dirty-close prompt is rendered by the
+  panel's own confirm modal via `panel.confirmDiscard()` (ADR-018).
+
+  The header is a <ng-template pTemplate="header"> block so it can render the
+  namespace name AND the conditional dirty indicator in the same header.
+
+  [closable] / [dismissableMask] lock the X / dismissable-mask dismissal
+  channels during an in-flight write (saving OR cloning). Reads (validate /
+  load) stay dismissable — `isWriteInFlight` intentionally excludes
+  `validating` / `loading`.
+
+  `[closeOnEscape]="false"` on ALL THREE dialogs (this config host + the
+  panel's Clone + confirm modals). PrimeNG attaches `closeOnEscape` as a
+  DOCUMENT-level listener per dialog, so a secondary modal's stopPropagation
+  cannot stop this host's listener. Instead the host owns ONE coordinated
+  Escape handler (`onConfigDialogEscape`, a `document:keydown.escape`
+  HostListener) that closes only the topmost secondary modal, or — when none
+  is open — runs the config panel close flow.
 -->
 <p-dialog
   [visible]="namespacePanelVisible"

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -227,27 +227,28 @@
 -->
 <!--
   Story 11.3 — split [(visible)] into [visible] + (visibleChange) so the
-  dirty-close guard can intercept dismissals. A separate <p-confirmDialog />
-  is mounted at the end of this template so PrimeNG's ConfirmationService
-  can target it (first PrimeNG ConfirmDialog in HomeComponent — scoped to
-  the component, not app-root).
+  dirty-close guard can intercept dismissals. The dirty-close prompt is now
+  rendered by the panel's own custom confirm modal via `panel.confirmDiscard()`
+  (ADR-018 Amendment §c), so there is NO more `<p-confirmDialog>` here.
 -->
 <!--
   Story 11.7 AC 8, 9, 10 — replace the [header]="..." string binding with
   a <ng-template pTemplate="header"> block so we can render the namespace
   name AND the conditional FR15 dirty indicator inside the same header.
-  Story 11.7 AC 22, 23 — lock all three dismissal channels (close X,
-  Escape, dismissable mask) during an in-flight write (saving OR
-  cloning). Reads (validate / load) stay dismissable — `isWriteInFlight`
-  intentionally excludes `validating` / `loading`.
+  Story 11.7 AC 22, 23 — lock the X / dismissable-mask dismissal channels
+  during an in-flight write (saving OR cloning). Reads (validate / load) stay
+  dismissable — `isWriteInFlight` intentionally excludes `validating` /
+  `loading`.
 -->
 <!--
-  Story 22.3 (ADR-018 §3) — suppress the host config dialog's `closeOnEscape`
-  while ANY secondary panel (Clone modal or confirmation modal) is open, so Esc
-  closes only the topmost secondary panel and does NOT bubble through to close
-  the config panel. `namespacePanel?.hasSecondaryPanelOpen !== true` keeps the
-  existing close-on-escape behaviour when no secondary panel is open (and the
-  panel may be undefined before the @defer block mounts it).
+  Story 22 (ADR-018 Amendment §b) — `[closeOnEscape]="false"` on ALL THREE
+  dialogs (this config host + the panel's Clone + confirm modals). PrimeNG
+  attaches `closeOnEscape` as a DOCUMENT-level listener per dialog, so a
+  secondary modal's stopPropagation cannot stop this host's listener (Esc closed
+  both in turn). Instead the host owns ONE coordinated Escape handler
+  (`onConfigDialogEscape`, a `document:keydown.escape` HostListener) that closes
+  only the topmost secondary modal, or — when none is open — runs the config
+  panel close flow.
 -->
 <p-dialog
   [visible]="namespacePanelVisible"
@@ -255,7 +256,7 @@
   [modal]="true"
   [style]="{ width: '90vw', height: '90vh' }"
   [closable]="!isWriteInFlight"
-  [closeOnEscape]="!isWriteInFlight && namespacePanel?.hasSecondaryPanelOpen !== true"
+  [closeOnEscape]="false"
   [dismissableMask]="!isWriteInFlight"
 >
   <ng-template pTemplate="header">
@@ -279,5 +280,3 @@
     />
   }
 </p-dialog>
-
-<p-confirmDialog></p-confirmDialog>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -666,6 +666,54 @@ describe('HomeComponent', () => {
     expect(component.isWriteInFlight).toBeFalse();
   });
 
+  // --- Story 22.3 (ADR-018 §3) — config dialog closeOnEscape gated on the ---
+  // --- panel's secondary-panel-open state. The template binding is         ---
+  // --- `!isWriteInFlight && namespacePanel?.hasSecondaryPanelOpen !== true`.---
+
+  /** Mirrors the home.component.html `[closeOnEscape]` binding expression. */
+  function closeOnEscape(): boolean {
+    return (
+      !component.isWriteInFlight &&
+      component.namespacePanel?.hasSecondaryPanelOpen !== true
+    );
+  }
+
+  it('(22.3 AC12) config dialog closeOnEscape is false while a secondary panel is open', () => {
+    component.namespacePanel = {
+      saving: false,
+      cloning: false,
+      hasSecondaryPanelOpen: true,
+    } as unknown as NamespacePanelComponent;
+
+    expect(closeOnEscape()).toBeFalse();
+  });
+
+  it('(22.3 AC13) config dialog closeOnEscape is true when no secondary panel is open (and no write in flight)', () => {
+    component.namespacePanel = {
+      saving: false,
+      cloning: false,
+      hasSecondaryPanelOpen: false,
+    } as unknown as NamespacePanelComponent;
+
+    expect(closeOnEscape()).toBeTrue();
+  });
+
+  it('(22.3 AC13) config dialog closeOnEscape stays false while a write is in flight, regardless of secondary panel', () => {
+    component.namespacePanel = {
+      saving: true,
+      cloning: false,
+      hasSecondaryPanelOpen: false,
+    } as unknown as NamespacePanelComponent;
+
+    // isWriteInFlight wins — closeOnEscape is suppressed during a write.
+    expect(closeOnEscape()).toBeFalse();
+  });
+
+  it('(22.3 AC13) config dialog closeOnEscape is true when the panel is not yet mounted (undefined)', () => {
+    component.namespacePanel = undefined;
+    expect(closeOnEscape()).toBeTrue();
+  });
+
   it('(11.7 AC8) namespaceLabel returns selected.name when present', () => {
     component.selectedNamespace$.next({
       namespace: 'foo',

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -38,7 +38,7 @@ describe('HomeComponent', () => {
     currentUser$: BehaviorSubject<any>;
     currentUserValue: any;
   };
-  // Story 14.4 — settable auth subject so the reactive admin predicate
+  // Settable auth subject so the reactive admin predicate
   // (isAdmin$ derived from currentUser$) can be driven from tests.
   let currentUser$: BehaviorSubject<any>;
   let routerSpy: jasmine.SpyObj<Router>;
@@ -73,7 +73,7 @@ describe('HomeComponent', () => {
     contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
     contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
 
-    // Story 14.4 — anonymous by default (no `roles`), so isAdmin$ resolves
+    // Anonymous by default (no `roles`), so isAdmin$ resolves
     // false and the toggle is hidden unless a test pushes an admin user.
     currentUser$ = new BehaviorSubject<any>({ user_id: 'anonymous' });
     authSpy = jasmine.createSpyObj('AuthService', ['checkAuth'], {
@@ -90,10 +90,9 @@ describe('HomeComponent', () => {
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
-    // ADR-018 Amendment §c — the dirty-close prompt is now the panel's custom
-    // confirm modal (`panel.confirmDiscard()`), so HomeComponent no longer
-    // provides/uses PrimeNG `ConfirmationService` / `<p-confirmDialog>`. Tests
-    // stub `namespacePanel.confirmDiscard` directly.
+    // HomeComponent's dirty-close prompt is the panel's custom confirm modal
+    // (`panel.confirmDiscard()`); tests stub `namespacePanel.confirmDiscard`
+    // directly. (ADR-018)
     await TestBed.configureTestingModule({
       imports: [HomeComponent, CommonModule, NoopAnimationsModule],
       providers: [
@@ -109,8 +108,6 @@ describe('HomeComponent', () => {
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
   });
-
-  // --- AC6, AC7 ----------------------------------------------------------
 
   it('(AC6) component has no `context` field after the refactor', () => {
     expect((component as any).context).toBeUndefined();
@@ -168,8 +165,6 @@ describe('HomeComponent', () => {
     expect((component as any).context).toBeUndefined();
   });
 
-  // --- Story 10.4 — HomeComponent.createTeamAndNavigate delegation ------
-
   it('(AC4 10.4) HomeComponent.createTeamAndNavigate delegates to contextService and has no reload compensation', async () => {
     const ns = { namespace: 'cat-1', name: 'Cat One', description: 'first cat' };
     component.selectedNamespace$.next(ns);
@@ -188,8 +183,6 @@ describe('HomeComponent', () => {
     await component.createTeamAndNavigate();
     expect(contextSpy.createTeamAndNavigate).not.toHaveBeenCalled();
   });
-
-  // --- Story 1.9 — namespace picker wiring --------------------------------
 
   it('(AC1 1.9) ngOnInit loads namespaces via getNamespaces and selects the first', async () => {
     apiSpy.getNamespaces.and.returnValue(
@@ -240,10 +233,6 @@ describe('HomeComponent', () => {
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(component.namespaces$.value).toEqual([]);
   });
-
-  // --- AC9 ---------------------------------------------------------------
-
-  // --- Story 10.5 — reactive stopTeam delegation -----------------------
 
   it('(AC5 10.5) HomeComponent.stopTeam delegates to contextService.stopTeamAndAwait without polling', async () => {
     apiSpy.stopTeam.calls.reset();
@@ -324,8 +313,6 @@ describe('HomeComponent', () => {
     expect(component.stoppingTeams.has('team-B')).toBe(false);
   });
 
-  // --- Story 11.2 — namespace-panel dialog wiring ---------------------
-
   function editButton(): HTMLButtonElement | null {
     const el = fixture.nativeElement.querySelector(
       'button[data-test="edit-namespace-yaml-btn"]',
@@ -347,8 +334,8 @@ describe('HomeComponent', () => {
 
   it('(AC14 11.2) "Edit Configuration" button is enabled when a namespace is selected', async () => {
     // The refreshed list (driven by ngOnInit's loadNamespaces) must contain
-    // the seeded selection — otherwise the Story 14.2 reconciliation correctly
-    // drops a selection absent from the fetched list, clearing it to null.
+    // the seeded selection — otherwise the reconciliation correctly drops a
+    // selection absent from the fetched list, clearing it to null.
     apiSpy.getNamespaces.and.returnValue(
       Promise.resolve([{ namespace: 'foo', name: 'Foo', description: '' }]),
     );
@@ -368,7 +355,7 @@ describe('HomeComponent', () => {
 
   it('(AC14 11.2) clicking the button sets namespacePanelVisible = true', async () => {
     // See note above: keep the seeded selection present in the fetched list so
-    // the Story 14.2 reconciliation does not drop it during ngOnInit.
+    // the reconciliation does not drop it during ngOnInit.
     apiSpy.getNamespaces.and.returnValue(
       Promise.resolve([{ namespace: 'foo', name: 'Foo', description: '' }]),
     );
@@ -413,8 +400,6 @@ describe('HomeComponent', () => {
     fixture.destroy();
     expect(teams$.observed).toBeFalse();
   });
-
-  // --- Story 11.3 — dialog dirty-close guard + (saved) re-fetch -------
 
   it('(11.3 AC10) onNamespacePanelVisibleChange(true) is a no-op (opening the dialog)', () => {
     const confirmDiscard = jasmine.createSpy('confirmDiscard');
@@ -497,8 +482,8 @@ describe('HomeComponent', () => {
   });
 
   it('(11.3 AC6) onNamespaceSaved re-invokes getNamespaces and pushes the result into namespaces$', async () => {
-    // First load pushed [] from beforeEach spy setup. Now prime a new list
-    // and invoke the (saved) handler — the dropdown must refresh.
+    // Prime a new list and invoke the (saved) handler — the dropdown must
+    // refresh.
     const updated = [
       { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd1' },
       { namespace: 'rag-team-v1', name: 'RAG Team', description: 'd2' },
@@ -511,8 +496,6 @@ describe('HomeComponent', () => {
     expect(apiSpy.getNamespaces).toHaveBeenCalledTimes(1);
     expect(component.namespaces$.value).toEqual(updated);
   });
-
-  // --- Story 14.2 — stale-selection drop on refresh --------------------
 
   it('(14.2 AC8) stale selection (deleted ns) is dropped → advances to first remaining', async () => {
     // Seed a selection that the refreshed list no longer contains.
@@ -618,8 +601,6 @@ describe('HomeComponent', () => {
     ]);
   });
 
-  // --- Story 11.5 — namespaceIdentifiers getter + binding ---------------
-
   it('(11.5 AC13) namespaceIdentifiers returns the `.namespace` field of each namespaces$ entry', () => {
     component.namespaces$.next([
       { namespace: 'foo', name: 'F', description: '' },
@@ -632,8 +613,6 @@ describe('HomeComponent', () => {
     component.namespaces$.next([]);
     expect(component.namespaceIdentifiers).toEqual([]);
   });
-
-  // --- Story 11.7 — dirty indicator + dialog [closable] (FR15 + FR18) ---
 
   it('(11.7 AC22) isWriteInFlight is true when namespacePanel.saving === true', () => {
     component.namespacePanel = {
@@ -666,9 +645,12 @@ describe('HomeComponent', () => {
     expect(component.isWriteInFlight).toBeFalse();
   });
 
-  // --- ADR-018 Amendment §b (FIX 2) — single coordinated Escape handler. ---
-  // The host config dialog sets `[closeOnEscape]="false"`; `onConfigDialogEscape`
-  // (a `document:keydown.escape` HostListener) does exactly ONE thing per Esc.
+  // Single coordinated Escape handler. The host config dialog sets
+  // `[closeOnEscape]="false"`; `onConfigDialogEscape` (a `document:keydown.escape`
+  // HostListener) delegates to `panel.handleSecondaryEscape()` first — closing
+  // only the topmost secondary modal — else runs the config close flow. It is
+  // inactive unless the dialog is open, and a write in flight suppresses Escape.
+  // (ADR-018)
 
   function escapeEvent(): jasmine.SpyObj<Event> {
     return jasmine.createSpyObj<Event>('KeyboardEvent', ['preventDefault']);
@@ -820,8 +802,6 @@ describe('HomeComponent', () => {
     expect(component.namespaceIdentifiers).toEqual(['alpha', 'beta']);
   });
 
-  // --- Story 14.4 — admin "show all namespaces" toggle -----------------
-
   function toggleEl(): HTMLElement | null {
     return fixture.nativeElement.querySelector(
       '[data-test="show-all-namespaces-toggle"]',
@@ -949,7 +929,7 @@ describe('HomeComponent', () => {
     expect(apiSpy.getNamespaces.calls.mostRecent().args[0]).toEqual({
       all: true,
     });
-    // AC18: stale selection dropped, advanced to first remaining (Story 14.2).
+    // AC18: stale selection dropped, advanced to first remaining.
     expect(component.selectedNamespace$.value?.namespace).toBe('agent-team-v1');
   });
 
@@ -970,7 +950,7 @@ describe('HomeComponent', () => {
 
     await component.onToggleShowAll(true);
 
-    // Still-present selection left untouched (reference-equal) — Story 14.2.
+    // Still-present selection left untouched (reference-equal).
     expect(component.selectedNamespace$.value).toBe(original);
   });
 });

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -3,7 +3,6 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
-import { ConfirmationService } from 'primeng/api';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { ApiService } from '../../core/http/api.service';
@@ -43,7 +42,6 @@ describe('HomeComponent', () => {
   // (isAdmin$ derived from currentUser$) can be driven from tests.
   let currentUser$: BehaviorSubject<any>;
   let routerSpy: jasmine.SpyObj<Router>;
-  let confirmationSpy: jasmine.SpyObj<ConfirmationService>;
 
   beforeEach(async () => {
     teams$ = new BehaviorSubject<TeamContext[]>([]);
@@ -92,13 +90,10 @@ describe('HomeComponent', () => {
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     routerSpy.navigate.and.returnValue(Promise.resolve(true));
 
-    // Use a REAL ConfirmationService instance (so its `requireConfirmation$`
-    // Subject is wired) and spy on `.confirm` to observe calls. Using a bare
-    // `jasmine.createSpyObj` breaks PrimeNG's `<p-confirmDialog>` constructor
-    // because it subscribes to `requireConfirmation$` on instantiation.
-    confirmationSpy = new ConfirmationService() as jasmine.SpyObj<ConfirmationService>;
-    spyOn(confirmationSpy, 'confirm').and.callThrough();
-
+    // ADR-018 Amendment §c — the dirty-close prompt is now the panel's custom
+    // confirm modal (`panel.confirmDiscard()`), so HomeComponent no longer
+    // provides/uses PrimeNG `ConfirmationService` / `<p-confirmDialog>`. Tests
+    // stub `namespacePanel.confirmDiscard` directly.
     await TestBed.configureTestingModule({
       imports: [HomeComponent, CommonModule, NoopAnimationsModule],
       providers: [
@@ -109,17 +104,7 @@ describe('HomeComponent', () => {
         { provide: Router, useValue: routerSpy },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    })
-      // Swap the HomeComponent's locally-provided ConfirmationService for a
-      // spy so the Story 11.3 dirty-close guard is testable deterministically.
-      .overrideComponent(HomeComponent, {
-        set: {
-          providers: [
-            { provide: ConfirmationService, useValue: confirmationSpy },
-          ],
-        },
-      })
-      .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
@@ -432,22 +417,31 @@ describe('HomeComponent', () => {
   // --- Story 11.3 — dialog dirty-close guard + (saved) re-fetch -------
 
   it('(11.3 AC10) onNamespacePanelVisibleChange(true) is a no-op (opening the dialog)', () => {
+    const confirmDiscard = jasmine.createSpy('confirmDiscard');
     component.namespacePanelVisible = true;
+    component.namespacePanel = {
+      hasUnsavedChanges: () => true,
+      confirmDiscard,
+    } as unknown as NamespacePanelComponent;
+
     component.onNamespacePanelVisibleChange(true);
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+
+    expect(confirmDiscard).not.toHaveBeenCalled();
     expect(component.namespacePanelVisible).toBeTrue();
   });
 
   it('(11.3 AC10) onNamespacePanelVisibleChange(false) with clean panel closes without confirm', () => {
+    const confirmDiscard = jasmine.createSpy('confirmDiscard');
     component.namespacePanelVisible = true;
     // Simulate a mounted-but-clean panel.
     component.namespacePanel = {
       hasUnsavedChanges: () => false,
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
 
     component.onNamespacePanelVisibleChange(false);
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
+    expect(confirmDiscard).not.toHaveBeenCalled();
     expect(component.namespacePanelVisible).toBeFalse();
   });
 
@@ -457,42 +451,48 @@ describe('HomeComponent', () => {
 
     component.onNamespacePanelVisibleChange(false);
 
-    expect(confirmationSpy.confirm).not.toHaveBeenCalled();
     expect(component.namespacePanelVisible).toBeFalse();
   });
 
-  it('(11.3 AC10) onNamespacePanelVisibleChange(false) with dirty panel requests confirm and keeps dialog open', () => {
+  it('(ADR-018 §c) onNamespacePanelVisibleChange(false) with dirty panel calls confirmDiscard and keeps dialog open; Proceed closes', async () => {
+    let resolveDiscard!: (v: boolean) => void;
+    const confirmDiscard = jasmine
+      .createSpy('confirmDiscard')
+      .and.returnValue(new Promise<boolean>((r) => (resolveDiscard = r)));
     component.namespacePanelVisible = true;
     component.namespacePanel = {
       hasUnsavedChanges: () => true,
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
 
     component.onNamespacePanelVisibleChange(false);
 
-    expect(confirmationSpy.confirm).toHaveBeenCalledTimes(1);
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.message as string).toContain('unsaved changes');
-    // Re-asserted visibility to keep the dialog open during the confirm.
+    expect(confirmDiscard).toHaveBeenCalledTimes(1);
+    // Re-asserted visibility to keep the dialog open while the modal runs.
     expect(component.namespacePanelVisible).toBeTrue();
 
-    // Accept → the dialog truly closes.
-    args.accept!();
+    // Proceed → the dialog truly closes.
+    resolveDiscard(true);
+    await Promise.resolve();
     expect(component.namespacePanelVisible).toBeFalse();
   });
 
-  it('(11.3 AC10) dismissing the confirm (reject) leaves the dialog open, buffer intact', () => {
+  it('(ADR-018 §c) Cancel/dismiss (confirmDiscard resolves false) leaves the dialog open, buffer intact', async () => {
+    let resolveDiscard!: (v: boolean) => void;
+    const confirmDiscard = jasmine
+      .createSpy('confirmDiscard')
+      .and.returnValue(new Promise<boolean>((r) => (resolveDiscard = r)));
     component.namespacePanelVisible = true;
     component.namespacePanel = {
       hasUnsavedChanges: () => true,
+      confirmDiscard,
     } as unknown as NamespacePanelComponent;
 
     component.onNamespacePanelVisibleChange(false);
+    resolveDiscard(false);
+    await Promise.resolve();
 
-    // Reject is optional in ConfirmationService; the call-site does not
-    // register one, so dismissing leaves state unchanged.
-    const args = confirmationSpy.confirm.calls.mostRecent().args[0];
-    expect(args.reject).toBeUndefined();
-    // Visibility is still true (re-asserted by the handler).
+    // Dismissing keeps the dialog open (re-asserted by the handler).
     expect(component.namespacePanelVisible).toBeTrue();
   });
 
@@ -666,52 +666,80 @@ describe('HomeComponent', () => {
     expect(component.isWriteInFlight).toBeFalse();
   });
 
-  // --- Story 22.3 (ADR-018 §3) — config dialog closeOnEscape gated on the ---
-  // --- panel's secondary-panel-open state. The template binding is         ---
-  // --- `!isWriteInFlight && namespacePanel?.hasSecondaryPanelOpen !== true`.---
+  // --- ADR-018 Amendment §b (FIX 2) — single coordinated Escape handler. ---
+  // The host config dialog sets `[closeOnEscape]="false"`; `onConfigDialogEscape`
+  // (a `document:keydown.escape` HostListener) does exactly ONE thing per Esc.
 
-  /** Mirrors the home.component.html `[closeOnEscape]` binding expression. */
-  function closeOnEscape(): boolean {
-    return (
-      !component.isWriteInFlight &&
-      component.namespacePanel?.hasSecondaryPanelOpen !== true
-    );
+  function escapeEvent(): jasmine.SpyObj<Event> {
+    return jasmine.createSpyObj<Event>('KeyboardEvent', ['preventDefault']);
   }
 
-  it('(22.3 AC12) config dialog closeOnEscape is false while a secondary panel is open', () => {
+  it('(ADR-018 §b) Escape is a no-op when the config dialog is not open', () => {
+    const handleSecondaryEscape = jasmine.createSpy('handleSecondaryEscape');
+    component.namespacePanelVisible = false;
     component.namespacePanel = {
       saving: false,
       cloning: false,
-      hasSecondaryPanelOpen: true,
+      handleSecondaryEscape,
     } as unknown as NamespacePanelComponent;
 
-    expect(closeOnEscape()).toBeFalse();
+    component.onConfigDialogEscape(escapeEvent());
+
+    expect(handleSecondaryEscape).not.toHaveBeenCalled();
   });
 
-  it('(22.3 AC13) config dialog closeOnEscape is true when no secondary panel is open (and no write in flight)', () => {
-    component.namespacePanel = {
-      saving: false,
-      cloning: false,
-      hasSecondaryPanelOpen: false,
-    } as unknown as NamespacePanelComponent;
-
-    expect(closeOnEscape()).toBeTrue();
-  });
-
-  it('(22.3 AC13) config dialog closeOnEscape stays false while a write is in flight, regardless of secondary panel', () => {
+  it('(ADR-018 §b) Escape is a no-op while a write is in flight', () => {
+    const handleSecondaryEscape = jasmine.createSpy('handleSecondaryEscape');
+    component.namespacePanelVisible = true;
     component.namespacePanel = {
       saving: true,
       cloning: false,
-      hasSecondaryPanelOpen: false,
+      handleSecondaryEscape,
     } as unknown as NamespacePanelComponent;
 
-    // isWriteInFlight wins — closeOnEscape is suppressed during a write.
-    expect(closeOnEscape()).toBeFalse();
+    component.onConfigDialogEscape(escapeEvent());
+
+    expect(handleSecondaryEscape).not.toHaveBeenCalled();
   });
 
-  it('(22.3 AC13) config dialog closeOnEscape is true when the panel is not yet mounted (undefined)', () => {
-    component.namespacePanel = undefined;
-    expect(closeOnEscape()).toBeTrue();
+  it('(ADR-018 §b) Escape closes ONLY the topmost secondary modal when one is open (config stays open)', () => {
+    const handleSecondaryEscape = jasmine
+      .createSpy('handleSecondaryEscape')
+      .and.returnValue(true);
+    component.namespacePanelVisible = true;
+    component.namespacePanel = {
+      saving: false,
+      cloning: false,
+      hasUnsavedChanges: () => true,
+      handleSecondaryEscape,
+    } as unknown as NamespacePanelComponent;
+
+    const event = escapeEvent();
+    component.onConfigDialogEscape(event);
+
+    expect(handleSecondaryEscape).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    // Config panel was NOT closed (the secondary modal consumed the Escape).
+    expect(component.namespacePanelVisible).toBeTrue();
+  });
+
+  it('(ADR-018 §b) Escape with no secondary modal open runs the config panel close flow', () => {
+    const handleSecondaryEscape = jasmine
+      .createSpy('handleSecondaryEscape')
+      .and.returnValue(false);
+    component.namespacePanelVisible = true;
+    component.namespacePanel = {
+      saving: false,
+      cloning: false,
+      hasUnsavedChanges: () => false,
+      handleSecondaryEscape,
+    } as unknown as NamespacePanelComponent;
+
+    component.onConfigDialogEscape(escapeEvent());
+
+    expect(handleSecondaryEscape).toHaveBeenCalledTimes(1);
+    // Clean panel → close flow closes the config dialog directly.
+    expect(component.namespacePanelVisible).toBeFalse();
   });
 
   it('(11.7 AC8) namespaceLabel returns selected.name when present', () => {

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -29,11 +29,11 @@ import { AuthService } from '../../core/auth/auth.service';
 import { ConfigService } from '../../core/config/config.service';
 import { ContextService } from '../../core/context/context.service';
 
-// Story 11.2 — Listed in @Component.imports so Angular's @defer block can
-// resolve <app-namespace-panel>. The `@defer (when ...)` block in the
-// template ensures the component's compiled code (and its Monaco chunk)
-// lives in a deferred chunk that is only loaded on first opening of the
-// namespace-editor dialog — the initial home-page bundle stays Monaco-free.
+// Listed in @Component.imports so Angular's @defer block can resolve
+// <app-namespace-panel>. The `@defer (when ...)` block in the template keeps
+// the component's compiled code (and its Monaco chunk) in a deferred chunk
+// loaded only on first opening of the namespace-editor dialog — the initial
+// home-page bundle stays Monaco-free.
 import { NamespacePanelComponent } from '../catalog/namespace-panel/namespace-panel.component';
 
 @Component({
@@ -70,12 +70,12 @@ export class HomeComponent {
   editingDescriptionFor: string | null = null;
   descriptionDrafts = new Map<string, string>();
 
-  // Story 11.2 — controls the Namespace Panel dialog visibility. The panel
-  // component is mounted lazily via @defer in home.component.html so its
-  // Monaco-editor dependency is NOT part of the initial home-page chunk.
+  // Controls the Namespace Panel dialog visibility. The panel component is
+  // mounted lazily via @defer in home.component.html so its Monaco-editor
+  // dependency is NOT part of the initial home-page chunk.
   namespacePanelVisible: boolean = false;
 
-  // Story 14.4 — admin-only "show all namespaces" toggle (ADR-028 §Decision 9).
+  // Admin-only "show all namespaces" toggle (ADR-028).
   //
   // This is an admin-gated UX affordance, NOT the security boundary. The
   // authoritative "see all" enforcement is the infra unscoping of admin reads
@@ -102,11 +102,11 @@ export class HomeComponent {
 
   @ViewChildren('descriptionInput') descriptionInputs!: QueryList<ElementRef>;
 
-  // Story 11.3 — @ViewChild on the @defer-rendered panel. The reference is
-  // `undefined` until the user opens the dialog (the @defer block only
-  // mounts the child when `namespacePanelVisible` flips true), so the close
-  // handler MUST null-check. `{ static: false }` is the default for
-  // @ViewChild on conditionally-rendered children; no explicit option needed.
+  // @ViewChild on the @defer-rendered panel. The reference is `undefined`
+  // until the user opens the dialog (the @defer block only mounts the child
+  // when `namespacePanelVisible` flips true), so the close handler MUST
+  // null-check. `{ static: false }` is the default for @ViewChild on
+  // conditionally-rendered children; no explicit option needed.
   @ViewChild(NamespacePanelComponent)
   namespacePanel?: NamespacePanelComponent;
 
@@ -138,29 +138,26 @@ export class HomeComponent {
   }
 
   /**
-   * Load catalog namespaces for the dropdown. Extracted so the 2xx save
-   * branch (Story 11.3 AC 6) can re-invoke the same code path without
-   * duplicating the error handling.
+   * Load catalog namespaces for the dropdown. Shared by initial load and the
+   * 2xx save branch so the fetch and error handling live in one place.
    *
-   * Story 14.2 — drop a stale selection / preserve a valid one. After
-   * refreshing the options, reconcile the current selection against the
-   * freshly-fetched list, comparing on the stable `namespace` identifier
-   * (NOT object reference — every fetch returns new objects — and NOT the
-   * display `name`, which two summaries may share). If the current
-   * selection is no longer present (e.g. it was just deleted), re-select
-   * the first remaining namespace, or `null` when the list is empty. If it
-   * is still present, leave the subject untouched to avoid a gratuitous
-   * dropdown flicker on an unrelated refresh. A `null` current selection
-   * is "not present", so a non-empty list still auto-selects `namespaces[0]`
-   * (preserves the Story 1.9 initial-load behavior).
+   * Reconciles the current selection against the freshly-fetched list,
+   * comparing on the stable `namespace` identifier (NOT object reference —
+   * every fetch returns new objects — and NOT the display `name`, which two
+   * summaries may share). If the current selection is no longer present (e.g.
+   * it was just deleted), re-select the first remaining namespace, or `null`
+   * when the list is empty. If it is still present, leave the subject
+   * untouched to avoid a gratuitous dropdown flicker on an unrelated refresh.
+   * A `null` current selection is "not present", so a non-empty list still
+   * auto-selects `namespaces[0]`.
    */
   private async loadNamespaces(): Promise<void> {
     try {
-      // Story 14.4 — forward the admin "show all" flag through the single
-      // load path so every caller (initial, save, clone, delete, refresh,
-      // toggle) stays consistent and the Story 14.2 reconciliation below still
-      // runs on every re-fetch. `all=true` is honoured server-side only for
-      // admins; for everyone else it is a no-op (normal owner+public list).
+      // Forward the admin "show all" flag through the single load path so
+      // every caller (initial, save, clone, delete, refresh, toggle) stays
+      // consistent and the selection reconciliation below runs on every
+      // re-fetch. `all=true` is honoured server-side only for admins; for
+      // everyone else it is a no-op (normal owner+public list).
       const namespaces = await this.apiService.getNamespaces({
         all: this.showAllNamespaces,
       });
@@ -293,8 +290,7 @@ export class HomeComponent {
   }
 
   /**
-   * Story 11.3 AC 10 — dialog dirty-close guard (ADR-018 Amendment §c —
-   * migrated to the panel's custom confirm modal).
+   * Dialog dirty-close guard (ADR-018).
    *
    * The `p-dialog` binding is split into `[visible]` + `(visibleChange)` so
    * this handler can intercept close attempts (the X button / dismissable
@@ -304,11 +300,6 @@ export class HomeComponent {
    * `confirmDiscard()` modal runs. On Proceed (resolve `true`) flip visibility
    * to false; on Cancel/dismiss (resolve `false`) leave the dialog open with
    * the buffer intact.
-   *
-   * Migrating to `panel.confirmDiscard()` removes the old PrimeNG
-   * `ConfirmationService` / `<p-confirmDialog>` usage for the panel's dirty
-   * state, so both presentations (this dialog + the route guard) share ONE
-   * confirm idiom.
    *
    * `this.namespacePanel` may be `undefined` (the panel is mounted lazily
    * via @defer) — when it is not mounted there is nothing to discard, so
@@ -327,7 +318,7 @@ export class HomeComponent {
     }
     // Dirty panel — re-assert visibility to keep the dialog open while the
     // panel's custom confirm modal runs. Proceed closes; Cancel/dismiss keeps
-    // it open (AC 10 dismiss branch).
+    // it open.
     this.namespacePanelVisible = true;
     void panel.confirmDiscard().then((discard) => {
       if (discard) {
@@ -337,15 +328,16 @@ export class HomeComponent {
   }
 
   /**
-   * Single coordinated Escape handler for the config dialog (ADR-018
-   * Amendment §b — FIX 2). All three dialogs (this host config dialog + the
-   * panel's Clone + confirm modals) set `[closeOnEscape]="false"`, so PrimeNG's
-   * per-dialog document-level Esc listeners never fire and cannot cascade.
-   * Instead this ONE document-level handler coordinates Escape while the config
-   * dialog is open. A document listener (not a `<p-dialog>`-scoped one) is
-   * load-bearing: a secondary modal is teleported to `<body>` as a SIBLING
-   * overlay, so its keydown does not bubble to the config dialog element — only
-   * a document-level handler sees Escape regardless of which overlay has focus.
+   * Single coordinated Escape handler for the config dialog (ADR-018).
+   *
+   * All three dialogs (this host config dialog + the panel's Clone + confirm
+   * modals) set `[closeOnEscape]="false"`, so PrimeNG's per-dialog
+   * document-level Esc listeners never fire and cannot cascade. Instead this
+   * ONE document-level handler coordinates Escape while the config dialog is
+   * open. A document listener (not a `<p-dialog>`-scoped one) is load-bearing:
+   * a secondary modal is teleported to `<body>` as a SIBLING overlay, so its
+   * keydown does not bubble to the config dialog element — only a
+   * document-level handler sees Escape regardless of which overlay has focus.
    *
    * Exactly ONE action per Escape, in priority order:
    *   1. delegate to `panel.handleSecondaryEscape()` — if a secondary modal
@@ -356,8 +348,7 @@ export class HomeComponent {
    *      buffer through `confirmDiscard()`.
    *
    * Inactive unless the config dialog is open; a write-in-flight suppresses
-   * Escape entirely (mirrors the old `[closeOnEscape]="!isWriteInFlight…"`
-   * contract).
+   * Escape entirely.
    */
   @HostListener('document:keydown.escape', ['$event'])
   onConfigDialogEscape(event: Event): void {
@@ -375,23 +366,21 @@ export class HomeComponent {
   }
 
   /**
-   * Story 11.3 AC 6 — `(saved)` output handler. Re-fetches namespaces so
-   * any summary-metadata changes (e.g. renamed description) propagate to
-   * the dropdown. Shares `loadNamespaces()` with `ngOnInit` to keep the
-   * fetch logic in one place.
+   * `(saved)` output handler. Re-fetches namespaces so any summary-metadata
+   * changes (e.g. renamed description) propagate to the dropdown. Shares
+   * `loadNamespaces()` with `ngOnInit` to keep the fetch logic in one place.
    */
   async onNamespaceSaved(): Promise<void> {
     await this.loadNamespaces();
   }
 
   /**
-   * Story 14.4 — admin "show all namespaces" toggle handler. Flips the
-   * component flag and re-runs the single `loadNamespaces()` path so the
-   * `all` flag flows through it (the toggle never calls `getNamespaces`
-   * directly — that keeps every load path consistent and preserves the
-   * Story 14.2 stale-selection reconciliation on the re-fetch). Turning on
-   * requests `?all=true` (admin firehose); turning off restores the normal
-   * owner+public list.
+   * Admin "show all namespaces" toggle handler. Flips the component flag and
+   * re-runs the single `loadNamespaces()` path so the `all` flag flows through
+   * it (the toggle never calls `getNamespaces` directly — that keeps every
+   * load path consistent and preserves the stale-selection reconciliation on
+   * the re-fetch). Turning on requests `?all=true` (admin firehose); turning
+   * off restores the normal owner+public list.
    */
   async onToggleShowAll(value: boolean): Promise<void> {
     this.showAllNamespaces = value;
@@ -399,28 +388,27 @@ export class HomeComponent {
   }
 
   /**
-   * Story 11.5 AC 13 — pure derivation of namespace identifiers from the
-   * synchronous current value of `namespaces$`. Supplied to the panel via
-   * `[existingNamespaces]` for the Clone dialog's pre-flight collision
-   * check (panel's AC 4). Getter instead of a dedicated stream because
-   * BehaviorSubject exposes `.value` synchronously; no pipe / async needed.
+   * Pure derivation of namespace identifiers from the synchronous current
+   * value of `namespaces$`. Supplied to the panel via `[existingNamespaces]`
+   * for the Clone dialog's pre-flight collision check. Getter instead of a
+   * dedicated stream because BehaviorSubject exposes `.value` synchronously;
+   * no pipe / async needed.
    */
   get namespaceIdentifiers(): string[] {
     return (this.namespaces$.value ?? []).map((n) => n.namespace);
   }
 
   /**
-   * Story 11.7 AC 22, 23 — write-in-flight predicate (FR18). True iff the
-   * panel is currently saving OR cloning. Reads (validate / load) are
-   * NON-destructive and intentionally excluded so the operator can dismiss
-   * the dialog while a Validate request is mid-flight.
+   * Write-in-flight predicate. True iff the panel is currently saving OR
+   * cloning. Reads (validate / load) are NON-destructive and intentionally
+   * excluded so the operator can dismiss the dialog while a Validate request
+   * is mid-flight.
    *
    * Used by the dialog's `[closable]` / `[dismissableMask]` bindings and by
    * the coordinated `onConfigDialogEscape` handler to lock all dismissal
-   * channels during an in-flight write. (`[closeOnEscape]` itself is now always
-   * `false` — Escape is owned by `onConfigDialogEscape`, ADR-018 Amendment §b.)
-   * Existing destroyed-guard pattern in the panel (Story 11.3 AC 13 + 11.5
-   * AC 16) absorbs late resolutions; this gate just prevents the operator from
+   * channels during an in-flight write. (`[closeOnEscape]` is always `false` —
+   * Escape is owned by `onConfigDialogEscape`.) The panel's destroyed-guard
+   * absorbs late resolutions; this gate just prevents the operator from
    * hitting that race in the first place.
    */
   get isWriteInFlight(): boolean {
@@ -431,11 +419,10 @@ export class HomeComponent {
   }
 
   /**
-   * Story 11.7 AC 8 — namespace label for the dialog header. Inlined
-   * resolution of (selectedNamespace.name ?? selectedNamespace.namespace ??
-   * 'Namespace') from the existing async pipe. Wrapped in a getter so the
-   * dialog's `<ng-template pTemplate="header">` block can render it
-   * alongside the conditional dirty indicator without two async pipes.
+   * Namespace label for the dialog header. Resolves (selectedNamespace.name ??
+   * selectedNamespace.namespace ?? 'Namespace'). Wrapped in a getter so the
+   * dialog's `<ng-template pTemplate="header">` block can render it alongside
+   * the conditional dirty indicator without two async pipes.
    */
   get namespaceLabel(): string {
     const selected = this.selectedNamespace$.value;

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  HostListener,
   inject,
   ViewChild,
   ViewChildren,
@@ -16,9 +17,7 @@ import { TeamContext, isRunning } from '../../core/context/team.interface';
 import { NamespaceSummary } from '../../protocol/catalog.interface';
 
 import { CommonModule } from '@angular/common';
-import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
@@ -47,16 +46,10 @@ import { NamespacePanelComponent } from '../catalog/namespace-panel/namespace-pa
     TagModule,
     CommonModule,
     DialogModule,
-    ConfirmDialogModule,
     InputTextModule,
     ToggleSwitchModule,
     NamespacePanelComponent,
   ],
-  // First PrimeNG ConfirmDialog in the HomeComponent — scoped locally for
-  // the dirty-close guard (Story 11.3 AC 10). The NamespacePanelComponent
-  // provides its OWN ConfirmationService for its Cancel-with-dirty-buffer
-  // confirm, so they don't collide.
-  providers: [ConfirmationService],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss',
 })
@@ -65,7 +58,6 @@ export class HomeComponent {
   contextService: ContextService = inject(ContextService);
   router: Router = inject(Router);
   authService: AuthService = inject(AuthService);
-  private confirmationService: ConfirmationService = inject(ConfirmationService);
   private config = inject(ConfigService);
 
   // Catalog namespaces for the team creation dropdown
@@ -301,13 +293,22 @@ export class HomeComponent {
   }
 
   /**
-   * Story 11.3 AC 10 — dialog dirty-close guard.
+   * Story 11.3 AC 10 — dialog dirty-close guard (ADR-018 Amendment §c —
+   * migrated to the panel's custom confirm modal).
    *
    * The `p-dialog` binding is split into `[visible]` + `(visibleChange)` so
-   * this handler can intercept close attempts. When the user dismisses the
-   * dialog and the panel reports unsaved changes, re-assert
-   * `namespacePanelVisible = true` and trigger a PrimeNG ConfirmDialog. On
-   * confirm, flip visibility to false. On dismiss, leave the dialog open.
+   * this handler can intercept close attempts (the X button / dismissable
+   * mask; Esc is handled by `onConfigDialogEscape`). When the user dismisses
+   * the dialog and the panel reports unsaved changes, re-assert
+   * `namespacePanelVisible = true` to keep the dialog open while the panel's
+   * `confirmDiscard()` modal runs. On Proceed (resolve `true`) flip visibility
+   * to false; on Cancel/dismiss (resolve `false`) leave the dialog open with
+   * the buffer intact.
+   *
+   * Migrating to `panel.confirmDiscard()` removes the old PrimeNG
+   * `ConfirmationService` / `<p-confirmDialog>` usage for the panel's dirty
+   * state, so both presentations (this dialog + the route guard) share ONE
+   * confirm idiom.
    *
    * `this.namespacePanel` may be `undefined` (the panel is mounted lazily
    * via @defer) — when it is not mounted there is nothing to discard, so
@@ -325,18 +326,52 @@ export class HomeComponent {
       return;
     }
     // Dirty panel — re-assert visibility to keep the dialog open while the
-    // confirm runs. The confirm's accept callback then truly closes.
+    // panel's custom confirm modal runs. Proceed closes; Cancel/dismiss keeps
+    // it open (AC 10 dismiss branch).
     this.namespacePanelVisible = true;
-    this.confirmationService.confirm({
-      header: 'Unsaved changes',
-      icon: 'pi pi-exclamation-triangle',
-      message: 'You have unsaved changes. Discard?',
-      accept: () => {
+    void panel.confirmDiscard().then((discard) => {
+      if (discard) {
         this.namespacePanelVisible = false;
-      },
-      // `reject` intentionally omitted — dismissing keeps the dialog open
-      // (AC 10 dismiss branch).
+      }
     });
+  }
+
+  /**
+   * Single coordinated Escape handler for the config dialog (ADR-018
+   * Amendment §b — FIX 2). All three dialogs (this host config dialog + the
+   * panel's Clone + confirm modals) set `[closeOnEscape]="false"`, so PrimeNG's
+   * per-dialog document-level Esc listeners never fire and cannot cascade.
+   * Instead this ONE document-level handler coordinates Escape while the config
+   * dialog is open. A document listener (not a `<p-dialog>`-scoped one) is
+   * load-bearing: a secondary modal is teleported to `<body>` as a SIBLING
+   * overlay, so its keydown does not bubble to the config dialog element — only
+   * a document-level handler sees Escape regardless of which overlay has focus.
+   *
+   * Exactly ONE action per Escape, in priority order:
+   *   1. delegate to `panel.handleSecondaryEscape()` — if a secondary modal
+   *      (confirm, then Clone) is open it closes ONLY the topmost one and
+   *      returns `true`; we stop there.
+   *   2. otherwise (no secondary panel open) run the config panel's own close
+   *      flow (`onNamespacePanelVisibleChange(false)`), which routes a dirty
+   *      buffer through `confirmDiscard()`.
+   *
+   * Inactive unless the config dialog is open; a write-in-flight suppresses
+   * Escape entirely (mirrors the old `[closeOnEscape]="!isWriteInFlight…"`
+   * contract).
+   */
+  @HostListener('document:keydown.escape', ['$event'])
+  onConfigDialogEscape(event: Event): void {
+    if (!this.namespacePanelVisible || this.isWriteInFlight) {
+      return;
+    }
+    const panel = this.namespacePanel;
+    if (panel?.handleSecondaryEscape() === true) {
+      // A secondary modal consumed the Escape — do not also close the config
+      // panel. Prevent the default so nothing else acts on this keystroke.
+      event.preventDefault();
+      return;
+    }
+    this.onNamespacePanelVisibleChange(false);
   }
 
   /**
@@ -380,11 +415,13 @@ export class HomeComponent {
    * NON-destructive and intentionally excluded so the operator can dismiss
    * the dialog while a Validate request is mid-flight.
    *
-   * Used by the dialog's `[closable]` / `[closeOnEscape]` /
-   * `[dismissableMask]` bindings to lock all dismissal channels during
-   * an in-flight write. Existing destroyed-guard pattern in the panel
-   * (Story 11.3 AC 13 + 11.5 AC 16) absorbs late resolutions; this gate
-   * just prevents the operator from hitting that race in the first place.
+   * Used by the dialog's `[closable]` / `[dismissableMask]` bindings and by
+   * the coordinated `onConfigDialogEscape` handler to lock all dismissal
+   * channels during an in-flight write. (`[closeOnEscape]` itself is now always
+   * `false` — Escape is owned by `onConfigDialogEscape`, ADR-018 Amendment §b.)
+   * Existing destroyed-guard pattern in the panel (Story 11.3 AC 13 + 11.5
+   * AC 16) absorbs late resolutions; this gate just prevents the operator from
+   * hitting that race in the first place.
    */
   get isWriteInFlight(): boolean {
     return (


### PR DESCRIPTION
## Epic 22 — Always-editable namespace panel

Umbrella PR for Epic 22. Collapses the catalog namespace panel's `view`/`edit`
two-mode state machine into a single **dirty** signal (`buffer !== serverYaml`),
per ADR-017. The panel is always editable; the action row is driven by one
boolean.

### Stories

- [x] 22-1-always-editable-namespace-panel-dirty-driven-action-row — always-editable namespace panel, dirty-driven action row (Relates to #170)
- [x] 22-2-action-row-keyboard-shortcuts — action-row keyboard shortcuts (Relates to #172)
- [x] 22-3-custom-confirmation-modal-and-secondary-modal-contract — custom confirmation modal + secondary-modal contract (Relates to #173)
- [x] 22-4-macos-option-shortcut-robustness — macOS Option-shortcut robustness (dead-key / IME composition) (Relates to #174)

### What 22-1 delivers (ADR-017 §1–§6)

- Monaco mounts permanently writable; `editorOptions` is a single stable
  `readonly` constant (`readOnly: false`). Deletes `mode`, `setMode()`,
  `buildEditorOptions()`, `onEditClick()`, `refreshingForEdit`.
- `hasUnsavedChanges()` collapses to `buffer !== serverYaml` — name + signature
  preserved so the route `CanDeactivate` guard and the home dirty-close guard
  consume it unchanged.
- Action row rebuilt as one un-gated row: **Validate** (always) · **Save**
  (dirty) · **Reset** (dirty) · **Clone** (clean) · **Delete** (always).
  Validate is never disabled by the FR14 known-bad-validation gate.
- Single buffer Validate handler (`onValidateBufferClick`); retires
  `onValidatePersistedClick` and collapses the two flash flags into one.
- Cancel removed — Reset is the sole undo affordance.
- Drift check relocated from Edit-entry into Save (`checkSaveDrift`): re-export
  before import; on divergence prompt reload-and-rebase (accept) vs overwrite
  (reject).

### What 22-2 delivers (ADR-017 §7 / FR10–FR12)

- Five ⌥-key shortcuts over the 22-1 action row: ⌥S Save · ⌥V Validate ·
  ⌥R Reset · ⌥⇧C Clone · ⌥D Delete.
- Five `can*` getters centralise enablement; the button `[disabled]` bindings
  now consume them, so the click path and the shortcut path share ONE predicate.
  Five `triggerX()` entry points delegate to the existing (unchanged) handlers.
- A single `matchShortcut()` keys off `altKey` + `code` (never `key`) so macOS
  Option dead-keys (ß/√) still match; ⌥⇧C additionally requires `shiftKey`;
  `preventDefault` on every handled combo including the no-op-by-enablement case.
- Two capture sites over the shared surface: a host `@HostListener('keydown')`
  for focus outside the editor, and Monaco `editor.addAction` wired off the
  `<nu-monaco-editor>` `(event)` init payload for in-editor focus
  (re-init guarded). ⌥D still routes through the Delete confirm dialog.

### What 22-3 delivers (ADR-018 §1–§4)

- Replaces the panel's generic `<p-confirmDialog>` / `ConfirmationService` with
  a panel-owned **custom confirmation modal** on the same `<p-dialog>` shell +
  `namespace-panel__clone-body` / `__clone-actions` styling as the Clone modal,
  driven from component state (a typed `ConfirmRequest` + `confirmDialogVisible`
  + captured accept/reload closures). Reused across Reset-discard, Save-drift,
  and Delete.
- Save-drift renders **two explicit named buttons** (Reload + Overwrite)
  returning a `Promise<boolean>`: Reload → `false` (rebase, skip import, safe
  default); Overwrite → `true`. Dismissal (Esc / Cancel / X) settles the **safe**
  branch (`false`) so an accidental dismissal never lands a blind overwrite.
- Safety-first keyboard (§2): the safe button (Cancel for reset/delete, Reload
  for drift) autofocuses on open so native Enter/Esc cancel; proceeding requires
  a deliberate click. No Enter-proceeds handler.
- Uniform secondary-modal contract (§3): public `hasSecondaryPanelOpen`
  predicate (`cloneDialogVisible || confirmDialogVisible`) gates the host config
  dialog's `[closeOnEscape]`; each secondary panel stops Esc propagation. No
  dimming backdrop under either secondary panel (Clone `[modal]="false"`,
  confirmation modal sets none; host config dialog `[modal]="true"` untouched).
- One scoped dark-red `namespace-panel__danger` class (§4) defined once under
  `:host ::ng-deep`, reused by the action-row Delete button (replacing
  `severity="danger"`) and the Delete-confirm Proceed button.

### What 22-4 delivers (ADR-018 §5 / FR19)

- **Hardens the ⌥-chord shortcuts against macOS dead-key / IME composition.** On
  some macOS keyboard layouts an ⌥-chord (notably ⌥V) initiates a dead-key
  composition and the browser delivers the `keydown` flagged composing
  (`isComposing:true`, `keyCode:229`, `key:'Dead'`). `matchShortcut` already
  keys off `altKey` + `event.code` ONLY (never `event.key`) and has no
  composing early-return, so a composing chord still matches and `preventDefault`s
  the OS dead-key — locked in by unit specs; uniform across all five chords,
  ⌥V not special-cased.
- **Makes the host keydown capture the authoritative path.** The bubble-phase
  `@HostListener('keydown')` is replaced by a **capture-phase** listener on the
  host element (registered in `ngAfterViewInit`, removed via `destroyRef` — no
  leak) so the host sees the chord BEFORE Monaco can swallow it when the editor
  has focus. The Monaco `editor.addAction` keybindings stay best-effort
  in-editor convenience only; correctness no longer depends on them.
- **Single-fire-per-keystroke preserved.** Exactly one host dispatch site routes
  through the idempotent `triggerX()` surface — the old bubble-phase listener is
  gone, so no second uncoordinated host dispatch can open two confirms or submit
  two imports. The `can*` getters, `triggerX()` bodies, and all action handlers
  are unchanged.

## Review status

**22-1 — APPROVED / done.** Adversarial review of commit `f103e9c` against all
24 ACs: every AC implemented and evidenced. Button `[disabled]` bindings match
the dirty-driven enablement spec exactly (Save `buffer === serverYaml || saving
|| isSaveGated`; Validate `saving || validating`; Reset `buffer === serverYaml
|| saving`; Clone `buffer !== serverYaml || cloning || isCloneGated`; Delete
`deleting`). Comprehensive Karma coverage including DOM-level button-disabled
assertions, all Save error branches (422 structured/unstructured, 5xx, 401),
the four drift branches (match → no prompt, reload-and-rebase, buffer-rebase,
overwrite), the network-error fallthrough, and the destroy-during-save guard.
No fix-worthy issues found — no review fixup commit was needed.

Local gates green: Karma **890/890 SUCCESS**, ESLint clean, `ng build` succeeds
(pre-existing lodash-CJS warning only).

- 22-2 review: **PASS** — adversarial review of commit `7052ea3` against AC 1–14.
  Shortcut→action mapping, enablement parity (single `can*` predicate shared by
  buttons + shortcuts), `altKey`+`code` matching with dead-key survival, Shift
  gating for ⌥⇧C with no double-fire, `preventDefault` on handled combos only,
  and both capture sites (HostListener + Monaco `addAction`) funnelling through
  one `triggerX()` dispatch surface — all implemented and evidenced. No existing
  handler body changed; all changes confined to the namespace-panel component.
  No HIGH/MEDIUM issues; no review fixup commit needed. Local gates green:
  Karma **918/918 SUCCESS**, ESLint clean, `ng build` succeeds (pre-existing
  lodash-CJS warning only).

- 22-3 review: **PASS** — adversarial review of commit `0428ab2` against AC 1–22.
  All special-attention areas verified: the secondary-modal Esc contract (both
  secondary panels `stopPropagation` on `keydown.escape`; host
  `[closeOnEscape]="!isWriteInFlight && namespacePanel?.hasSecondaryPanelOpen !== true"`;
  `hasSecondaryPanelOpen = cloneDialogVisible || confirmDialogVisible`; Esc still
  closes the config panel when none open); the focus-Cancel safety default
  (`#confirmSafeBtn` autofocused on show, no Enter-proceeds path); the Save-drift
  two-button mapping (Reload→`false`+rebase safe, Overwrite→`true`, dismiss→safe
  `false` via `onConfirmDialogHide`, guarded against double-resolution by a
  `settled` latch + `confirmDriftResolve` clearing); the no-backdrop change
  (Clone `[modal]="false"`, confirmation modal none, host config dialog
  untouched); and the single shared dark-red `namespace-panel__danger` class on
  both the action-row Delete and the Delete-confirm Proceed. `ConfirmRequest` is
  a typed interface (Golden Rule #1); no ADR-string test assertions (Golden Rule
  #8); all changes confined to `akgentic-frontend` (Golden Rule #4). The
  HomeComponent retains its OWN `<p-confirmDialog>` for the config dialog's
  dirty-close guard — correctly out of scope. No HIGH/MEDIUM issues; no review
  fixup commit needed. Local gates green: Karma **940/940 SUCCESS**, ESLint
  clean, `ng build` succeeds (pre-existing lodash-CJS warning only).

- 22-4 review: **PASS (unit-gated) — AC 8 macOS manual verification PENDING.**
  Adversarial review of commit `9f69d24` against AC 1–8. All four
  special-attention areas verified: **(a)** the capture-phase host keydown
  listener is registered in `ngAfterViewInit` AND removed via `destroyRef`
  (no leak — proven by the destroy-cleanup spec); **(b)** no double-fire — the
  old bubble-phase `@HostListener` and its import are removed, leaving exactly
  one host dispatch site through the idempotent `triggerX()` surface, with both
  capture sites funnelling through it; **(c)** `matchShortcut` matches `altKey`+
  `event.code` even for composing events (`keyCode:229`/`isComposing`/`key:'Dead'`)
  and `preventDefault`s including the no-op-by-enablement case; **(d)** the `can*`
  getters and all existing handlers are unchanged. No ADR-string test assertions
  (Golden Rule #8); changes confined to the namespace-panel component (Golden
  Rule #4). No HIGH/MEDIUM issues; no review fixup commit needed. Local gates
  green: namespace-panel Karma **175/175 SUCCESS**, ESLint clean, `ng build`
  succeeds (pre-existing lodash-CJS warning only). **Green CI is necessary but
  NOT sufficient for AC 8 — see the manual-verification note below.**

## Epic 22 slice complete

All four stories of Epic 22 are dev- and review-complete and confined to
`packages/akgentic-frontend/`:

- **22-1** — collapsed the `view`/`edit` two-mode state machine into a single
  `buffer !== serverYaml` dirty signal; always-editable panel + dirty-driven
  action row (ADR-017 §1–§6).
- **22-2** — five ⌥-key action-row shortcuts (⌥S/⌥V/⌥R/⌥⇧C/⌥D) over a shared
  `can*` enablement + `triggerX()` dispatch surface, two capture sites
  (HostListener + Monaco) (ADR-017 §7).
- **22-3** — replaced the generic `<p-confirmDialog>` with a panel-owned custom
  confirmation modal; safety-first keyboard, two-button Save-drift contract,
  uniform secondary-modal Esc/backdrop contract, scoped danger styling
  (ADR-018 §1–§4).
- **22-4** — hardened the ⌥-chords against macOS dead-key / IME composition and
  made the host capture-phase listener the authoritative path (ADR-018 §5).

Local gates across the epic: full frontend Karma suite green, ESLint clean,
`ng build` succeeds (only the pre-existing, unrelated lodash CommonJS bailout
warning).

> ### ⚠ Manual verification pending — Epic 22 is NOT truly shipped until this is confirmed
>
> **Story 22-4's ⌥V macOS dead-key fix is unit-gated ONLY.** This defect does
> **not** reproduce under Karma — synthetic `KeyboardEvent`s bypass the OS
> composition layer, so a green pipeline is **necessary but NOT sufficient** to
> close Story 22-4 (AC 8). The operator **MUST confirm on a real Mac**, with the
> operator's actual keyboard layout, with the editor **both focused AND
> unfocused**, that:
>
> - ⌥V triggers **Validate** — the previously-failing chord — **without** holding Shift,
> - ⌥S triggers **Save** (when dirty),
> - ⌥R triggers **Reset** (when dirty),
> - ⌥⇧C triggers **Clone** (when clean),
> - ⌥D opens the **Delete** confirm,
> - and **no dead-key glyph** is inserted into the editor by any of these chords.
>
> Until the operator explicitly confirms the above on a real Mac, AC 8 stays
> **open** and Epic 22 is **not** considered fully shipped, even with all checks
> green.

## Scope guard

All changes are confined to `packages/akgentic-frontend/`
(`namespace-panel.component.{ts,html}` + the sibling specs and host wiring). No
backend, catalog-protocol, or other-submodule change; every catalog endpoint
(`exportNamespace`, `importNamespace`, `validateNamespaceBuffer`,
`deleteNamespace`) is reused as-is. The doc-sync target
(`_bmad-output/akgentic-frontend/architecture/09-catalog-admin.md`) and
sprint-status are planning artifacts outside the submodule.
