### PR TITLE
feat(akgentic-frontend): epic 23 — Workspace sub-tabs from a per-agent WorkspaceTool registry (23-1-workspace-protocol-model-and-workspace-registry-selector → 23-3-workspace-sub-tabs-ui)

### DIFF
--- a/src/app/components/process/components/workspace-explorer/workspace-explorer.component.spec.ts
+++ b/src/app/components/process/components/workspace-explorer/workspace-explorer.component.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TreeNode } from 'primeng/api';
@@ -386,6 +386,135 @@ describe('WorkspaceExplorerComponent', () => {
       await component.handleUploadComplete();
 
       expect(workspaceServiceSpy.uploadFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- workspaceId threading (AC6, AC7) ------------------------------
+
+  describe('workspaceId threading', () => {
+    beforeEach(() => {
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+      workspaceServiceSpy.getFileContent.and.resolveTo({
+        content: 'x',
+        type: 'text',
+      });
+      workspaceServiceSpy.getDownloadUrl.and.returnValue('http://dl');
+      workspaceServiceSpy.uploadFiles.and.resolveTo();
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      component.processId = 'proc';
+    });
+
+    it('scenario 12 — set workspaceId threads as the trailing arg on every call', async () => {
+      component.workspaceId = 'ws-1';
+
+      // getWorkspaceTree via loadWorkspace
+      await component.loadWorkspace();
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledWith(
+        'proc',
+        '',
+        'ws-1'
+      );
+
+      // getWorkspaceTree via onNodeExpand
+      const subDir: TreeNode = {
+        label: 'sub',
+        data: fileNode({ name: 'sub', path: 'sub', type: 'directory' }),
+        leaf: false,
+        children: undefined,
+      };
+      await component.onNodeExpand({ node: subDir });
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledWith(
+        'proc',
+        'sub',
+        'ws-1'
+      );
+
+      // getFileContent via loadFileContent
+      await component.loadFileContent('docs/a.md');
+      expect(workspaceServiceSpy.getFileContent).toHaveBeenCalledWith(
+        'proc',
+        'docs/a.md',
+        'ws-1'
+      );
+
+      // getDownloadUrl via downloadFile
+      component.selectedFile = fileNode({
+        name: 'a.md',
+        path: 'docs/a.md',
+        type: 'file',
+      });
+      spyOn(window, 'open');
+      component.downloadFile();
+      expect(workspaceServiceSpy.getDownloadUrl).toHaveBeenCalledWith(
+        'proc',
+        'docs/a.md',
+        'ws-1'
+      );
+
+      // uploadFiles via handleUploadComplete
+      component.uploadTargetPath = 'docs';
+      component.uploadModal = {
+        getSelectedFiles: () => [new File(['x'], 'b.md')],
+      } as unknown as UploadModalComponent;
+      await component.handleUploadComplete();
+      expect(workspaceServiceSpy.uploadFiles).toHaveBeenCalledWith(
+        'proc',
+        jasmine.any(Array),
+        'docs',
+        'ws-1'
+      );
+    });
+
+    it('scenario 13 — unset workspaceId keeps the 2-arg getWorkspaceTree shape', async () => {
+      // workspaceId left undefined
+      await component.loadWorkspace();
+      expect(workspaceServiceSpy.getWorkspaceTree).toHaveBeenCalledOnceWith(
+        'proc',
+        ''
+      );
+    });
+  });
+
+  // --- ngOnChanges refetch (AC8) -------------------------------------
+
+  describe('ngOnChanges refetch', () => {
+    beforeEach(() => {
+      workspaceServiceSpy.getWorkspaceTree.and.resolveTo([]);
+      fixture = TestBed.createComponent(WorkspaceExplorerComponent);
+      component = fixture.componentInstance;
+      component.processId = 'proc';
+    });
+
+    it('scenario 14 — a non-first workspaceId change refetches the tree', () => {
+      const loadSpy = spyOn(component, 'loadWorkspace').and.resolveTo();
+
+      component.workspaceId = 'ws-2';
+      component.ngOnChanges({
+        workspaceId: new SimpleChange('ws-1', 'ws-2', false),
+      });
+
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('scenario 15 — the first (init) change does NOT trigger a refetch', () => {
+      const loadSpy = spyOn(component, 'loadWorkspace').and.resolveTo();
+
+      component.ngOnChanges({
+        workspaceId: new SimpleChange(undefined, 'ws-1', true),
+      });
+
+      expect(loadSpy).not.toHaveBeenCalled();
+    });
+
+    it('scenario 16 — an unchanged value does not refetch', () => {
+      const loadSpy = spyOn(component, 'loadWorkspace').and.resolveTo();
+
+      component.ngOnChanges({
+        workspaceId: new SimpleChange('ws-1', 'ws-1', false),
+      });
+
+      expect(loadSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/process/components/workspace-explorer/workspace-explorer.component.ts
+++ b/src/app/components/process/components/workspace-explorer/workspace-explorer.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, inject, ViewChild } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  inject,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TreeModule } from 'primeng/tree';
 import { TreeNode } from 'primeng/api';
@@ -40,8 +48,16 @@ import { UploadModalComponent } from './upload-modal/upload-modal.component';
   templateUrl: './workspace-explorer.component.html',
   styleUrls: ['./workspace-explorer.component.scss'],
 })
-export class WorkspaceExplorerComponent implements OnInit {
+export class WorkspaceExplorerComponent implements OnInit, OnChanges {
   @ViewChild(UploadModalComponent) uploadModal!: UploadModalComponent;
+
+  /**
+   * Optional workspace addressed by this explorer (Epic 23 / ADR-019). Unset
+   * (the default tab / today's behaviour) ⇒ every WorkspaceService call omits
+   * `workspaceId`, so the backend falls back to `team_id`. When bound to a
+   * value it is threaded through every call; a later change refetches the tree.
+   */
+  @Input() workspaceId?: string;
 
   workspaceService = inject(WorkspaceService);
   contextService = inject(ContextService);
@@ -68,6 +84,29 @@ export class WorkspaceExplorerComponent implements OnInit {
     this.loadWorkspace();
   }
 
+  /**
+   * Refetch the tree when the bound `workspaceId` switches AFTER init. The
+   * first (init) input arrival is `firstChange` and is handled by ngOnInit's
+   * loadWorkspace — guarding on `!firstChange` avoids a double initial fetch.
+   * A change that does not alter the value is skipped (no redundant refetch).
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    const change = changes['workspaceId'];
+    if (!change || change.firstChange) return;
+    if (change.currentValue === change.previousValue) return;
+    this.loadWorkspace();
+  }
+
+  /**
+   * Fetch a directory listing, threading `workspaceId` only when set so the
+   * unset path keeps today's 2-arg call shape (and byte-identical URL).
+   */
+  private fetchTree(path: string): Promise<FileNode[]> {
+    return this.workspaceId
+      ? this.workspaceService.getWorkspaceTree(this.processId, path, this.workspaceId)
+      : this.workspaceService.getWorkspaceTree(this.processId, path);
+  }
+
   async checkProcessStatus() {
     this.isProcessRunning = await firstValueFrom(
       this.contextService.currentTeamRunning$,
@@ -81,7 +120,7 @@ export class WorkspaceExplorerComponent implements OnInit {
     this.errorMessage = null;
 
     try {
-      const tree = await this.workspaceService.getWorkspaceTree(this.processId);
+      const tree = await this.fetchTree('');
       const fileNodes = this.convertToTreeNodes(tree);
 
       // Add root node at the top
@@ -171,10 +210,7 @@ export class WorkspaceExplorerComponent implements OnInit {
     if (node.children !== undefined) return;
 
     try {
-      const children = await this.workspaceService.getWorkspaceTree(
-        this.processId,
-        fileNode.path
-      );
+      const children = await this.fetchTree(fileNode.path);
       node.children = this.convertToTreeNodes(children);
       // Re-assign the top-level array reference so Angular's default CD
       // picks up the mutation on a nested TreeNode's `children` property.
@@ -213,7 +249,8 @@ export class WorkspaceExplorerComponent implements OnInit {
     try {
       const result: FileContent = await this.workspaceService.getFileContent(
         this.processId,
-        path
+        path,
+        this.workspaceId
       );
 
       if (result.type === 'binary') {
@@ -239,7 +276,8 @@ export class WorkspaceExplorerComponent implements OnInit {
 
     const url = this.workspaceService.getDownloadUrl(
       this.processId,
-      this.selectedFile.path
+      this.selectedFile.path,
+      this.workspaceId
     );
     window.open(url, '_blank');
   }
@@ -314,7 +352,8 @@ export class WorkspaceExplorerComponent implements OnInit {
       await this.workspaceService.uploadFiles(
         this.processId,
         files,
-        this.uploadTargetPath
+        this.uploadTargetPath,
+        this.workspaceId
       );
 
       // Refresh ONLY the directory the user uploaded to — preserves the
@@ -336,10 +375,7 @@ export class WorkspaceExplorerComponent implements OnInit {
    * the next manual expand will lazy-fetch the fresh listing anyway.
    */
   private async refreshDirectory(path: string): Promise<void> {
-    const fresh = await this.workspaceService.getWorkspaceTree(
-      this.processId,
-      path
-    );
+    const fresh = await this.fetchTree(path);
     const freshNodes = this.convertToTreeNodes(fresh);
 
     if (path === '') {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -1,14 +1,12 @@
 <ng-container *ngIf="vm$ | async as vm">
   <!-- Single default workspace → header strip + single explorer, NO tab chrome -->
   <div *ngIf="vm.workspaces.length <= 1" class="workspace-pane">
-    <div class="workspace-header-strip">
-      <ng-container
-        *ngTemplateOutlet="
-          memberRow;
-          context: { d: vm.workspaces[0], agents: vm.agentsById }
-        "
-      ></ng-container>
-    </div>
+    <ng-container
+      *ngTemplateOutlet="
+        memberStrip;
+        context: { d: vm.workspaces[0], agents: vm.agentsById }
+      "
+    ></ng-container>
     <app-workspace-explorer></app-workspace-explorer>
   </div>
 
@@ -22,11 +20,9 @@
     <p-tabpanels>
       <p-tabpanel *ngFor="let d of vm.workspaces; let i = index" [value]="i.toString()">
         <div class="workspace-pane">
-          <div class="workspace-header-strip">
-            <ng-container
-              *ngTemplateOutlet="memberRow; context: { d: d, agents: vm.agentsById }"
-            ></ng-container>
-          </div>
+          <ng-container
+            *ngTemplateOutlet="memberStrip; context: { d: d, agents: vm.agentsById }"
+          ></ng-container>
           <app-workspace-explorer
             [workspaceId]="d.isDefault ? undefined : d.workspaceId"
           ></app-workspace-explorer>
@@ -37,14 +33,14 @@
 </ng-container>
 
 <!--
-  Reusable member-chip row (v1 = membership only — name + role, no RW level).
-  Access is per-workspace and depends on which agents mount a WorkspaceTool for
-  it — the default workspace is NOT implicitly "all members". Show the resolved
-  members for every workspace; when none declared access, say so neutrally.
+  Member-chip strip (v1 = membership only — name + role, no RW level).
+  A workspace is listed only because ≥1 agent declared access to it, so the
+  strip normally has members; if (defensively) empty, render nothing rather
+  than an empty bar — there is no "no access" state to display.
 -->
-<ng-template #memberRow let-d="d" let-agents="agents">
+<ng-template #memberStrip let-d="d" let-agents="agents">
   <ng-container *ngIf="resolveMembers(d, agents) as members">
-    <ng-container *ngIf="members.length > 0; else noAccess">
+    <div class="workspace-header-strip" *ngIf="members.length > 0">
       <span class="ws-access-label">Accessible by:</span>
       <p-chip
         *ngFor="let m of members"
@@ -52,9 +48,6 @@
         [label]="m.name"
         [pTooltip]="m.role"
       ></p-chip>
-    </ng-container>
-    <ng-template #noAccess>
-      <span class="ws-no-members">No members with declared access</span>
-    </ng-template>
+    </div>
   </ng-container>
 </ng-template>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -1,16 +1,31 @@
-<ng-container *ngIf="workspaces$ | async as ws">
-  <!-- Single default workspace → no tab chrome, identical to today -->
-  <app-workspace-explorer *ngIf="ws.length <= 1"></app-workspace-explorer>
+<ng-container *ngIf="vm$ | async as vm">
+  <!-- Single default workspace → header strip + single explorer, NO tab chrome -->
+  <ng-container *ngIf="vm.workspaces.length <= 1">
+    <div class="workspace-header-strip">
+      <ng-container
+        *ngTemplateOutlet="
+          memberRow;
+          context: { d: vm.workspaces[0], agents: vm.agentsById }
+        "
+      ></ng-container>
+    </div>
+    <app-workspace-explorer></app-workspace-explorer>
+  </ng-container>
 
   <!-- ≥1 named workspace → PrimeNG sub-tabs, one panel per descriptor -->
-  <p-tabs *ngIf="ws.length > 1" value="0">
+  <p-tabs *ngIf="vm.workspaces.length > 1" value="0">
     <p-tablist>
-      <p-tab *ngFor="let d of ws; let i = index" [value]="i.toString()">
+      <p-tab *ngFor="let d of vm.workspaces; let i = index" [value]="i.toString()">
         {{ d.label }}
       </p-tab>
     </p-tablist>
     <p-tabpanels>
-      <p-tabpanel *ngFor="let d of ws; let i = index" [value]="i.toString()">
+      <p-tabpanel *ngFor="let d of vm.workspaces; let i = index" [value]="i.toString()">
+        <div class="workspace-header-strip">
+          <ng-container
+            *ngTemplateOutlet="memberRow; context: { d: d, agents: vm.agentsById }"
+          ></ng-container>
+        </div>
         <app-workspace-explorer
           [workspaceId]="d.isDefault ? undefined : d.workspaceId"
         ></app-workspace-explorer>
@@ -18,3 +33,18 @@
     </p-tabpanels>
   </p-tabs>
 </ng-container>
+
+<!-- Reusable member-chip row (v1 = membership only — name + role, no RW level) -->
+<ng-template #memberRow let-d="d" let-agents="agents">
+  <ng-container *ngIf="d.isDefault && d.agentIds.length === 0; else chips">
+    <span class="ws-all-members">Team default — all members</span>
+  </ng-container>
+  <ng-template #chips>
+    <p-chip
+      *ngFor="let m of resolveMembers(d, agents)"
+      class="ws-member-chip"
+      [label]="m.name"
+      [pTooltip]="m.role"
+    ></p-chip>
+  </ng-template>
+</ng-template>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -1,13 +1,17 @@
 <ng-container *ngIf="vm$ | async as vm">
-  <!-- Single default workspace → header strip + single explorer, NO tab chrome -->
-  <div *ngIf="vm.workspaces.length <= 1" class="workspace-pane">
+  <!-- Exactly one workspace → header strip + single explorer, NO tab chrome -->
+  <div *ngIf="vm.workspaces.length === 1" class="workspace-pane">
     <ng-container
       *ngTemplateOutlet="
         memberStrip;
         context: { d: vm.workspaces[0], agents: vm.agentsById }
       "
     ></ng-container>
-    <app-workspace-explorer></app-workspace-explorer>
+    <app-workspace-explorer
+      [workspaceId]="
+        vm.workspaces[0].isDefault ? undefined : vm.workspaces[0].workspaceId
+      "
+    ></app-workspace-explorer>
   </div>
 
   <!-- ≥1 named workspace → PrimeNG sub-tabs, one panel per descriptor -->

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -33,20 +33,24 @@
 </ng-container>
 
 <!--
-  Member-chip strip (v1 = membership only — name + role, no RW level).
-  A workspace is listed only because ≥1 agent declared access to it, so the
-  strip normally has members; if (defensively) empty, render nothing rather
-  than an empty bar — there is no "no access" state to display.
+  Member-chip strip (v1 = membership only — name only, no RW level).
+  The strip always renders (with its divider): "Accessible by: <chips>" when
+  the workspace has members, otherwise a neutral "no members" message.
 -->
 <ng-template #memberStrip let-d="d" let-agents="agents">
   <ng-container *ngIf="resolveMembers(d, agents) as members">
-    <div class="workspace-header-strip" *ngIf="members.length > 0">
-      <span class="ws-access-label">Accessible by:</span>
-      <p-chip
-        *ngFor="let m of members"
-        class="ws-member-chip"
-        [label]="m.name"
-      ></p-chip>
+    <div class="workspace-header-strip">
+      <ng-container *ngIf="members.length > 0; else noMembers">
+        <span class="ws-access-label">Accessible by:</span>
+        <p-chip
+          *ngFor="let m of members"
+          class="ws-member-chip"
+          [label]="m.name"
+        ></p-chip>
+      </ng-container>
+      <ng-template #noMembers>
+        <span class="ws-access-label">No members can access this workspace</span>
+      </ng-template>
     </div>
   </ng-container>
 </ng-template>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -46,7 +46,6 @@
         *ngFor="let m of members"
         class="ws-member-chip"
         [label]="m.name"
-        [pTooltip]="m.role"
       ></p-chip>
     </div>
   </ng-container>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="vm$ | async as vm">
   <!-- Single default workspace → header strip + single explorer, NO tab chrome -->
-  <ng-container *ngIf="vm.workspaces.length <= 1">
+  <div *ngIf="vm.workspaces.length <= 1" class="workspace-pane">
     <div class="workspace-header-strip">
       <ng-container
         *ngTemplateOutlet="
@@ -10,7 +10,7 @@
       ></ng-container>
     </div>
     <app-workspace-explorer></app-workspace-explorer>
-  </ng-container>
+  </div>
 
   <!-- ≥1 named workspace → PrimeNG sub-tabs, one panel per descriptor -->
   <p-tabs *ngIf="vm.workspaces.length > 1" value="0">
@@ -21,30 +21,40 @@
     </p-tablist>
     <p-tabpanels>
       <p-tabpanel *ngFor="let d of vm.workspaces; let i = index" [value]="i.toString()">
-        <div class="workspace-header-strip">
-          <ng-container
-            *ngTemplateOutlet="memberRow; context: { d: d, agents: vm.agentsById }"
-          ></ng-container>
+        <div class="workspace-pane">
+          <div class="workspace-header-strip">
+            <ng-container
+              *ngTemplateOutlet="memberRow; context: { d: d, agents: vm.agentsById }"
+            ></ng-container>
+          </div>
+          <app-workspace-explorer
+            [workspaceId]="d.isDefault ? undefined : d.workspaceId"
+          ></app-workspace-explorer>
         </div>
-        <app-workspace-explorer
-          [workspaceId]="d.isDefault ? undefined : d.workspaceId"
-        ></app-workspace-explorer>
       </p-tabpanel>
     </p-tabpanels>
   </p-tabs>
 </ng-container>
 
-<!-- Reusable member-chip row (v1 = membership only — name + role, no RW level) -->
+<!--
+  Reusable member-chip row (v1 = membership only — name + role, no RW level).
+  Access is per-workspace and depends on which agents mount a WorkspaceTool for
+  it — the default workspace is NOT implicitly "all members". Show the resolved
+  members for every workspace; when none declared access, say so neutrally.
+-->
 <ng-template #memberRow let-d="d" let-agents="agents">
-  <ng-container *ngIf="d.isDefault && d.agentIds.length === 0; else chips">
-    <span class="ws-all-members">Team default — all members</span>
+  <ng-container *ngIf="resolveMembers(d, agents) as members">
+    <ng-container *ngIf="members.length > 0; else noAccess">
+      <span class="ws-access-label">Accessible by:</span>
+      <p-chip
+        *ngFor="let m of members"
+        class="ws-member-chip"
+        [label]="m.name"
+        [pTooltip]="m.role"
+      ></p-chip>
+    </ng-container>
+    <ng-template #noAccess>
+      <span class="ws-no-members">No members with declared access</span>
+    </ng-template>
   </ng-container>
-  <ng-template #chips>
-    <p-chip
-      *ngFor="let m of resolveMembers(d, agents)"
-      class="ws-member-chip"
-      [label]="m.name"
-      [pTooltip]="m.role"
-    ></p-chip>
-  </ng-template>
 </ng-template>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.html
@@ -1,0 +1,20 @@
+<ng-container *ngIf="workspaces$ | async as ws">
+  <!-- Single default workspace → no tab chrome, identical to today -->
+  <app-workspace-explorer *ngIf="ws.length <= 1"></app-workspace-explorer>
+
+  <!-- ≥1 named workspace → PrimeNG sub-tabs, one panel per descriptor -->
+  <p-tabs *ngIf="ws.length > 1" value="0">
+    <p-tablist>
+      <p-tab *ngFor="let d of ws; let i = index" [value]="i.toString()">
+        {{ d.label }}
+      </p-tab>
+    </p-tablist>
+    <p-tabpanels>
+      <p-tabpanel *ngFor="let d of ws; let i = index" [value]="i.toString()">
+        <app-workspace-explorer
+          [workspaceId]="d.isDefault ? undefined : d.workspaceId"
+        ></app-workspace-explorer>
+      </p-tabpanel>
+    </p-tabpanels>
+  </p-tabs>
+</ng-container>

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -1,25 +1,49 @@
 /*
  * Fill the full height of the visualization slot so the workspace panel
- * extends to the bottom — in both the single-default case (bare explorer)
- * and the tabbed case (PrimeNG <p-tabs>, which otherwise sizes to content).
+ * extends to the bottom — in both the single-default case (header strip +
+ * bare explorer) and the tabbed case (PrimeNG <p-tabs>, which otherwise sizes
+ * to content). A flex column so the slim header strip (Story 23-4) sizes to
+ * content and the explorer (or the tab chrome) flex-fills the remaining height.
  */
 :host {
-  display: block;
-  height: 100%;
-}
-
-/* Single-default case: the bare explorer is a direct child of the host. */
-app-workspace-explorer {
-  display: block;
-  height: 100%;
-}
-
-/* Tabbed case: stack the tablist over a flex-filling panels area so the
- * hosted explorer reaches the bottom edge. */
-:host ::ng-deep .p-tabs {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+/* Slim header strip (Story 23-4): a thin horizontal member-chip row above the
+ * explorer in BOTH branches. It is NOT a tab bar — it never reintroduces tab
+ * chrome in the single-default branch (FR13). */
+.workspace-header-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  min-height: 2rem;
+}
+
+.workspace-header-strip .ws-all-members {
+  font-size: 0.875rem;
+  opacity: 0.7;
+}
+
+/* Single-default case: the bare explorer follows the header strip and fills
+ * the remaining height. */
+app-workspace-explorer {
+  display: block;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Tabbed case: the <p-tabs> is the flex-filling child of the host; stack the
+ * tablist over a flex-filling panels area so the hosted explorer reaches the
+ * bottom edge. */
+:host ::ng-deep .p-tabs {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 :host ::ng-deep .p-tabpanels {
@@ -27,6 +51,10 @@ app-workspace-explorer {
   min-height: 0;
 }
 
+/* Each panel stacks its own header strip over its explorer (flex column) so
+ * the explorer fills the panel below the strip. */
 :host ::ng-deep .p-tabpanel {
+  display: flex;
+  flex-direction: column;
   height: 100%;
 }

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -2,8 +2,7 @@
  * Fill the full height of the visualization slot so the workspace panel
  * extends to the bottom — in both the single-default case (header strip +
  * bare explorer) and the tabbed case (PrimeNG <p-tabs>, which otherwise sizes
- * to content). A flex column so the slim header strip (Story 23-4) sizes to
- * content and the explorer (or the tab chrome) flex-fills the remaining height.
+ * to content).
  */
 :host {
   display: flex;
@@ -11,9 +10,29 @@
   height: 100%;
 }
 
-/* Slim header strip (Story 23-4): a thin horizontal member-chip row above the
- * explorer in BOTH branches. It is NOT a tab bar — it never reintroduces tab
- * chrome in the single-default branch (FR13). */
+/*
+ * Strip + explorer pane (Story 23-4). A GRID, not a flex column: the slim
+ * header strip takes its content height (auto) and the explorer fills the
+ * remaining height (1fr). Grid is deterministic here where flex was not — the
+ * explorer carries its own `height: 100%`, which under flex inflated its basis
+ * and pushed the strip past the bottom edge; against a 1fr grid track that
+ * same `height: 100%` simply resolves to the track and fills it.
+ */
+.workspace-pane {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+
+/* Single-default branch: the pane is the flex-filling child of the host. */
+:host > .workspace-pane {
+  flex: 1 1 auto;
+}
+
+/* Slim header strip: a thin horizontal member-chip row above the explorer in
+ * BOTH branches. It is NOT a tab bar — it never reintroduces tab chrome in the
+ * single-default branch (ADR-019 FR13). */
 .workspace-header-strip {
   display: flex;
   flex-wrap: wrap;
@@ -23,22 +42,28 @@
   min-height: 2rem;
 }
 
-.workspace-header-strip .ws-all-members {
+.workspace-header-strip .ws-access-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  opacity: 0.7;
+  margin-right: 0.25rem;
+}
+
+.workspace-header-strip .ws-no-members {
   font-size: 0.875rem;
   opacity: 0.7;
 }
 
-/* Single-default case: the bare explorer follows the header strip and fills
- * the remaining height. */
-app-workspace-explorer {
+/* The explorer fills its grid row (1fr); its own `height: 100%` now resolves
+ * against that definite track. */
+.workspace-pane > app-workspace-explorer {
   display: block;
-  flex: 1 1 auto;
+  height: 100%;
   min-height: 0;
 }
 
-/* Tabbed case: the <p-tabs> is the flex-filling child of the host; stack the
- * tablist over a flex-filling panels area so the hosted explorer reaches the
- * bottom edge. */
+/* Tabbed case: fill the PrimeNG tab chain to the host height so each panel's
+ * pane reaches the bottom edge. */
 :host ::ng-deep .p-tabs {
   display: flex;
   flex-direction: column;
@@ -51,10 +76,7 @@ app-workspace-explorer {
   min-height: 0;
 }
 
-/* Each panel stacks its own header strip over its explorer (flex column) so
- * the explorer fills the panel below the strip. */
 :host ::ng-deep .p-tabpanel {
-  display: flex;
-  flex-direction: column;
   height: 100%;
+  min-height: 0;
 }

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -50,7 +50,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.125rem 0.5rem;
+  padding: 0.375rem 0.625rem;
 }
 
 .workspace-header-strip .ws-access-label {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -60,19 +60,6 @@
   margin-right: 0.125rem;
 }
 
-/* Compact chips — minimal padding/size so the strip uses as little space as
- * possible. */
-:host ::ng-deep .ws-member-chip {
-  font-size: 0.75rem;
-}
-
-:host ::ng-deep .ws-member-chip.p-chip,
-:host ::ng-deep .ws-member-chip .p-chip {
-  padding: 0.0625rem 0.4rem;
-  min-height: 0;
-  border-radius: 0.75rem;
-}
-
 /* Tabbed case: fill the PrimeNG tab chain to the host height and strip the
  * default tabpanel padding (token --p-tabs-tabpanel-padding) so the strip sits
  * directly under the tablist. */

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -1,0 +1,32 @@
+/*
+ * Fill the full height of the visualization slot so the workspace panel
+ * extends to the bottom — in both the single-default case (bare explorer)
+ * and the tabbed case (PrimeNG <p-tabs>, which otherwise sizes to content).
+ */
+:host {
+  display: block;
+  height: 100%;
+}
+
+/* Single-default case: the bare explorer is a direct child of the host. */
+app-workspace-explorer {
+  display: block;
+  height: 100%;
+}
+
+/* Tabbed case: stack the tablist over a flex-filling panels area so the
+ * hosted explorer reaches the bottom edge. */
+:host ::ng-deep .p-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+:host ::ng-deep .p-tabpanels {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+:host ::ng-deep .p-tabpanel {
+  height: 100%;
+}

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -55,7 +55,7 @@
    * no-members text, so clamp both to a min-height that fits a chip (vertically
    * centred). box-sizing: border-box so the padding + border are included. */
   box-sizing: border-box;
-  min-height: 3rem;
+  min-height: 3.2rem;
   /* Same separator as the explorer toolbar / file-header rows. The fallback
    * is required: --surface-border is not defined in this component's scope, so
    * without it the var() is invalid and the whole border declaration drops. */

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -12,11 +12,10 @@
 
 /*
  * Strip + explorer pane (Story 23-4). A GRID, not a flex column: the slim
- * header strip takes its content height (auto) and the explorer fills the
- * remaining height (1fr). Grid is deterministic here where flex was not — the
- * explorer carries its own `height: 100%`, which under flex inflated its basis
- * and pushed the strip past the bottom edge; against a 1fr grid track that
- * same `height: 100%` simply resolves to the track and fills it.
+ * header strip takes its content height (auto, row 1) and the explorer fills
+ * the remaining height (1fr, row 2). Rows are assigned EXPLICITLY so the
+ * explorer always lands in the 1fr track even when the strip is absent (a
+ * workspace with no declared members renders no strip).
  */
 .workspace-pane {
   display: grid;
@@ -30,40 +29,53 @@
   flex: 1 1 auto;
 }
 
-/* Slim header strip: a thin horizontal member-chip row above the explorer in
- * BOTH branches. It is NOT a tab bar — it never reintroduces tab chrome in the
- * single-default branch (ADR-019 FR13). */
-.workspace-header-strip {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.5rem;
-  min-height: 2rem;
+.workspace-pane > .workspace-header-strip {
+  grid-row: 1;
 }
 
-.workspace-header-strip .ws-access-label {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  opacity: 0.7;
-  margin-right: 0.25rem;
-}
-
-.workspace-header-strip .ws-no-members {
-  font-size: 0.875rem;
-  opacity: 0.7;
-}
-
-/* The explorer fills its grid row (1fr); its own `height: 100%` now resolves
+/* The explorer always occupies the 1fr row; its own height:100% resolves
  * against that definite track. */
 .workspace-pane > app-workspace-explorer {
+  grid-row: 2;
   display: block;
   height: 100%;
   min-height: 0;
 }
 
-/* Tabbed case: fill the PrimeNG tab chain to the host height so each panel's
- * pane reaches the bottom edge. */
+/* Slim header strip: a thin member-chip row above the explorer in BOTH
+ * branches, with minimal vertical space. It is NOT a tab bar — it never
+ * reintroduces tab chrome in the single-default branch (ADR-019 FR13). */
+.workspace-header-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+}
+
+.workspace-header-strip .ws-access-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  opacity: 0.65;
+  margin-right: 0.125rem;
+}
+
+/* Compact chips — minimal padding/size so the strip uses as little space as
+ * possible. */
+:host ::ng-deep .ws-member-chip {
+  font-size: 0.75rem;
+}
+
+:host ::ng-deep .ws-member-chip.p-chip,
+:host ::ng-deep .ws-member-chip .p-chip {
+  padding: 0.0625rem 0.4rem;
+  min-height: 0;
+  border-radius: 0.75rem;
+}
+
+/* Tabbed case: fill the PrimeNG tab chain to the host height and strip the
+ * default tabpanel padding (token --p-tabs-tabpanel-padding) so the strip sits
+ * directly under the tablist. */
 :host ::ng-deep .p-tabs {
   display: flex;
   flex-direction: column;
@@ -74,9 +86,11 @@
 :host ::ng-deep .p-tabpanels {
   flex: 1 1 auto;
   min-height: 0;
+  padding: 0;
 }
 
 :host ::ng-deep .p-tabpanel {
   height: 100%;
   min-height: 0;
+  padding: 0;
 }

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -50,11 +50,15 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.375rem 0.625rem;
+  padding: 0.5rem 0.75rem;
+  /* Same separator as the explorer toolbar / file-header rows. The fallback
+   * is required: --surface-border is not defined in this component's scope, so
+   * without it the var() is invalid and the whole border declaration drops. */
+  border-bottom: 1px solid var(--surface-border, #dee2e6);
 }
 
 .workspace-header-strip .ws-access-label {
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   font-weight: 600;
   opacity: 0.65;
   margin-right: 0.125rem;

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.scss
@@ -51,6 +51,11 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.5rem 0.75rem;
+  /* Same height with and without members: a chip is taller than the plain
+   * no-members text, so clamp both to a min-height that fits a chip (vertically
+   * centred). box-sizing: border-box so the padding + border are included. */
+  box-sizing: border-box;
+  min-height: 3rem;
   /* Same separator as the explorer toolbar / file-header rows. The fallback
    * is required: --surface-border is not defined in this component's scope, so
    * without it the var() is invalid and the whole border declaration drops. */

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -256,17 +256,16 @@ describe('WorkspaceTabsComponent', () => {
     expect(tooltips).toEqual(['Scrum Master', 'Developer']);
   });
 
-  it('(AC4) descriptor with no declared members → neutral "no access" text, no chips', () => {
+  it('(AC4) descriptor with no declared members → no strip rendered (no empty bar)', () => {
+    // A workspace is only ever listed because ≥1 agent declared access, so an
+    // empty member set is not a real state to label — render no strip at all.
     registry.workspaces$.next([defaultDescriptor([])]);
     agents.agentsById$.next({});
     fixture.detectChanges();
 
     expect(chipLabels()).toEqual([]);
-    const text = (
-      fixture.debugElement.query(By.css('.ws-no-members'))
-        .nativeElement.textContent as string
-    ).trim();
-    expect(text).toBe('No members with declared access');
+    expect(strips()).toBe(0);
+    expect(fixture.debugElement.query(By.css('.ws-no-members'))).toBeNull();
   });
 
   it('(AC4b) the default workspace is NOT treated as "all members" — chips reflect its agentIds', () => {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Tabs } from 'primeng/tabs';
-import { Tooltip } from 'primeng/tooltip';
 import { BehaviorSubject } from 'rxjs';
 
 import { ContextService } from '../../../../core/context/context.service';
@@ -233,7 +232,7 @@ describe('WorkspaceTabsComponent', () => {
     expect(hasTabChrome()).toBe(false);
   });
 
-  it('(AC3) one chip per member, names in agentIds order, role as tooltip', () => {
+  it('(AC3) one chip per member, names in agentIds order', () => {
     registry.workspaces$.next([
       defaultDescriptor(),
       namedDescriptor('ws-named', ['a1', 'a2']),
@@ -247,13 +246,6 @@ describe('WorkspaceTabsComponent', () => {
     // The named workspace's members are visible on its (active) panel.
     activateTab(1);
     expect(chipLabels()).toEqual(['Bob', 'Amelia']);
-
-    // Each chip exposes its role via the pTooltip binding (Tooltip.content is
-    // the `pTooltip` input's property alias).
-    const tooltips = fixture.debugElement
-      .queryAll(By.directive(Tooltip))
-      .map((de) => (de.injector.get(Tooltip) as Tooltip).content);
-    expect(tooltips).toEqual(['Scrum Master', 'Developer']);
   });
 
   it('(AC4) descriptor with no declared members → no strip rendered (no empty bar)', () => {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -4,10 +4,15 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Tabs } from 'primeng/tabs';
+import { Tooltip } from 'primeng/tooltip';
 import { BehaviorSubject } from 'rxjs';
 
 import { ContextService } from '../../../../core/context/context.service';
 import { WorkspaceService } from '../../workspace/workspace.service';
+import {
+  AgentsById,
+  AgentsByIdService,
+} from '../../selectors/agents-by-id.selector';
 import {
   WorkspaceDescriptor,
   WorkspaceRegistryService,
@@ -21,20 +26,23 @@ import { WorkspaceTabsComponent } from './workspace-tabs.component';
 
 const TEAM_ID = 'team-1';
 
-function defaultDescriptor(): WorkspaceDescriptor {
+function defaultDescriptor(agentIds: string[] = []): WorkspaceDescriptor {
   return {
     workspaceId: TEAM_ID,
     isDefault: true,
-    agentIds: [],
+    agentIds,
     label: 'Default workspace',
   };
 }
 
-function namedDescriptor(workspaceId: string): WorkspaceDescriptor {
+function namedDescriptor(
+  workspaceId: string,
+  agentIds: string[] = ['agent-A'],
+): WorkspaceDescriptor {
   return {
     workspaceId,
     isDefault: false,
-    agentIds: ['agent-A'],
+    agentIds,
     label: workspaceId,
   };
 }
@@ -46,12 +54,19 @@ class FakeWorkspaceRegistryService {
   ]);
 }
 
+/** Fake identity map exposing a BehaviorSubject the test drives directly. */
+class FakeAgentsByIdService {
+  readonly agentsById$ = new BehaviorSubject<AgentsById>({});
+}
+
 describe('WorkspaceTabsComponent', () => {
   let fixture: ComponentFixture<WorkspaceTabsComponent>;
   let registry: FakeWorkspaceRegistryService;
+  let agents: FakeAgentsByIdService;
 
   beforeEach(async () => {
     registry = new FakeWorkspaceRegistryService();
+    agents = new FakeAgentsByIdService();
 
     const contextStub = {
       currentProcessId$: new BehaviorSubject<string>('proc'),
@@ -72,11 +87,13 @@ describe('WorkspaceTabsComponent', () => {
         { provide: WorkspaceService, useValue: workspaceStub },
       ],
     })
-      // Drive `workspaces$` directly via the component-scoped registry.
+      // Drive `workspaces$` / `agentsById$` directly via the component-scoped
+      // services.
       .overrideComponent(WorkspaceTabsComponent, {
         set: {
           providers: [
             { provide: WorkspaceRegistryService, useValue: registry },
+            { provide: AgentsByIdService, useValue: agents },
           ],
         },
       })
@@ -108,6 +125,17 @@ describe('WorkspaceTabsComponent', () => {
     );
   }
 
+  function chipLabels(): string[] {
+    return fixture.debugElement
+      .queryAll(By.css('p-chip'))
+      .map((de) => (de.nativeElement.textContent as string).trim());
+  }
+
+  function strips(): number {
+    return fixture.debugElement.queryAll(By.css('.workspace-header-strip'))
+      .length;
+  }
+
   /**
    * Activate the tab at `index`. PrimeNG 19's `<p-tabpanel>` renders ONLY the
    * active panel's content (`@if (active())`), so each tab's explorer is
@@ -121,7 +149,11 @@ describe('WorkspaceTabsComponent', () => {
     fixture.detectChanges();
   }
 
-  it('(AC3) default-only → one explorer, no tab chrome, workspaceId undefined', () => {
+  // -------------------------------------------------------------------
+  // Story 23-3 sub-tab behaviour (must stay green — AC6 no churn).
+  // -------------------------------------------------------------------
+
+  it('(23-3 AC3) default-only → one explorer, no tab chrome, workspaceId undefined', () => {
     registry.workspaces$.next([defaultDescriptor()]);
     fixture.detectChanges();
 
@@ -131,7 +163,7 @@ describe('WorkspaceTabsComponent', () => {
     expect(found[0].workspaceId).toBeUndefined();
   });
 
-  it('(AC1, AC2, AC4) default + 1 named → tab chrome, one panel per descriptor, correct bindings', () => {
+  it('(23-3 AC1, AC2, AC4) default + 1 named → tab chrome, one panel per descriptor, correct bindings', () => {
     registry.workspaces$.next([
       defaultDescriptor(),
       namedDescriptor('ws-named'),
@@ -157,7 +189,7 @@ describe('WorkspaceTabsComponent', () => {
     expect(found[0].workspaceId).toBe('ws-named');
   });
 
-  it('(AC5) tab labels render from descriptor.label', () => {
+  it('(23-3 AC5) tab labels render from descriptor.label', () => {
     registry.workspaces$.next([
       defaultDescriptor(),
       namedDescriptor('ws-named'),
@@ -170,7 +202,7 @@ describe('WorkspaceTabsComponent', () => {
     expect(labels).toEqual(['Default workspace', 'ws-named']);
   });
 
-  it('(AC6) reactive re-emission re-renders the sub-tabs', () => {
+  it('(23-3 AC6) reactive re-emission re-renders the sub-tabs', () => {
     registry.workspaces$.next([defaultDescriptor()]);
     fixture.detectChanges();
     expect(explorers().length).toBe(1);
@@ -185,5 +217,83 @@ describe('WorkspaceTabsComponent', () => {
     fixture.detectChanges();
     expect(hasTabChrome()).toBe(true);
     expect(fixture.debugElement.queryAll(By.css('p-tabpanel')).length).toBe(2);
+  });
+
+  // -------------------------------------------------------------------
+  // Story 23-4 member-chip header strip.
+  // -------------------------------------------------------------------
+
+  it('(AC2) single-default → strip above the bare explorer, NO tab chrome', () => {
+    registry.workspaces$.next([defaultDescriptor(['a1'])]);
+    agents.agentsById$.next({ a1: { name: 'Bob', role: 'Scrum Master' } });
+    fixture.detectChanges();
+
+    expect(strips()).toBe(1);
+    expect(explorers().length).toBe(1);
+    expect(hasTabChrome()).toBe(false);
+  });
+
+  it('(AC3) one chip per member, names in agentIds order, role as tooltip', () => {
+    registry.workspaces$.next([
+      defaultDescriptor(),
+      namedDescriptor('ws-named', ['a1', 'a2']),
+    ]);
+    agents.agentsById$.next({
+      a1: { name: 'Bob', role: 'Scrum Master' },
+      a2: { name: 'Amelia', role: 'Developer' },
+    });
+    fixture.detectChanges();
+
+    // The named workspace's members are visible on its (active) panel.
+    activateTab(1);
+    expect(chipLabels()).toEqual(['Bob', 'Amelia']);
+
+    // Each chip exposes its role via the pTooltip binding (Tooltip.content is
+    // the `pTooltip` input's property alias).
+    const tooltips = fixture.debugElement
+      .queryAll(By.directive(Tooltip))
+      .map((de) => (de.injector.get(Tooltip) as Tooltip).content);
+    expect(tooltips).toEqual(['Scrum Master', 'Developer']);
+  });
+
+  it('(AC4) empty default descriptor → "Team default — all members", no chips', () => {
+    registry.workspaces$.next([defaultDescriptor([])]);
+    agents.agentsById$.next({});
+    fixture.detectChanges();
+
+    expect(chipLabels()).toEqual([]);
+    const text = (
+      fixture.debugElement.query(By.css('.ws-all-members'))
+        .nativeElement.textContent as string
+    ).trim();
+    expect(text).toBe('Team default — all members');
+  });
+
+  it('(AC5) selecting a sub-tab updates the chip row to that workspace members', () => {
+    registry.workspaces$.next([
+      defaultDescriptor(['d1']),
+      namedDescriptor('ws-named', ['n1', 'n2']),
+    ]);
+    agents.agentsById$.next({
+      d1: { name: 'Dana', role: 'Lead' },
+      n1: { name: 'Bob', role: 'Scrum Master' },
+      n2: { name: 'Amelia', role: 'Developer' },
+    });
+    fixture.detectChanges();
+
+    // Default tab (index 0) active first → its sole member.
+    expect(chipLabels()).toEqual(['Dana']);
+
+    // Switching to the named tab updates the strip to that workspace members.
+    activateTab(1);
+    expect(chipLabels()).toEqual(['Bob', 'Amelia']);
+  });
+
+  it('(AC3 defensive) unknown agent_id falls back to the raw id as the name', () => {
+    registry.workspaces$.next([defaultDescriptor(['ghost'])]);
+    agents.agentsById$.next({});
+    fixture.detectChanges();
+
+    expect(chipLabels()).toEqual(['ghost']);
   });
 });

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -1,0 +1,189 @@
+import { CommonModule } from '@angular/common';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Tabs } from 'primeng/tabs';
+import { BehaviorSubject } from 'rxjs';
+
+import { ContextService } from '../../../../core/context/context.service';
+import { WorkspaceService } from '../../workspace/workspace.service';
+import {
+  WorkspaceDescriptor,
+  WorkspaceRegistryService,
+} from '../../selectors/workspace-registry.selector';
+import { WorkspaceExplorerComponent } from '../workspace-explorer/workspace-explorer.component';
+import { WorkspaceTabsComponent } from './workspace-tabs.component';
+
+// --------------------------------------------------------------------
+// Fixture helpers — descriptor shape mirrors workspace-registry.selector.
+// --------------------------------------------------------------------
+
+const TEAM_ID = 'team-1';
+
+function defaultDescriptor(): WorkspaceDescriptor {
+  return {
+    workspaceId: TEAM_ID,
+    isDefault: true,
+    agentIds: [],
+    label: 'Default workspace',
+  };
+}
+
+function namedDescriptor(workspaceId: string): WorkspaceDescriptor {
+  return {
+    workspaceId,
+    isDefault: false,
+    agentIds: ['agent-A'],
+    label: workspaceId,
+  };
+}
+
+/** Fake registry exposing a BehaviorSubject the test drives directly. */
+class FakeWorkspaceRegistryService {
+  readonly workspaces$ = new BehaviorSubject<WorkspaceDescriptor[]>([
+    defaultDescriptor(),
+  ]);
+}
+
+describe('WorkspaceTabsComponent', () => {
+  let fixture: ComponentFixture<WorkspaceTabsComponent>;
+  let registry: FakeWorkspaceRegistryService;
+
+  beforeEach(async () => {
+    registry = new FakeWorkspaceRegistryService();
+
+    const contextStub = {
+      currentProcessId$: new BehaviorSubject<string>('proc'),
+      currentTeamRunning$: new BehaviorSubject<boolean>(true),
+    };
+    const workspaceStub = jasmine.createSpyObj('WorkspaceService', [
+      'getWorkspaceTree',
+      'getFileContent',
+      'getDownloadUrl',
+      'uploadFiles',
+    ]);
+    workspaceStub.getWorkspaceTree.and.resolveTo([]);
+
+    await TestBed.configureTestingModule({
+      imports: [WorkspaceTabsComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ContextService, useValue: contextStub },
+        { provide: WorkspaceService, useValue: workspaceStub },
+      ],
+    })
+      // Drive `workspaces$` directly via the component-scoped registry.
+      .overrideComponent(WorkspaceTabsComponent, {
+        set: {
+          providers: [
+            { provide: WorkspaceRegistryService, useValue: registry },
+          ],
+        },
+      })
+      // Neutralise the explorer's heavy PrimeNG/markdown template so we can
+      // mount the REAL explorer (and read its `workspaceId` @Input) without
+      // pulling in its full render tree.
+      .overrideComponent(WorkspaceExplorerComponent, {
+        set: {
+          imports: [CommonModule],
+          template: '',
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(WorkspaceTabsComponent);
+  });
+
+  function explorers(): WorkspaceExplorerComponent[] {
+    return fixture.debugElement
+      .queryAll(By.directive(WorkspaceExplorerComponent))
+      .map((de) => de.componentInstance as WorkspaceExplorerComponent);
+  }
+
+  function hasTabChrome(): boolean {
+    return (
+      fixture.debugElement.query(By.css('p-tabs')) !== null ||
+      fixture.debugElement.query(By.css('p-tablist')) !== null
+    );
+  }
+
+  /**
+   * Activate the tab at `index`. PrimeNG 19's `<p-tabpanel>` renders ONLY the
+   * active panel's content (`@if (active())`), so each tab's explorer is
+   * mounted only while its panel is selected. Switching the `Tabs` value lets
+   * us inspect the explorer bound inside each panel in turn.
+   */
+  function activateTab(index: number): void {
+    const tabs = fixture.debugElement.query(By.directive(Tabs))
+      .componentInstance as Tabs;
+    tabs.value.set(index.toString());
+    fixture.detectChanges();
+  }
+
+  it('(AC3) default-only → one explorer, no tab chrome, workspaceId undefined', () => {
+    registry.workspaces$.next([defaultDescriptor()]);
+    fixture.detectChanges();
+
+    const found = explorers();
+    expect(found.length).toBe(1);
+    expect(hasTabChrome()).toBe(false);
+    expect(found[0].workspaceId).toBeUndefined();
+  });
+
+  it('(AC1, AC2, AC4) default + 1 named → tab chrome, one panel per descriptor, correct bindings', () => {
+    registry.workspaces$.next([
+      defaultDescriptor(),
+      namedDescriptor('ws-named'),
+    ]);
+    fixture.detectChanges();
+
+    expect(hasTabChrome()).toBe(true);
+    // One <p-tabpanel> per descriptor exists in the DOM (AC1)...
+    expect(fixture.debugElement.queryAll(By.css('p-tabpanel')).length).toBe(2);
+
+    // ...but PrimeNG mounts only the active panel's content, so we inspect
+    // each panel's bound explorer by activating its tab in turn.
+    // Default tab (index 0) is active by default: explorer keeps team-id-only
+    // behaviour (workspaceId undefined) (AC2).
+    let found = explorers();
+    expect(found.length).toBe(1);
+    expect(found[0].workspaceId).toBeUndefined();
+
+    // Named tab (index 1): explorer is bound to its workspace id (AC2).
+    activateTab(1);
+    found = explorers();
+    expect(found.length).toBe(1);
+    expect(found[0].workspaceId).toBe('ws-named');
+  });
+
+  it('(AC5) tab labels render from descriptor.label', () => {
+    registry.workspaces$.next([
+      defaultDescriptor(),
+      namedDescriptor('ws-named'),
+    ]);
+    fixture.detectChanges();
+
+    const labels = fixture.debugElement
+      .queryAll(By.css('p-tab'))
+      .map((de) => (de.nativeElement.textContent as string).trim());
+    expect(labels).toEqual(['Default workspace', 'ws-named']);
+  });
+
+  it('(AC6) reactive re-emission re-renders the sub-tabs', () => {
+    registry.workspaces$.next([defaultDescriptor()]);
+    fixture.detectChanges();
+    expect(explorers().length).toBe(1);
+    expect(hasTabChrome()).toBe(false);
+
+    // A later named-workspace discovery flips the view to tabbed chrome with
+    // one <p-tabpanel> per descriptor.
+    registry.workspaces$.next([
+      defaultDescriptor(),
+      namedDescriptor('ws-named'),
+    ]);
+    fixture.detectChanges();
+    expect(hasTabChrome()).toBe(true);
+    expect(fixture.debugElement.queryAll(By.css('p-tabpanel')).length).toBe(2);
+  });
+});

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -152,14 +152,39 @@ describe('WorkspaceTabsComponent', () => {
   // Story 23-3 sub-tab behaviour (must stay green — AC6 no churn).
   // -------------------------------------------------------------------
 
-  it('(23-3 AC3) default-only → one explorer, no tab chrome, workspaceId undefined', () => {
-    registry.workspaces$.next([defaultDescriptor()]);
+  it('(empty) no workspaces → renders nothing (parent hides the whole tab)', () => {
+    // A team with no WorkspaceTool yields an empty registry. The component
+    // renders nothing; the parent (ProcessComponent) hides the Workspaces tab
+    // entirely via hasWorkspace$, so no fabricated default is ever shown.
+    registry.workspaces$.next([]);
+    agents.agentsById$.next({});
+    fixture.detectChanges();
+
+    expect(explorers().length).toBe(0);
+    expect(hasTabChrome()).toBe(false);
+    expect(strips()).toBe(0);
+  });
+
+  it('(23-3 AC3) single default → one explorer, no tab chrome, workspaceId undefined', () => {
+    registry.workspaces$.next([defaultDescriptor(['a1'])]);
+    agents.agentsById$.next({ a1: { name: 'Bob', role: 'SM' } });
     fixture.detectChanges();
 
     const found = explorers();
     expect(found.length).toBe(1);
     expect(hasTabChrome()).toBe(false);
     expect(found[0].workspaceId).toBeUndefined();
+  });
+
+  it('(single named) one named workspace → explorer bound to its workspaceId, no tab chrome', () => {
+    registry.workspaces$.next([namedDescriptor('ws-solo', ['a1'])]);
+    agents.agentsById$.next({ a1: { name: 'Bob', role: 'SM' } });
+    fixture.detectChanges();
+
+    const found = explorers();
+    expect(found.length).toBe(1);
+    expect(hasTabChrome()).toBe(false);
+    expect(found[0].workspaceId).toBe('ws-solo');
   });
 
   it('(23-3 AC1, AC2, AC4) default + 1 named → tab chrome, one panel per descriptor, correct bindings', () => {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -248,16 +248,20 @@ describe('WorkspaceTabsComponent', () => {
     expect(chipLabels()).toEqual(['Bob', 'Amelia']);
   });
 
-  it('(AC4) descriptor with no declared members → no strip rendered (no empty bar)', () => {
-    // A workspace is only ever listed because ≥1 agent declared access, so an
-    // empty member set is not a real state to label — render no strip at all.
+  it('(AC4) workspace with no members → strip shows the no-members message, no chips', () => {
+    // A workspace can legitimately have zero members (members can be removed),
+    // so the strip renders and states that no members can access it.
     registry.workspaces$.next([defaultDescriptor([])]);
     agents.agentsById$.next({});
     fixture.detectChanges();
 
     expect(chipLabels()).toEqual([]);
-    expect(strips()).toBe(0);
-    expect(fixture.debugElement.query(By.css('.ws-no-members'))).toBeNull();
+    expect(strips()).toBe(1);
+    const text = (
+      fixture.debugElement.query(By.css('.workspace-header-strip'))
+        .nativeElement.textContent as string
+    ).trim();
+    expect(text).toContain('No members can access this workspace');
   });
 
   it('(AC4b) the default workspace is NOT treated as "all members" — chips reflect its agentIds', () => {
@@ -268,7 +272,9 @@ describe('WorkspaceTabsComponent', () => {
     fixture.detectChanges();
 
     expect(chipLabels()).toEqual(['Bob']);
-    expect(fixture.debugElement.query(By.css('.ws-no-members'))).toBeNull();
+    const text = fixture.debugElement.query(By.css('.workspace-header-strip'))
+      .nativeElement.textContent as string;
+    expect(text).not.toContain('No members');
   });
 
   it('(layout) header strip is rendered above the explorer within the pane', () => {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.spec.ts
@@ -256,17 +256,46 @@ describe('WorkspaceTabsComponent', () => {
     expect(tooltips).toEqual(['Scrum Master', 'Developer']);
   });
 
-  it('(AC4) empty default descriptor → "Team default — all members", no chips', () => {
+  it('(AC4) descriptor with no declared members → neutral "no access" text, no chips', () => {
     registry.workspaces$.next([defaultDescriptor([])]);
     agents.agentsById$.next({});
     fixture.detectChanges();
 
     expect(chipLabels()).toEqual([]);
     const text = (
-      fixture.debugElement.query(By.css('.ws-all-members'))
+      fixture.debugElement.query(By.css('.ws-no-members'))
         .nativeElement.textContent as string
     ).trim();
-    expect(text).toBe('Team default — all members');
+    expect(text).toBe('No members with declared access');
+  });
+
+  it('(AC4b) the default workspace is NOT treated as "all members" — chips reflect its agentIds', () => {
+    // Access is per-workspace and tool-dependent: a default workspace with one
+    // declared member shows that member, never an implicit "all members".
+    registry.workspaces$.next([defaultDescriptor(['agent-A'])]);
+    agents.agentsById$.next({ 'agent-A': { name: 'Bob', role: 'Scrum Master' } });
+    fixture.detectChanges();
+
+    expect(chipLabels()).toEqual(['Bob']);
+    expect(fixture.debugElement.query(By.css('.ws-no-members'))).toBeNull();
+  });
+
+  it('(layout) header strip is rendered above the explorer within the pane', () => {
+    registry.workspaces$.next([defaultDescriptor(['d1'])]);
+    agents.agentsById$.next({ d1: { name: 'Bob', role: 'SM' } });
+    fixture.detectChanges();
+
+    const pane = fixture.debugElement.query(By.css('.workspace-pane'))
+      .nativeElement as HTMLElement;
+    const strip = pane.querySelector('.workspace-header-strip');
+    const explorer = pane.querySelector('app-workspace-explorer');
+    expect(strip).not.toBeNull();
+    expect(explorer).not.toBeNull();
+    // The strip must precede the explorer in document order (strip on top).
+    expect(
+      strip!.compareDocumentPosition(explorer!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it('(AC5) selecting a sub-tab updates the chip row to that workspace members', () => {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
@@ -28,6 +28,7 @@ import { WorkspaceExplorerComponent } from '../workspace-explorer/workspace-expl
   standalone: true,
   imports: [CommonModule, TabsModule, WorkspaceExplorerComponent],
   templateUrl: './workspace-tabs.component.html',
+  styleUrl: './workspace-tabs.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkspaceTabsComponent {

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
@@ -1,0 +1,35 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { TabsModule } from 'primeng/tabs';
+
+import { WorkspaceRegistryService } from '../../selectors/workspace-registry.selector';
+import { WorkspaceExplorerComponent } from '../workspace-explorer/workspace-explorer.component';
+
+/**
+ * Workspace sub-tabs view — Story 23-3 (ADR-019 §Decision 4).
+ *
+ * Renders one PrimeNG `<p-tabpanel>` per `WorkspaceDescriptor` emitted by
+ * `WorkspaceRegistryService.workspaces$`, each hosting an
+ * `<app-workspace-explorer>`. A non-default descriptor binds its
+ * `workspaceId`; the default descriptor leaves the explorer's `workspaceId`
+ * unset (`undefined`) so it keeps today's team-id-only behaviour.
+ *
+ * When only the default descriptor is present the view renders a single
+ * explorer with NO tab chrome — visually identical to today's single-pane
+ * Workspace view (FR13). Tab chrome appears only once at least one named
+ * workspace is discovered.
+ *
+ * `WorkspaceRegistryService` is NOT re-provided here — it is provided by
+ * `ProcessComponent` so the view shares the component-scoped
+ * `MessageLogService` lifecycle.
+ */
+@Component({
+  selector: 'app-workspace-tabs',
+  standalone: true,
+  imports: [CommonModule, TabsModule, WorkspaceExplorerComponent],
+  templateUrl: './workspace-tabs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WorkspaceTabsComponent {
+  readonly workspaces$ = inject(WorkspaceRegistryService).workspaces$;
+}

--- a/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
+++ b/src/app/components/process/components/workspace-tabs/workspace-tabs.component.ts
@@ -1,12 +1,36 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { AvatarModule } from 'primeng/avatar';
+import { ChipModule } from 'primeng/chip';
 import { TabsModule } from 'primeng/tabs';
+import { TooltipModule } from 'primeng/tooltip';
+import { combineLatest, map, Observable } from 'rxjs';
 
-import { WorkspaceRegistryService } from '../../selectors/workspace-registry.selector';
+import {
+  AgentsById,
+  AgentsByIdService,
+} from '../../selectors/agents-by-id.selector';
+import {
+  WorkspaceDescriptor,
+  WorkspaceRegistryService,
+} from '../../selectors/workspace-registry.selector';
 import { WorkspaceExplorerComponent } from '../workspace-explorer/workspace-explorer.component';
 
+/** One resolved member row rendered as a chip (name + role). */
+interface MemberRow {
+  name: string;
+  role: string;
+}
+
+/** Combined view-model for the template (workspaces + identity map). */
+interface WorkspaceTabsVm {
+  workspaces: WorkspaceDescriptor[];
+  agentsById: AgentsById;
+}
+
 /**
- * Workspace sub-tabs view — Story 23-3 (ADR-019 §Decision 4).
+ * Workspace sub-tabs view — Story 23-3 (ADR-019 §Decision 4) + the member-chip
+ * header strip from Story 23-4 (ADR-020 §Decisions 1–4).
  *
  * Renders one PrimeNG `<p-tabpanel>` per `WorkspaceDescriptor` emitted by
  * `WorkspaceRegistryService.workspaces$`, each hosting an
@@ -19,18 +43,57 @@ import { WorkspaceExplorerComponent } from '../workspace-explorer/workspace-expl
  * Workspace view (FR13). Tab chrome appears only once at least one named
  * workspace is discovered.
  *
- * `WorkspaceRegistryService` is NOT re-provided here — it is provided by
- * `ProcessComponent` so the view shares the component-scoped
- * `MessageLogService` lifecycle.
+ * Story 23-4 adds a slim header strip ABOVE the explorer in BOTH branches
+ * (the strip is NOT a tab bar — FR13 stays intact): a member-chip row built
+ * from the descriptor's `agentIds` resolved to `{ name, role }` via
+ * `AgentsByIdService.agentsById$`. v1 surfaces MEMBERSHIP only (who) — no
+ * read/write access-level indicator. A default descriptor with an empty
+ * `agentIds` renders a neutral "Team default — all members" affordance.
+ *
+ * Neither `WorkspaceRegistryService` nor `AgentsByIdService` is re-provided
+ * here — both are provided by `ProcessComponent` so the view shares the
+ * component-scoped `MessageLogService` lifecycle.
  */
 @Component({
   selector: 'app-workspace-tabs',
   standalone: true,
-  imports: [CommonModule, TabsModule, WorkspaceExplorerComponent],
+  imports: [
+    CommonModule,
+    TabsModule,
+    ChipModule,
+    AvatarModule,
+    TooltipModule,
+    WorkspaceExplorerComponent,
+  ],
   templateUrl: './workspace-tabs.component.html',
   styleUrl: './workspace-tabs.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkspaceTabsComponent {
-  readonly workspaces$ = inject(WorkspaceRegistryService).workspaces$;
+  /**
+   * Combined stream of the discovered workspaces and the agent identity map.
+   * Both are pure folds over the same component-scoped `MessageLogService.log$`,
+   * each with a structural `distinctUntilChanged`, so the combined VM only
+   * re-emits when one of them changes structurally (OnPush-safe).
+   */
+  readonly vm$: Observable<WorkspaceTabsVm> = combineLatest([
+    inject(WorkspaceRegistryService).workspaces$,
+    inject(AgentsByIdService).agentsById$,
+  ]).pipe(map(([workspaces, agentsById]) => ({ workspaces, agentsById })));
+
+  /**
+   * Resolve a descriptor's `agentIds` to displayable member rows in the
+   * descriptor's `agentIds` order. Pure: no mutation, no side effects. An
+   * `agent_id` missing from the identity map (defensive — should not happen
+   * for a live descriptor) falls back to the raw `agent_id` as the name with
+   * an empty role rather than dropping the chip.
+   */
+  resolveMembers(d: WorkspaceDescriptor, agentsById: AgentsById): MemberRow[] {
+    return d.agentIds.map((id) => {
+      const identity = agentsById[id];
+      return identity
+        ? { name: identity.name, role: identity.role }
+        : { name: id, role: '' };
+    });
+  }
 }

--- a/src/app/components/process/process.component.html
+++ b/src/app/components/process/process.component.html
@@ -34,7 +34,7 @@
           <app-agent-tabs></app-agent-tabs>
         </div>
         <app-workspace-tabs
-          *ngIf="hasWorkspace"
+          *ngIf="hasWorkspace$ | async"
           [class.moved-offscreen]="isHidden('workspace')"
         ></app-workspace-tabs>
         <app-knowledge-graph

--- a/src/app/components/process/process.component.html
+++ b/src/app/components/process/process.component.html
@@ -33,10 +33,10 @@
         <div [class.moved-offscreen]="isHidden('member')">
           <app-agent-tabs></app-agent-tabs>
         </div>
-        <app-workspace-explorer
+        <app-workspace-tabs
           *ngIf="hasWorkspace"
           [class.moved-offscreen]="isHidden('workspace')"
-        ></app-workspace-explorer>
+        ></app-workspace-tabs>
         <app-knowledge-graph
           *ngIf="hasKnowledgeGraph$ | async"
           [class.moved-offscreen]="isHidden('knowledge-graph')"

--- a/src/app/components/process/process.component.spec.ts
+++ b/src/app/components/process/process.component.spec.ts
@@ -19,6 +19,7 @@ import {
   KG_ACTOR_NAME,
   ToolPresenceService,
 } from './selectors/tool-presence.selector';
+import { WorkspaceRegistryService } from './selectors/workspace-registry.selector';
 import { TeamContext } from '../../core/context/team.interface';
 import { ViewService } from '../../core/ui/view.service';
 import { ProcessComponent } from './process.component';
@@ -73,6 +74,42 @@ function makeKgStop(id: string): StopMessage {
     team_id: 'team-1',
     timestamp: new Date().toISOString(),
     sender: baseSender(KG_ACTOR_NAME),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StopMessage',
+  };
+}
+
+// A normal agent declaring a WorkspaceTool with no workspace_id (→ default).
+function makeWorkspaceStart(id: string, agentName: string): StartMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: baseSender(agentName),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+    config: {
+      tools: [
+        {
+          __model__: 'akgentic.tool.workspace.tool.WorkspaceTool',
+          workspace_id: null,
+        },
+      ],
+    } as any,
+    parent: null,
+  };
+}
+
+function makeWorkspaceStop(id: string, agentName: string): StopMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: baseSender(agentName),
     display_type: 'other',
     content: null,
     __model__: 'akgentic.core.messages.orchestrator.StopMessage',
@@ -144,6 +181,7 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
         MessageLogService,
         ToolPresenceService,
         KGStateReducer,
+        WorkspaceRegistryService,
         { provide: ContextService, useValue: contextService },
         { provide: IngestionService, useValue: messageService },
         { provide: AkgentService, useValue: akgentService },
@@ -234,10 +272,11 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
   });
 
   it('scenario 5 — no regression: Team / Member / Messages entries remain present under both KG presence states (order preserved)', async () => {
-    // `hasWorkspace` defaults to `true` in production (Story 6-2 AC1), so
-    // Workspace is always present; the legacy KG-presence regression check
-    // now runs against `[team, member, workspace, messages]` without KG and
-    // `[team, member, knowledge-graph, workspace, messages]` with KG.
+    // Workspace presence is reactive (ADR-020): declare a WorkspaceTool so the
+    // Workspaces tab is present, then verify the order holds without KG —
+    // `[team, member, workspace, messages]` — and with KG —
+    // `[team, member, knowledge-graph, workspace, messages]`.
+    log.append(makeWorkspaceStart('ws-start-1', 'Worker'));
     let options = await firstValue(component.visualizationOptions$);
     let labels = options.map((o) => o.value);
     expect(labels).toEqual(['team', 'member', 'workspace', 'messages']);
@@ -254,9 +293,10 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
     ]);
   });
 
-  it('scenario 6 — hasWorkspace=true: Workspace appears between KG and Messages (Story 6-2 AC1, AC2)', async () => {
-    // Default is `hasWorkspace = true` (Story 6-2 AC1). Without KG, the
-    // tab order degrades gracefully to [team, member, workspace, messages].
+  it('scenario 6 — Workspaces appears between KG and Messages once a WorkspaceTool exists', async () => {
+    // With a WorkspaceTool but no KG, the order is [team, member, workspace,
+    // messages].
+    log.append(makeWorkspaceStart('ws-start-1', 'Worker'));
     let options = await firstValue(component.visualizationOptions$);
     expect(options.map((o) => o.value)).toEqual([
       'team',
@@ -265,7 +305,7 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
       'messages',
     ]);
 
-    // With KG present, Workspace sits between KG and Messages (AC2 order).
+    // With KG present, Workspace sits between KG and Messages (order).
     log.append(makeKgStart('kg-start-1'));
     options = await firstValue(component.visualizationOptions$);
     expect(options.map((o) => o.value)).toEqual([
@@ -275,6 +315,34 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
       'workspace',
       'messages',
     ]);
+  });
+
+  it('scenario 7 — empty log: Workspaces option absent, <app-workspace-tabs> not in DOM', async () => {
+    const options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'workspace')).toBe(false);
+    expect(
+      fixture.nativeElement.querySelector('app-workspace-tabs'),
+    ).toBeNull();
+  });
+
+  it('scenario 8 — WorkspaceTool appears; sticky: Stop keeps the Workspaces tab', async () => {
+    log.append(makeWorkspaceStart('ws-start-1', 'Worker'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    let options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'workspace')).toBe(true);
+    expect(
+      fixture.nativeElement.querySelector('app-workspace-tabs'),
+    ).not.toBeNull();
+
+    // Firing the member (Stop) is sticky — the workspace persists, tab stays.
+    log.append(makeWorkspaceStop('ws-stop-1', 'Worker'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    options = await firstValue(component.visualizationOptions$);
+    expect(options.some((o) => o.value === 'workspace')).toBe(true);
   });
 });
 
@@ -346,6 +414,7 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
         MessageLogService,
         ToolPresenceService,
         KGStateReducer,
+        WorkspaceRegistryService,
         { provide: ContextService, useValue: contextService },
         { provide: IngestionService, useValue: messageService },
         { provide: AkgentService, useValue: akgentService },

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -12,6 +12,7 @@ import { PerAgentStoreRegistry } from './event/per-agent-store';
 import { SystemPromptSelector } from './selectors/system-prompt.selector';
 import { ToolPresenceService } from './selectors/tool-presence.selector';
 import { WorkspaceRegistryService } from './selectors/workspace-registry.selector';
+import { AgentsByIdService } from './selectors/agents-by-id.selector';
 
 import { AgentTabsComponent } from './components/agent-tabs/agent-tabs.component';
 import { TeamTabsComponent } from './components/team-tabs/team-tabs.component';
@@ -62,6 +63,12 @@ interface VisualizationOption {
     // `providedIn: 'root'` — it shares the team-scoped log lifecycle, so a team
     // switch destroys it and never leaks workspaces across teams.
     WorkspaceRegistryService,
+    // Epic 23 (ADR-020): component-scoped identity map that folds the message
+    // log into `agent_id -> { name, role }`, combined in WorkspaceTabsComponent
+    // with the workspace registry to render each workspace's member chips.
+    // Provided AFTER MessageLogService (which it injects); never
+    // `providedIn: 'root'` — it shares the team-scoped log lifecycle.
+    AgentsByIdService,
     ToolPresenceService,
     KGStateReducer,
     SystemPromptSelector,

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -115,7 +115,7 @@ export class ProcessComponent implements OnDestroy {
       value: 'knowledge-graph',
       icon: 'pi pi-sitemap',
     },
-    { label: 'Workspace', value: 'workspace', icon: 'pi pi-folder-open' },
+    { label: 'Workspaces', value: 'workspace', icon: 'pi pi-folder-open' },
     { label: 'Messages', value: 'messages', icon: 'pi pi-envelope' },
   ];
 

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -24,8 +24,8 @@ import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { TabsModule } from 'primeng/tabs';
-import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import { ChatPanelComponent } from './components/chat/chat-panel.component';
 import { ChatService } from './selectors/chat.selector';
 import { FeedbackService } from './ui-state/feedback.service';
@@ -97,12 +97,9 @@ export class ProcessComponent implements OnDestroy {
   graphDataService: GraphDataService = inject(GraphDataService);
   viewService: ViewService = inject(ViewService);
   toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
+  private readonly workspaceRegistry = inject(WorkspaceRegistryService);
 
   processId: string = '';
-  // Workspace presence is static: every team has a workspace directory by
-  // default (backend creates one on team boot). Reactive presence detection
-  // for workspace is an explicit future enhancement — out of scope today.
-  hasWorkspace: boolean = true;
 
   /**
    * Reactive presence observable for the `#KnowledgeGraphTool` actor.
@@ -111,6 +108,18 @@ export class ProcessComponent implements OnDestroy {
    */
   hasKnowledgeGraph$: Observable<boolean> =
     this.toolPresenceService.hasKnowledgeGraph$;
+
+  /**
+   * Reactive workspace presence (ADR-020): the team has at least one workspace
+   * iff the registry holds at least one descriptor (i.e. some agent declared a
+   * `WorkspaceTool`). Drives both the `Workspaces` tab option and the
+   * `<app-workspace-tabs>` `*ngIf` — the whole tab disappears when no workspace
+   * exists, mirroring the Knowledge graph tab.
+   */
+  hasWorkspace$: Observable<boolean> = this.workspaceRegistry.workspaces$.pipe(
+    map((ws) => ws.length > 0),
+    distinctUntilChanged(),
+  );
 
   visualizationMode$ = new BehaviorSubject<string>('team');
 
@@ -128,13 +137,12 @@ export class ProcessComponent implements OnDestroy {
 
   /**
    * Reactive, filtered list of visualization options. Recomputed whenever
-   * `hasKnowledgeGraph$` emits; preserves the `hasWorkspace` static gate so
-   * workspace-presence reactivation is a one-line change in the future.
-   * (AC3 — reactive derivation)
+   * `hasKnowledgeGraph$` or `hasWorkspace$` emits — the Knowledge graph and
+   * Workspaces tabs each appear only when their tool is present.
    */
   visualizationOptions$: Observable<VisualizationOption[]> = combineLatest([
     this.toolPresenceService.hasKnowledgeGraph$,
-    of(this.hasWorkspace),
+    this.hasWorkspace$,
   ]).pipe(
     map(([hasKG, hasWS]) =>
       this.allVisualizationOptions.filter(
@@ -151,6 +159,7 @@ export class ProcessComponent implements OnDestroy {
   isLoading$ = this.graphDataService.isLoading$;
 
   private presenceSub: Subscription | null = null;
+  private workspaceSub: Subscription | null = null;
 
   constructor() {
     // Active-mode reset guard (AC3 last clause, AC8): if the user is viewing
@@ -163,6 +172,14 @@ export class ProcessComponent implements OnDestroy {
         }
       },
     );
+
+    // Same guard for the Workspaces tab: if it disappears (last workspace tool
+    // removed) while the user is viewing it, snap back to 'team'.
+    this.workspaceSub = this.hasWorkspace$.subscribe((hasWS) => {
+      if (!hasWS && this.currentVisualizationMode === 'workspace') {
+        this.visualizationMode$.next('team');
+      }
+    });
   }
 
   async ngOnInit(): Promise<void> {
@@ -197,6 +214,8 @@ export class ProcessComponent implements OnDestroy {
     this.akgentService.unselect();
     this.presenceSub?.unsubscribe();
     this.presenceSub = null;
+    this.workspaceSub?.unsubscribe();
+    this.workspaceSub = null;
   }
 
   setVisualizationMode(mode: string): void {

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -11,12 +11,13 @@ import { IngestionService } from './event/ingestion.service';
 import { PerAgentStoreRegistry } from './event/per-agent-store';
 import { SystemPromptSelector } from './selectors/system-prompt.selector';
 import { ToolPresenceService } from './selectors/tool-presence.selector';
+import { WorkspaceRegistryService } from './selectors/workspace-registry.selector';
 
 import { AgentTabsComponent } from './components/agent-tabs/agent-tabs.component';
 import { TeamTabsComponent } from './components/team-tabs/team-tabs.component';
 import { KnowledgeGraphComponent } from './components/knowledge-graph/knowledge-graph.component';
 import { MessageListComponent } from './components/message-list/message-list.component';
-import { WorkspaceExplorerComponent } from './components/workspace-explorer/workspace-explorer.component';
+import { WorkspaceTabsComponent } from './components/workspace-tabs/workspace-tabs.component';
 
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
@@ -45,7 +46,7 @@ interface VisualizationOption {
     AgentTabsComponent,
     TeamTabsComponent,
     KnowledgeGraphComponent,
-    WorkspaceExplorerComponent,
+    WorkspaceTabsComponent,
     TabsModule,
     ButtonModule,
     ChatPanelComponent,
@@ -55,6 +56,12 @@ interface VisualizationOption {
   providers: [
     AsyncPipe,
     MessageLogService,
+    // Epic 23 (ADR-019): component-scoped registry that folds the message log
+    // into the set of WorkspaceDescriptors driving the workspace sub-tabs. Must
+    // be provided AFTER MessageLogService (which it injects). Never
+    // `providedIn: 'root'` — it shares the team-scoped log lifecycle, so a team
+    // switch destroys it and never leaks workspaces across teams.
+    WorkspaceRegistryService,
     ToolPresenceService,
     KGStateReducer,
     SystemPromptSelector,

--- a/src/app/components/process/selectors/agents-by-id.selector.spec.ts
+++ b/src/app/components/process/selectors/agents-by-id.selector.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  AkgenticMessage,
+  BaseConfig,
+  StartMessage,
+} from '../../../protocol/message.types';
+import { MessageLogService } from '../event/message-log.service';
+import {
+  AgentsById,
+  AgentsByIdService,
+  agentsByIdReduce,
+} from './agents-by-id.selector';
+
+// ---------------------------------------------------------------------
+// Fixture helpers — sender shape mirrors workspace-registry.selector.spec.
+// ---------------------------------------------------------------------
+
+const TEAM_ID = 'team-1';
+
+function sender(agentId: string, name: string, role: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name,
+    role,
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+function makeConfig(): BaseConfig {
+  return {
+    name: 'cfg',
+    role: 'Agent',
+    user_id: 'u1',
+    user_email: 'u@x',
+    squad_id: 's1',
+    team_id: TEAM_ID,
+    orchestrator: sender('orch', 'orchestrator', 'Orchestrator'),
+  };
+}
+
+function makeStartMessage(
+  agentId: string,
+  name: string,
+  role: string,
+): StartMessage {
+  return {
+    id: 'start-' + agentId,
+    parent_id: null,
+    team_id: TEAM_ID,
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId, name, role),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+    config: makeConfig(),
+    parent: null,
+  };
+}
+
+describe('agentsByIdReduce (pure function)', () => {
+  it('(AC1) empty log → empty map', () => {
+    expect(agentsByIdReduce([])).toEqual({});
+  });
+
+  it('(AC1) two StartMessages → both agent_id entries with name + role', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('a1', 'Bob', 'Scrum Master'),
+      makeStartMessage('a2', 'Amelia', 'Developer'),
+    ];
+    expect(agentsByIdReduce(log)).toEqual({
+      a1: { name: 'Bob', role: 'Scrum Master' },
+      a2: { name: 'Amelia', role: 'Developer' },
+    });
+  });
+
+  it('(AC1) a later StartMessage for the same agent_id supersedes (last-wins)', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('a1', 'Bob', 'Scrum Master'),
+      makeStartMessage('a1', 'Bobby', 'Lead'),
+    ];
+    expect(agentsByIdReduce(log)).toEqual({
+      a1: { name: 'Bobby', role: 'Lead' },
+    });
+  });
+
+  it('(NFR1) ignores non-Start messages', () => {
+    const stop = {
+      id: 'stop-a1',
+      parent_id: null,
+      team_id: TEAM_ID,
+      timestamp: new Date().toISOString(),
+      sender: sender('a1', 'Bob', 'Scrum Master'),
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.StopMessage',
+    } as unknown as AkgenticMessage;
+    // A Stop does NOT remove the identity recorded by the prior Start
+    // (display identity persists; membership is governed by the descriptor fold).
+    const log: AkgenticMessage[] = [
+      makeStartMessage('a1', 'Bob', 'Scrum Master'),
+      stop,
+    ];
+    expect(agentsByIdReduce(log)).toEqual({
+      a1: { name: 'Bob', role: 'Scrum Master' },
+    });
+  });
+});
+
+describe('AgentsByIdService (selector over MessageLogService.log$)', () => {
+  let log: MessageLogService;
+  let service: AgentsByIdService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MessageLogService, AgentsByIdService],
+    });
+    log = TestBed.inject(MessageLogService);
+    service = TestBed.inject(AgentsByIdService);
+  });
+
+  function currentValue(): AgentsById {
+    let v: AgentsById | undefined;
+    const sub = service.agentsById$.subscribe((x) => (v = x));
+    sub.unsubscribe();
+    return v as AgentsById;
+  }
+
+  it('(AC1) initial empty log → empty map', () => {
+    expect(currentValue()).toEqual({});
+  });
+
+  it('(AC1) live append of a StartMessage → identity registered', () => {
+    log.append(makeStartMessage('a1', 'Bob', 'Scrum Master'));
+    expect(currentValue()).toEqual({
+      a1: { name: 'Bob', role: 'Scrum Master' },
+    });
+  });
+
+  it('(AC1) distinctUntilChanged suppresses structurally identical re-emissions', () => {
+    const emissions: AgentsById[] = [];
+    const sub = service.agentsById$.subscribe((v) => emissions.push(v));
+
+    const start1 = makeStartMessage('a1', 'Bob', 'Scrum Master');
+    start1.id = 'a-1';
+    const start2 = makeStartMessage('a1', 'Bob', 'Scrum Master');
+    start2.id = 'a-2';
+    log.append(start1);
+    log.append(start2);
+
+    // [initial empty, after first start]. The second start for the same agent
+    // yields the same identity → structurally identical fold → suppressed.
+    expect(emissions.length).toBe(2);
+    sub.unsubscribe();
+  });
+
+  it('(AC1) log.reset() returns to empty map on team switch', () => {
+    log.append(makeStartMessage('a1', 'Bob', 'Scrum Master'));
+    expect(Object.keys(currentValue()).length).toBe(1);
+    log.reset();
+    expect(currentValue()).toEqual({});
+  });
+});

--- a/src/app/components/process/selectors/agents-by-id.selector.spec.ts
+++ b/src/app/components/process/selectors/agents-by-id.selector.spec.ts
@@ -30,13 +30,14 @@ function sender(agentId: string, name: string, role: string) {
 }
 
 function makeConfig(): BaseConfig {
+  // No team_id: the backend AgentConfig does not serialise it (absent on the
+  // wire). The team id is read from the message level, not config.
   return {
     name: 'cfg',
     role: 'Agent',
     user_id: 'u1',
     user_email: 'u@x',
     squad_id: 's1',
-    team_id: TEAM_ID,
     orchestrator: sender('orch', 'orchestrator', 'Orchestrator'),
   };
 }

--- a/src/app/components/process/selectors/agents-by-id.selector.ts
+++ b/src/app/components/process/selectors/agents-by-id.selector.ts
@@ -1,0 +1,93 @@
+import { inject, Injectable } from '@angular/core';
+import { distinctUntilChanged, map, Observable } from 'rxjs';
+
+import {
+  AkgenticMessage,
+  isStartMessage,
+} from '../../../protocol/message.types';
+import { MessageLogService } from '../event/message-log.service';
+
+/**
+ * Display identity for one agent (Epic 23 / ADR-020 §Decision 4). The two
+ * fields the member-chip row renders — the agent's `name` (chip label) and its
+ * `role` (chip tooltip/subtext). A typed value rather than an inline object
+ * shape so the component + spec share one contract.
+ */
+export interface AgentIdentity {
+  name: string;
+  role: string;
+}
+
+/** `agent_id → { name, role }`. */
+export type AgentsById = Record<string, AgentIdentity>;
+
+/**
+ * Pure ordered fold over the message log → the `agent_id → { name, role }`
+ * identity map (ADR-020 §Decision 4 / FR17, sibling of `presenceReduce` and
+ * `workspaceRegistryReduce`).
+ *
+ * Every `StartMessage.sender` is an `ActorAddress` carrying `agent_id`, `name`,
+ * and `role`; each Start records (last-wins) that agent's display identity. A
+ * later Start for the same `agent_id` supersedes the earlier identity — uniform
+ * with the other fold-the-log selectors. `StopMessage`s are deliberately NOT
+ * folded out: this map only resolves DISPLAY identity, while the descriptor
+ * fold (`workspaceRegistryReduce`) governs membership; an agent that
+ * contributed to a descriptor stays resolvable here even across a Start→Stop.
+ *
+ * Exported at module scope so tests assert the pure function directly without a
+ * `TestBed` harness (faster + clearer coverage).
+ */
+export function agentsByIdReduce(log: AkgenticMessage[]): AgentsById {
+  const byId: AgentsById = {};
+  for (const m of log) {
+    if (isStartMessage(m)) {
+      byId[m.sender.agent_id] = { name: m.sender.name, role: m.sender.role };
+    }
+  }
+  return byId;
+}
+
+/**
+ * Structural equality of two identity maps (mirror of `descriptorsEqual`). The
+ * fold returns a NEW object reference per `log$` emission, so the default
+ * reference comparator would never suppress structurally-identical
+ * re-emissions; compare the key set plus each entry's `name`/`role`.
+ */
+function agentsByIdEqual(a: AgentsById, b: AgentsById): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((k) => {
+    const o = b[k];
+    return o !== undefined && a[k].name === o.name && a[k].role === o.role;
+  });
+}
+
+/**
+ * AgentsByIdService — Story 23-4 (ADR-020 §Decision 4).
+ *
+ * Publishes `agentsById$` as a pure selector over `MessageLogService.log$`:
+ * the `agent_id → { name, role }` identity map folded from every agent's
+ * `StartMessage.sender`. Combined in `WorkspaceTabsComponent` with
+ * `WorkspaceRegistryService.workspaces$` to resolve each descriptor's
+ * `agentIds` to displayable member chips — the descriptor fold is left
+ * untouched (no descriptor churn, AC6).
+ *
+ * Scope: component-scoped (NOT `providedIn: 'root'`) because it injects
+ * `MessageLogService`, which is component-scoped on `ProcessComponent`. A team
+ * switch destroys the component (and the log), so the map shares that lifecycle
+ * and never leaks identities across teams.
+ *
+ * `distinctUntilChanged` uses a STRUCTURAL comparator (`agentsByIdEqual`): the
+ * fold emits a NEW object reference per `log$` emission, so the default
+ * reference comparator would never suppress no-op re-emissions.
+ */
+@Injectable()
+export class AgentsByIdService {
+  private readonly log: MessageLogService = inject(MessageLogService);
+
+  readonly agentsById$: Observable<AgentsById> = this.log.log$.pipe(
+    map(agentsByIdReduce),
+    distinctUntilChanged(agentsByIdEqual),
+  );
+}

--- a/src/app/components/process/selectors/workspace-registry.selector.spec.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.spec.ts
@@ -37,6 +37,10 @@ function workspaceTool(workspaceId?: string | null): ToolCardLite {
   return { __model__: WORKSPACE_MODEL, workspace_id: workspaceId };
 }
 
+// NOTE: the backend AgentConfig does NOT serialise `team_id` — it is absent
+// from `config` on the wire. The fixtures omit it deliberately so the fold is
+// exercised against the real payload shape (the team id is read from the
+// message level, `StartMessage.team_id`, not from `config`).
 function makeConfig(tools?: ToolCardLite[]): BaseConfig {
   return {
     name: 'cfg',
@@ -44,7 +48,6 @@ function makeConfig(tools?: ToolCardLite[]): BaseConfig {
     user_id: 'u1',
     user_email: 'u@x',
     squad_id: 's1',
-    team_id: TEAM_ID,
     orchestrator: baseSender('orchestrator'),
     tools,
   };
@@ -242,13 +245,14 @@ describe('workspaceRegistryReduce (pure function)', () => {
       content: null,
       __model__: 'akgentic.core.messages.orchestrator.StartMessage',
       parent: null,
+      // NOTE: NO `team_id` in config — the backend AgentConfig does not
+      // serialise it. The team id is only present at the MESSAGE level above.
       config: {
         name: 'Researcher',
         role: 'Agent',
         user_id: 'u1',
         user_email: 'u@x',
         squad_id: 's1',
-        team_id: TEAM_ID,
         orchestrator: {
           __actor_address__: true,
           agent_id: 'orch',
@@ -262,6 +266,14 @@ describe('workspaceRegistryReduce (pure function)', () => {
             __model__: WORKSPACE_MODEL,
             workspace_id: 'ws-from-wire',
           },
+          // Default workspace tool: NO workspace_id → must resolve to the
+          // team default via the message-level team_id (NOT config.team_id,
+          // which is absent on the wire). Regression guard for the bug where
+          // default-workspace members showed no chips.
+          {
+            __model__: WORKSPACE_MODEL,
+            workspace_id: null,
+          },
         ],
       },
     } as unknown as AkgenticMessage;
@@ -271,6 +283,11 @@ describe('workspaceRegistryReduce (pure function)', () => {
     expect(named).toBeDefined();
     expect(named?.isDefault).toBe(false);
     expect(named?.agentIds).toEqual(['agent-serialized']);
+    // The default tool (no workspace_id, config without team_id) still lands
+    // in the team-default descriptor — resolved from the message team_id.
+    const def = findById(result, TEAM_ID);
+    expect(def?.isDefault).toBe(true);
+    expect(def?.agentIds).toEqual(['agent-serialized']);
   });
 });
 

--- a/src/app/components/process/selectors/workspace-registry.selector.spec.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.spec.ts
@@ -1,0 +1,337 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  AkgenticMessage,
+  BaseConfig,
+  isWorkspaceTool,
+  StartMessage,
+  StopMessage,
+  ToolCardLite,
+} from '../../../protocol/message.types';
+import { MessageLogService } from '../event/message-log.service';
+import {
+  WorkspaceDescriptor,
+  WorkspaceRegistryService,
+  workspaceRegistryReduce,
+} from './workspace-registry.selector';
+
+// ---------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------
+
+const TEAM_ID = 'team-1';
+const WORKSPACE_MODEL = 'akgentic.tool.workspace.tool.WorkspaceTool';
+
+function baseSender(agentName: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: 'agent-' + agentName,
+    name: agentName,
+    role: 'Agent',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+function workspaceTool(workspaceId?: string | null): ToolCardLite {
+  return { __model__: WORKSPACE_MODEL, workspace_id: workspaceId };
+}
+
+function makeConfig(tools?: ToolCardLite[]): BaseConfig {
+  return {
+    name: 'cfg',
+    role: 'Agent',
+    user_id: 'u1',
+    user_email: 'u@x',
+    squad_id: 's1',
+    team_id: TEAM_ID,
+    orchestrator: baseSender('orchestrator'),
+    tools,
+  };
+}
+
+function makeStartMessage(
+  agentName: string,
+  tools?: ToolCardLite[],
+): StartMessage {
+  return {
+    id: 'start-' + agentName,
+    parent_id: null,
+    team_id: TEAM_ID,
+    timestamp: new Date().toISOString(),
+    sender: baseSender(agentName),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+    config: makeConfig(tools),
+    parent: null,
+  };
+}
+
+function makeStopMessage(agentName: string): StopMessage {
+  return {
+    id: 'stop-' + agentName,
+    parent_id: null,
+    team_id: TEAM_ID,
+    timestamp: new Date().toISOString(),
+    sender: baseSender(agentName),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.StopMessage',
+  };
+}
+
+function findById(
+  result: WorkspaceDescriptor[],
+  workspaceId: string,
+): WorkspaceDescriptor | undefined {
+  return result.find((d) => d.workspaceId === workspaceId);
+}
+
+describe('isWorkspaceTool (guard)', () => {
+  it('matches a __model__ ending in WorkspaceTool', () => {
+    expect(isWorkspaceTool(workspaceTool('w1'))).toBe(true);
+  });
+
+  it('rejects other tools, empty, and mid-string WorkspaceTool', () => {
+    expect(
+      isWorkspaceTool({ __model__: 'akgentic.tool.kg.tool.KnowledgeGraphTool' }),
+    ).toBe(false);
+    expect(
+      isWorkspaceTool({ __model__: 'akgentic.tool.vector.VectorStoreTool' }),
+    ).toBe(false);
+    expect(isWorkspaceTool({ __model__: '' })).toBe(false);
+    // Contains WorkspaceTool mid-string but does NOT end in it → rejected.
+    expect(isWorkspaceTool({ __model__: 'WorkspaceToolFactory' })).toBe(false);
+  });
+});
+
+describe('workspaceRegistryReduce (pure function)', () => {
+  it('(AC6) empty log → exactly one default descriptor keyed by team id', () => {
+    const result = workspaceRegistryReduce([], TEAM_ID);
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({
+      workspaceId: TEAM_ID,
+      isDefault: true,
+      agentIds: [],
+      label: 'Default workspace',
+    });
+  });
+
+  it('(AC3) StartMessage with a named WorkspaceTool → default + one named descriptor', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('ws-named')]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    expect(result.length).toBe(2);
+    expect(findById(result, TEAM_ID)?.isDefault).toBe(true);
+    const named = findById(result, 'ws-named');
+    expect(named?.isDefault).toBe(false);
+    expect(named?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(AC4) effective-id fallback — no workspace_id resolves to team id', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool(null)]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    // Falls back to team id → folds into the default descriptor, no new one.
+    expect(result.length).toBe(1);
+    expect(findById(result, TEAM_ID)?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(AC4) effective-id — explicit workspace_id resolves to that id', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('ws-x')]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    expect(findById(result, 'ws-x')).toBeDefined();
+    expect(findById(result, 'ws-x')?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(AC5) two agents sharing one effective id collapse to one descriptor recording both', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('ws-shared')]),
+      makeStartMessage('B', [workspaceTool('ws-shared')]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    const shared = findById(result, 'ws-shared');
+    expect(shared?.agentIds).toEqual(['agent-A', 'agent-B']);
+    expect(result.filter((d) => d.workspaceId === 'ws-shared').length).toBe(1);
+  });
+
+  it('(AC6) a WorkspaceTool with effective id == team id folds into the default, no second default', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool(TEAM_ID)]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    const defaults = result.filter((d) => d.isDefault);
+    expect(defaults.length).toBe(1);
+    expect(defaults[0].agentIds).toEqual(['agent-A']);
+  });
+
+  it('(AC7) Stop drops the sole contributor — named descriptor disappears, default survives', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('ws-named')]),
+      makeStopMessage('A'),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    expect(findById(result, 'ws-named')).toBeUndefined();
+    expect(result.length).toBe(1);
+    expect(result[0].isDefault).toBe(true);
+  });
+
+  it('(AC7) Stop — descriptor backed by another agent survives, stopped agent removed', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('ws-shared')]),
+      makeStartMessage('B', [workspaceTool('ws-shared')]),
+      makeStopMessage('A'),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    const shared = findById(result, 'ws-shared');
+    expect(shared).toBeDefined();
+    expect(shared?.agentIds).toEqual(['agent-B']);
+  });
+
+  it('(AC7) ordered last-wins — Start → Stop → Start ends with the named workspace present', () => {
+    const start1 = makeStartMessage('A', [workspaceTool('ws-named')]);
+    start1.id = 'a-start-1';
+    const stop1 = makeStopMessage('A');
+    stop1.id = 'a-stop-1';
+    const start2 = makeStartMessage('A', [workspaceTool('ws-named')]);
+    start2.id = 'a-start-2';
+    const result = workspaceRegistryReduce([start1, stop1, start2], TEAM_ID);
+    expect(findById(result, 'ws-named')?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(AC7) the default descriptor is never removed by a Stop', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool(TEAM_ID)]),
+      makeStopMessage('A'),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({
+      workspaceId: TEAM_ID,
+      isDefault: true,
+      agentIds: [],
+      label: 'Default workspace',
+    });
+  });
+
+  it('(NFR4) realistic serialized StartMessage fixture → named descriptor registered', () => {
+    // A JSON-shaped StartMessage as it arrives on the wire: config serialised
+    // in full, config.tools holding a nested WorkspaceTool object with both a
+    // recursive __model__ and a workspace_id. If a future infra serialization
+    // change drops `tools` or renames the discriminator, this fails in CI
+    // rather than silently collapsing the registry to the default-only tab.
+    const serialized = {
+      id: 'start-serialized',
+      parent_id: null,
+      team_id: TEAM_ID,
+      timestamp: '2026-06-16T00:00:00.000Z',
+      sender: {
+        __actor_address__: true,
+        agent_id: 'agent-serialized',
+        name: 'Researcher',
+        role: 'Agent',
+        squad_id: 's1',
+        user_message: false,
+      },
+      display_type: 'other',
+      content: null,
+      __model__: 'akgentic.core.messages.orchestrator.StartMessage',
+      parent: null,
+      config: {
+        name: 'Researcher',
+        role: 'Agent',
+        user_id: 'u1',
+        user_email: 'u@x',
+        squad_id: 's1',
+        team_id: TEAM_ID,
+        orchestrator: {
+          __actor_address__: true,
+          agent_id: 'orch',
+          name: 'orchestrator',
+          role: 'Orchestrator',
+          squad_id: 's1',
+          user_message: false,
+        },
+        tools: [
+          {
+            __model__: WORKSPACE_MODEL,
+            workspace_id: 'ws-from-wire',
+          },
+        ],
+      },
+    } as unknown as AkgenticMessage;
+
+    const result = workspaceRegistryReduce([serialized], TEAM_ID);
+    const named = findById(result, 'ws-from-wire');
+    expect(named).toBeDefined();
+    expect(named?.isDefault).toBe(false);
+    expect(named?.agentIds).toEqual(['agent-serialized']);
+  });
+});
+
+describe('WorkspaceRegistryService (selector over MessageLogService.log$)', () => {
+  let log: MessageLogService;
+  let service: WorkspaceRegistryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MessageLogService, WorkspaceRegistryService],
+    });
+    log = TestBed.inject(MessageLogService);
+    service = TestBed.inject(WorkspaceRegistryService);
+  });
+
+  function currentValue(): WorkspaceDescriptor[] {
+    let v: WorkspaceDescriptor[] | undefined;
+    const sub = service.workspaces$.subscribe((x) => (v = x));
+    sub.unsubscribe();
+    return v as WorkspaceDescriptor[];
+  }
+
+  it('(1) initial empty log → default-only (placeholder team id)', () => {
+    const result = currentValue();
+    expect(result.length).toBe(1);
+    expect(result[0].isDefault).toBe(true);
+    expect(result[0].workspaceId).toBe('');
+  });
+
+  it('(2) live append of a named-WorkspaceTool StartMessage → default + named', () => {
+    log.append(makeStartMessage('A', [workspaceTool('ws-named')]));
+    const result = currentValue();
+    expect(result.length).toBe(2);
+    expect(findById(result, TEAM_ID)?.isDefault).toBe(true);
+    expect(findById(result, 'ws-named')?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(3) distinctUntilChanged suppresses structurally identical re-emissions', () => {
+    const emissions: WorkspaceDescriptor[][] = [];
+    const sub = service.workspaces$.subscribe((v) => emissions.push(v));
+
+    const start1 = makeStartMessage('A', [workspaceTool('ws-named')]);
+    start1.id = 'a-1';
+    const start2 = makeStartMessage('A', [workspaceTool('ws-named')]);
+    start2.id = 'a-2';
+    log.append(start1);
+    log.append(start2);
+
+    // [initial default-only, after first named start]. The second start for the
+    // same agent yields the same effective contribution → structurally identical
+    // fold → distinctUntilChanged suppresses a third emission.
+    expect(emissions.length).toBe(2);
+    sub.unsubscribe();
+  });
+
+  it('(4) log.reset() returns to default-only on team switch', () => {
+    log.append(makeStartMessage('A', [workspaceTool('ws-named')]));
+    expect(currentValue().length).toBe(2);
+    log.reset();
+    const result = currentValue();
+    expect(result.length).toBe(1);
+    expect(result[0].isDefault).toBe(true);
+  });
+});

--- a/src/app/components/process/selectors/workspace-registry.selector.spec.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.spec.ts
@@ -110,36 +110,32 @@ describe('isWorkspaceTool (guard)', () => {
 });
 
 describe('workspaceRegistryReduce (pure function)', () => {
-  it('(AC6) empty log → exactly one default descriptor keyed by team id', () => {
+  it('(AC6) empty log → no descriptors (no always-present default)', () => {
     const result = workspaceRegistryReduce([], TEAM_ID);
-    expect(result.length).toBe(1);
-    expect(result[0]).toEqual({
-      workspaceId: TEAM_ID,
-      isDefault: true,
-      agentIds: [],
-      label: 'Default workspace',
-    });
+    expect(result).toEqual([]);
   });
 
-  it('(AC3) StartMessage with a named WorkspaceTool → default + one named descriptor', () => {
+  it('(AC3) StartMessage with a named WorkspaceTool only → one named descriptor, no default', () => {
     const log: AkgenticMessage[] = [
       makeStartMessage('A', [workspaceTool('ws-named')]),
     ];
     const result = workspaceRegistryReduce(log, TEAM_ID);
-    expect(result.length).toBe(2);
-    expect(findById(result, TEAM_ID)?.isDefault).toBe(true);
+    expect(result.length).toBe(1);
     const named = findById(result, 'ws-named');
     expect(named?.isDefault).toBe(false);
     expect(named?.agentIds).toEqual(['agent-A']);
+    // No agent declared a no-workspace_id tool → there is NO default descriptor.
+    expect(findById(result, TEAM_ID)).toBeUndefined();
   });
 
-  it('(AC4) effective-id fallback — no workspace_id resolves to team id', () => {
+  it('(AC4) no workspace_id → creates the default descriptor keyed by the team id', () => {
     const log: AkgenticMessage[] = [
       makeStartMessage('A', [workspaceTool(null)]),
     ];
     const result = workspaceRegistryReduce(log, TEAM_ID);
-    // Falls back to team id → folds into the default descriptor, no new one.
+    // A no-workspace_id tool resolves to the team id → the (only) default.
     expect(result.length).toBe(1);
+    expect(findById(result, TEAM_ID)?.isDefault).toBe(true);
     expect(findById(result, TEAM_ID)?.agentIds).toEqual(['agent-A']);
   });
 
@@ -150,6 +146,22 @@ describe('workspaceRegistryReduce (pure function)', () => {
     const result = workspaceRegistryReduce(log, TEAM_ID);
     expect(findById(result, 'ws-x')).toBeDefined();
     expect(findById(result, 'ws-x')?.agentIds).toEqual(['agent-A']);
+  });
+
+  it('(order) default sorts first, named workspaces follow alphabetically', () => {
+    const log: AkgenticMessage[] = [
+      makeStartMessage('A', [workspaceTool('shared_workspace')]),
+      makeStartMessage('B', [workspaceTool(null)]), // default, declared later
+      makeStartMessage('C', [workspaceTool('alpha')]),
+    ];
+    const result = workspaceRegistryReduce(log, TEAM_ID);
+    // Default first despite being declared second; named ones alphabetical.
+    expect(result.map((d) => d.workspaceId)).toEqual([
+      TEAM_ID,
+      'alpha',
+      'shared_workspace',
+    ]);
+    expect(result[0].isDefault).toBe(true);
   });
 
   it('(AC5) two agents sharing one effective id collapse to one descriptor recording both', () => {
@@ -173,15 +185,16 @@ describe('workspaceRegistryReduce (pure function)', () => {
     expect(defaults[0].agentIds).toEqual(['agent-A']);
   });
 
-  it('(AC7) Stop drops the sole contributor — named descriptor disappears, default survives', () => {
+  it('(AC7) Stop drops the member but KEEPS the workspace (sticky — operator retains access)', () => {
     const log: AkgenticMessage[] = [
       makeStartMessage('A', [workspaceTool('ws-named')]),
       makeStopMessage('A'),
     ];
     const result = workspaceRegistryReduce(log, TEAM_ID);
-    expect(findById(result, 'ws-named')).toBeUndefined();
-    expect(result.length).toBe(1);
-    expect(result[0].isDefault).toBe(true);
+    const named = findById(result, 'ws-named');
+    expect(named).toBeDefined();
+    // The fired member is gone, but the workspace persists with no members.
+    expect(named?.agentIds).toEqual([]);
   });
 
   it('(AC7) Stop — descriptor backed by another agent survives, stopped agent removed', () => {
@@ -207,19 +220,20 @@ describe('workspaceRegistryReduce (pure function)', () => {
     expect(findById(result, 'ws-named')?.agentIds).toEqual(['agent-A']);
   });
 
-  it('(AC7) the default descriptor is never removed by a Stop', () => {
+  it('(AC7) Stop keeps the default workspace (sticky), drops its member', () => {
     const log: AkgenticMessage[] = [
       makeStartMessage('A', [workspaceTool(TEAM_ID)]),
       makeStopMessage('A'),
     ];
     const result = workspaceRegistryReduce(log, TEAM_ID);
-    expect(result.length).toBe(1);
-    expect(result[0]).toEqual({
-      workspaceId: TEAM_ID,
-      isDefault: true,
-      agentIds: [],
-      label: 'Default workspace',
-    });
+    const def = findById(result, TEAM_ID);
+    expect(def?.isDefault).toBe(true);
+    expect(def?.agentIds).toEqual([]);
+  });
+
+  it('(sticky) a team that never declared a WorkspaceTool stays empty', () => {
+    const log: AkgenticMessage[] = [makeStartMessage('A', [])];
+    expect(workspaceRegistryReduce(log, TEAM_ID)).toEqual([]);
   });
 
   it('(NFR4) realistic serialized StartMessage fixture → named descriptor registered', () => {
@@ -310,19 +324,17 @@ describe('WorkspaceRegistryService (selector over MessageLogService.log$)', () =
     return v as WorkspaceDescriptor[];
   }
 
-  it('(1) initial empty log → default-only (placeholder team id)', () => {
+  it('(1) initial empty log → no descriptors', () => {
     const result = currentValue();
-    expect(result.length).toBe(1);
-    expect(result[0].isDefault).toBe(true);
-    expect(result[0].workspaceId).toBe('');
+    expect(result).toEqual([]);
   });
 
-  it('(2) live append of a named-WorkspaceTool StartMessage → default + named', () => {
+  it('(2) live append of a named-WorkspaceTool StartMessage → one named descriptor', () => {
     log.append(makeStartMessage('A', [workspaceTool('ws-named')]));
     const result = currentValue();
-    expect(result.length).toBe(2);
-    expect(findById(result, TEAM_ID)?.isDefault).toBe(true);
+    expect(result.length).toBe(1);
     expect(findById(result, 'ws-named')?.agentIds).toEqual(['agent-A']);
+    expect(findById(result, TEAM_ID)).toBeUndefined();
   });
 
   it('(3) distinctUntilChanged suppresses structurally identical re-emissions', () => {
@@ -336,19 +348,17 @@ describe('WorkspaceRegistryService (selector over MessageLogService.log$)', () =
     log.append(start1);
     log.append(start2);
 
-    // [initial default-only, after first named start]. The second start for the
-    // same agent yields the same effective contribution → structurally identical
+    // [initial empty, after first named start]. The second start for the same
+    // agent yields the same effective contribution → structurally identical
     // fold → distinctUntilChanged suppresses a third emission.
     expect(emissions.length).toBe(2);
     sub.unsubscribe();
   });
 
-  it('(4) log.reset() returns to default-only on team switch', () => {
+  it('(4) log.reset() clears the registry on team switch', () => {
     log.append(makeStartMessage('A', [workspaceTool('ws-named')]));
-    expect(currentValue().length).toBe(2);
+    expect(currentValue().length).toBe(1);
     log.reset();
-    const result = currentValue();
-    expect(result.length).toBe(1);
-    expect(result[0].isDefault).toBe(true);
+    expect(currentValue()).toEqual([]);
   });
 });

--- a/src/app/components/process/selectors/workspace-registry.selector.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.ts
@@ -1,0 +1,180 @@
+import { inject, Injectable } from '@angular/core';
+import { distinctUntilChanged, map, Observable } from 'rxjs';
+
+import {
+  AkgenticMessage,
+  isStartMessage,
+  isStopMessage,
+  isWorkspaceTool,
+  StartMessage,
+  ToolCardLite,
+} from '../../../protocol/message.types';
+import { MessageLogService } from '../event/message-log.service';
+
+/**
+ * One discovered workspace in a team (Epic 23 / ADR-019 §Decision 1).
+ *
+ * `workspaceId` is the *effective* id the backend resolves to (see
+ * `effectiveWorkspaceId`); `isDefault` marks the always-present team-default
+ * workspace; `agentIds` records every agent whose `WorkspaceTool` contributed
+ * to this descriptor (deterministically ordered for structural equality);
+ * `label` is a deterministic UI string consumed by Story 23-3.
+ */
+export interface WorkspaceDescriptor {
+  workspaceId: string;
+  isDefault: boolean;
+  agentIds: string[];
+  label: string;
+}
+
+/**
+ * Effective workspace id for a `WorkspaceTool` entry (ADR-019 FR4 / NFR5).
+ * Mirrors the backend `ws_name = self.workspace_id or str(observer.team_id)`
+ * so the UI and backend agree on workspace identity. Encoded ONCE here.
+ *
+ * JS `??` falls back only on `null`/`undefined` (matching the wire type
+ * `workspace_id?: string | null`); an empty `workspace_id` is not a
+ * real-world case, so `??` is the correct, simplest encoding.
+ */
+function effectiveWorkspaceId(tool: ToolCardLite, teamId: string): string {
+  return tool.workspace_id ?? teamId;
+}
+
+/** Deterministic per-descriptor label (UI nicety, finalised in Story 23-3). */
+function labelFor(workspaceId: string, isDefault: boolean): string {
+  return isDefault ? 'Default workspace' : workspaceId;
+}
+
+/**
+ * Per-agent contribution: the set of effective workspace ids an agent's
+ * `WorkspaceTool`s resolve to under its latest `StartMessage`. Keyed by
+ * `sender.agent_id`; a `StopMessage` removes the agent's entry; a later
+ * `StartMessage` for the same agent replaces it (last-wins).
+ */
+type Contributions = Map<string, Set<string>>;
+
+/** Effective ids contributed by one `StartMessage` (deduped within the agent). */
+function startContribution(msg: StartMessage): Set<string> {
+  const teamId = msg.config.team_id;
+  const ids = new Set<string>();
+  for (const tool of msg.config.tools ?? []) {
+    if (isWorkspaceTool(tool)) ids.add(effectiveWorkspaceId(tool, teamId));
+  }
+  return ids;
+}
+
+/**
+ * Build the descriptor list from the resolved per-agent contributions plus the
+ * always-present default descriptor (ADR-019 §Decision 3). The default
+ * (`workspaceId === teamId`) is emitted first and absorbs any agent whose
+ * effective id equals the team id rather than creating a second default.
+ */
+function buildDescriptors(
+  contributions: Contributions,
+  teamId: string,
+): WorkspaceDescriptor[] {
+  const byId = new Map<string, Set<string>>([[teamId, new Set<string>()]]);
+  for (const [agentId, ids] of contributions) {
+    for (const id of ids) {
+      const agents = byId.get(id) ?? new Set<string>();
+      agents.add(agentId);
+      byId.set(id, agents);
+    }
+  }
+  return [...byId.entries()].map(([workspaceId, agents]) => {
+    const isDefault = workspaceId === teamId;
+    return {
+      workspaceId,
+      isDefault,
+      agentIds: [...agents].sort(),
+      label: labelFor(workspaceId, isDefault),
+    };
+  });
+}
+
+/**
+ * Pure ordered fold over the message log → the deduped set of workspaces in a
+ * team (ADR-019 §Decision 1/2/3, mirror of `presenceReduce`).
+ *
+ * Ordered-reduce semantics are LOAD-BEARING: a `Start → Stop → Start` restart
+ * for one agent must resolve to *present* (last Start wins) — a
+ * `some(isStart) && !some(isStop)` shortcut would be wrong. We track each
+ * agent's latest contribution and rebuild descriptors, so a `StopMessage`
+ * drops only that agent (a descriptor backed by another agent survives; the
+ * default descriptor is never removed).
+ *
+ * Exported at module scope so tests assert it directly without a `TestBed`.
+ */
+export function workspaceRegistryReduce(
+  log: AkgenticMessage[],
+  teamId: string,
+): WorkspaceDescriptor[] {
+  const contributions: Contributions = new Map();
+  for (const m of log) {
+    if (isStartMessage(m)) {
+      contributions.set(m.sender.agent_id, startContribution(m));
+    } else if (isStopMessage(m)) {
+      contributions.delete(m.sender.agent_id);
+    }
+  }
+  return buildDescriptors(contributions, teamId);
+}
+
+/** Deep structural equality of two descriptor arrays (NFR3). `agentIds` is
+ *  kept sorted by the fold, so element-wise comparison is order-stable. */
+function descriptorsEqual(
+  a: WorkspaceDescriptor[],
+  b: WorkspaceDescriptor[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((d, i) => {
+    const o = b[i];
+    return (
+      d.workspaceId === o.workspaceId &&
+      d.isDefault === o.isDefault &&
+      d.label === o.label &&
+      d.agentIds.length === o.agentIds.length &&
+      d.agentIds.every((id, j) => id === o.agentIds[j])
+    );
+  });
+}
+
+/**
+ * Effective team id for the default descriptor, derived from the log itself so
+ * the fold stays a pure function of `log$` (restart- and REST-replay-safe, no
+ * external team-id input). Uses the first message's `team_id`; before any
+ * message arrives there is none, so a stable placeholder `''` is used and the
+ * real team id lands on the first emission — the panel is non-empty by
+ * construction at all times.
+ */
+function teamIdFromLog(log: AkgenticMessage[]): string {
+  return log.length > 0 ? log[0].team_id : '';
+}
+
+/**
+ * WorkspaceRegistryService — Story 23-1 (ADR-019 §Decision 1).
+ *
+ * Publishes `workspaces$` as a pure selector over `MessageLogService.log$`:
+ * the deduped set of `WorkspaceDescriptor`s discovered by folding every
+ * agent's `StartMessage.config.tools`. Set-valued sibling of
+ * `ToolPresenceService`.
+ *
+ * Scope: component-scoped (NOT `providedIn: 'root'`) because it injects
+ * `MessageLogService`, which is component-scoped on `ProcessComponent`. A team
+ * switch destroys the component (and the log), so the registry shares that
+ * lifecycle and never leaks workspaces across teams. NOT yet provided in
+ * `process.component` — that wiring is Story 23-3.
+ *
+ * `distinctUntilChanged` uses a STRUCTURAL comparator (`descriptorsEqual`):
+ * the fold emits a NEW array reference per `log$` emission, so the default
+ * reference comparator would never suppress no-op re-emissions (NFR3).
+ */
+@Injectable()
+export class WorkspaceRegistryService {
+  private readonly log: MessageLogService = inject(MessageLogService);
+
+  readonly workspaces$: Observable<WorkspaceDescriptor[]> = this.log.log$.pipe(
+    map((log) => workspaceRegistryReduce(log, teamIdFromLog(log))),
+    distinctUntilChanged(descriptorsEqual),
+  );
+}

--- a/src/app/components/process/selectors/workspace-registry.selector.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.ts
@@ -53,9 +53,17 @@ function labelFor(workspaceId: string, isDefault: boolean): string {
  */
 type Contributions = Map<string, Set<string>>;
 
-/** Effective ids contributed by one `StartMessage` (deduped within the agent). */
+/** Effective ids contributed by one `StartMessage` (deduped within the agent).
+ *
+ * The team id comes from the MESSAGE (`msg.team_id`), NOT `msg.config.team_id`:
+ * the backend `AgentConfig` does not serialise `team_id` (only name/role/
+ * squad_id/prompt/tools/…), so `config.team_id` is `undefined` on the wire. A
+ * default `WorkspaceTool` (no `workspace_id`) therefore resolved to `undefined`
+ * and never merged into the team-default descriptor — using the message-level
+ * `team_id` (which IS on the wire and equals the default descriptor's key) fixes
+ * that, so default-workspace members show up. */
 function startContribution(msg: StartMessage): Set<string> {
-  const teamId = msg.config.team_id;
+  const teamId = msg.team_id;
   const ids = new Set<string>();
   for (const tool of msg.config.tools ?? []) {
     if (isWorkspaceTool(tool)) ids.add(effectiveWorkspaceId(tool, teamId));

--- a/src/app/components/process/selectors/workspace-registry.selector.ts
+++ b/src/app/components/process/selectors/workspace-registry.selector.ts
@@ -72,44 +72,65 @@ function startContribution(msg: StartMessage): Set<string> {
 }
 
 /**
- * Build the descriptor list from the resolved per-agent contributions plus the
- * always-present default descriptor (ADR-019 §Decision 3). The default
- * (`workspaceId === teamId`) is emitted first and absorbs any agent whose
- * effective id equals the team id rather than creating a second default.
+ * Build the descriptor list from the set of workspaces ever discovered plus the
+ * CURRENT per-agent contributions.
+ *
+ * There is NO always-present default: a workspace exists only because at least
+ * one agent declared a `WorkspaceTool` for it (no `workspace_id` → team id,
+ * marked `isDefault`; a `workspace_id` → that name). A team with no
+ * `WorkspaceTool` at all yields an EMPTY list. (Supersedes ADR-019 §Decision 3
+ * / FR6.)
+ *
+ * Workspaces are STICKY: once discovered they remain listed even after their
+ * members are fired (`seen` is monotonic) — the operator keeps browsing access.
+ * `agentIds` reflects only the CURRENTLY-active contributors, so a workspace
+ * whose members have all stopped renders with an empty member list.
  */
 function buildDescriptors(
+  seen: Set<string>,
   contributions: Contributions,
   teamId: string,
 ): WorkspaceDescriptor[] {
-  const byId = new Map<string, Set<string>>([[teamId, new Set<string>()]]);
+  const membersById = new Map<string, Set<string>>();
+  for (const id of seen) membersById.set(id, new Set<string>());
   for (const [agentId, ids] of contributions) {
     for (const id of ids) {
-      const agents = byId.get(id) ?? new Set<string>();
-      agents.add(agentId);
-      byId.set(id, agents);
+      (membersById.get(id) ?? new Set<string>()).add(agentId);
+      membersById.set(id, membersById.get(id) as Set<string>);
     }
   }
-  return [...byId.entries()].map(([workspaceId, agents]) => {
-    const isDefault = workspaceId === teamId;
-    return {
-      workspaceId,
-      isDefault,
-      agentIds: [...agents].sort(),
-      label: labelFor(workspaceId, isDefault),
-    };
-  });
+  return [...membersById.entries()]
+    .map(([workspaceId, agents]) => {
+      const isDefault = workspaceId === teamId;
+      return {
+        workspaceId,
+        isDefault,
+        agentIds: [...agents].sort(),
+        label: labelFor(workspaceId, isDefault),
+      };
+    })
+    // Deterministic order: the default workspace first, then named workspaces
+    // alphabetically by label (stable across re-folds → OnPush-safe).
+    .sort((a, b) => {
+      if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
 }
 
 /**
  * Pure ordered fold over the message log → the deduped set of workspaces in a
- * team (ADR-019 §Decision 1/2/3, mirror of `presenceReduce`).
+ * team (ADR-019 §Decision 1/2, mirror of `presenceReduce`).
  *
- * Ordered-reduce semantics are LOAD-BEARING: a `Start → Stop → Start` restart
- * for one agent must resolve to *present* (last Start wins) — a
- * `some(isStart) && !some(isStop)` shortcut would be wrong. We track each
- * agent's latest contribution and rebuild descriptors, so a `StopMessage`
- * drops only that agent (a descriptor backed by another agent survives; the
- * default descriptor is never removed).
+ * Two pieces of state:
+ * - `seen` — every workspace id ever declared by a `WorkspaceTool`. MONOTONIC:
+ *   a `StopMessage` never removes a workspace, so a discovered workspace stays
+ *   browsable after its members are fired.
+ * - `contributions` — each agent's CURRENT effective ids (Start sets, Stop
+ *   removes). Drives the per-workspace member list.
+ *
+ * Ordered-reduce semantics are LOAD-BEARING for membership: a
+ * `Start → Stop → Start` restart for one agent must resolve to *present* (last
+ * Start wins) — so we track each agent's latest contribution and rebuild.
  *
  * Exported at module scope so tests assert it directly without a `TestBed`.
  */
@@ -118,14 +139,18 @@ export function workspaceRegistryReduce(
   teamId: string,
 ): WorkspaceDescriptor[] {
   const contributions: Contributions = new Map();
+  const seen = new Set<string>();
   for (const m of log) {
     if (isStartMessage(m)) {
-      contributions.set(m.sender.agent_id, startContribution(m));
+      const ids = startContribution(m);
+      contributions.set(m.sender.agent_id, ids);
+      for (const id of ids) seen.add(id);
     } else if (isStopMessage(m)) {
+      // Drop the agent's membership but KEEP the workspace(s) in `seen`.
       contributions.delete(m.sender.agent_id);
     }
   }
-  return buildDescriptors(contributions, teamId);
+  return buildDescriptors(seen, contributions, teamId);
 }
 
 /** Deep structural equality of two descriptor arrays (NFR3). `agentIds` is

--- a/src/app/components/process/workspace/workspace.service.spec.ts
+++ b/src/app/components/process/workspace/workspace.service.spec.ts
@@ -151,6 +151,50 @@ describe('WorkspaceService', () => {
         /Malformed workspace tree response/
       );
     });
+
+    it('appends &workspace_id (encoded) after ?path when workspaceId is set', async () => {
+      const response: WorkspaceTreeResponse = {
+        team_id: 't1',
+        path: 'docs',
+        entries: [],
+      };
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(response));
+
+      await service.getWorkspaceTree('p1', 'docs', 'ws/with space');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toBe(
+        `${environment.api}/workspace/p1/tree?path=docs&workspace_id=ws%2Fwith%20space`
+      );
+    });
+
+    it('leaves the URL byte-for-byte unchanged when workspaceId is omitted', async () => {
+      const response: WorkspaceTreeResponse = {
+        team_id: 't1',
+        path: '',
+        entries: [],
+      };
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(response));
+
+      await service.getWorkspaceTree('p1');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toBe(`${environment.api}/workspace/p1/tree?path=`);
+    });
+
+    it('treats an empty-string workspaceId as absent (appends nothing)', async () => {
+      const response: WorkspaceTreeResponse = {
+        team_id: 't1',
+        path: '',
+        entries: [],
+      };
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(response));
+
+      await service.getWorkspaceTree('p1', '', '');
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toBe(`${environment.api}/workspace/p1/tree?path=`);
+    });
   });
 
   describe('getFileContent', () => {
@@ -227,6 +271,23 @@ describe('WorkspaceService', () => {
         `${environment.api}/workspace/p1/file?path=sub%2Fa.md`
       );
     });
+
+    it('appends &workspace_id (encoded) after ?path when workspaceId is set', async () => {
+      const fetchSpy = spyOn(window, 'fetch').and.returnValue(
+        Promise.resolve(
+          mockFetchResponse({
+            ok: true,
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          })
+        )
+      );
+
+      await service.getFileContent('p1', 'sub/a.md', 'ws id');
+
+      expect(fetchSpy.calls.first().args[0]).toBe(
+        `${environment.api}/workspace/p1/file?path=sub%2Fa.md&workspace_id=ws%20id`
+      );
+    });
   });
 
   describe('getDownloadUrl', () => {
@@ -235,6 +296,18 @@ describe('WorkspaceService', () => {
       expect(url).toBe(
         `${environment.api}/workspace/p1/file?path=src%2Fa.md`
       );
+    });
+
+    it('appends &workspace_id (encoded) after ?path when workspaceId is set', () => {
+      const url = service.getDownloadUrl('p1', 'src/a.md', 'ws/1');
+      expect(url).toBe(
+        `${environment.api}/workspace/p1/file?path=src%2Fa.md&workspace_id=ws%2F1`
+      );
+    });
+
+    it('returns the unchanged URL when workspaceId is omitted', () => {
+      const url = service.getDownloadUrl('p1', 'src/a.md');
+      expect(url).toBe(`${environment.api}/workspace/p1/file?path=src%2Fa.md`);
     });
   });
 
@@ -322,6 +395,32 @@ describe('WorkspaceService', () => {
       await service.uploadFiles('p1', [boundary]);
 
       expect(fetchServiceSpy.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('appends ?workspace_id (encoded) to EVERY POST URL when workspaceId is set', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(undefined));
+      const f1 = new File(['a'], 'a.txt');
+      const f2 = new File(['b'], 'b.txt');
+
+      await service.uploadFiles('p1', [f1, f2], 'docs', 'ws/1');
+
+      expect(fetchServiceSpy.fetch).toHaveBeenCalledTimes(2);
+      for (const call of fetchServiceSpy.fetch.calls.all()) {
+        expect(call.args[0].url).toBe(
+          `${environment.api}/workspace/p1/file?workspace_id=ws%2F1`
+        );
+      }
+    });
+
+    it('leaves the bare /file POST URL unchanged when workspaceId is omitted', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(undefined));
+      const f1 = new File(['a'], 'a.txt');
+
+      await service.uploadFiles('p1', [f1], 'docs');
+
+      expect(fetchServiceSpy.fetch.calls.first().args[0].url).toBe(
+        `${environment.api}/workspace/p1/file`
+      );
     });
   });
 });

--- a/src/app/components/process/workspace/workspace.service.ts
+++ b/src/app/components/process/workspace/workspace.service.ts
@@ -48,12 +48,31 @@ export class WorkspaceService {
 
   private get apiUrl(): string { return this.config.api; }
 
+  /**
+   * Append `workspace_id=<encoded>` to a URL when (and only when) a non-empty
+   * id is supplied (Epic 23 / ADR-019). Centralises the append rule so call
+   * sites never duplicate the concatenation. `undefined`/`null`/`''` append
+   * NOTHING — the URL is returned byte-for-byte unchanged so the backend falls
+   * back to `team_id`. The separator is `&` when the URL already carries a
+   * query string (`?path=...`) and `?` for a bare endpoint (the upload POST).
+   */
+  private withWorkspaceId(url: string, workspaceId?: string | null): string {
+    if (!workspaceId) return url;
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}workspace_id=${encodeURIComponent(workspaceId)}`;
+  }
+
   async getWorkspaceTree(
     processId: string,
-    path: string = ''
+    path: string = '',
+    workspaceId?: string
   ): Promise<FileNode[]> {
+    const url = this.withWorkspaceId(
+      `${this.apiUrl}/workspace/${processId}/tree?path=${encodeURIComponent(path)}`,
+      workspaceId
+    );
     const response = (await this.fetchService.fetch({
-      url: `${this.apiUrl}/workspace/${processId}/tree?path=${encodeURIComponent(path)}`,
+      url,
     })) as WorkspaceTreeResponse | undefined;
 
     if (!response || !Array.isArray(response.entries)) {
@@ -80,13 +99,17 @@ export class WorkspaceService {
 
   async getFileContent(
     processId: string,
-    filePath: string
+    filePath: string,
+    workspaceId?: string
   ): Promise<FileContent> {
     // Bypass FetchService.fetch because its tail unconditionally calls
     // response.json() — incompatible with application/octet-stream bytes.
     // Inline the credentials logic from fetch.service.ts so auth cookies
     // still propagate. See ADR-006 §Decision 2.2.
-    const url = `${this.apiUrl}/workspace/${processId}/file?path=${encodeURIComponent(filePath)}`;
+    const url = this.withWorkspaceId(
+      `${this.apiUrl}/workspace/${processId}/file?path=${encodeURIComponent(filePath)}`,
+      workspaceId
+    );
     const options: RequestInit = this.config.hideLogin
       ? {}
       : { credentials: 'include' };
@@ -110,14 +133,22 @@ export class WorkspaceService {
     }
   }
 
-  getDownloadUrl(processId: string, filePath: string): string {
-    return `${this.apiUrl}/workspace/${processId}/file?path=${encodeURIComponent(filePath)}`;
+  getDownloadUrl(
+    processId: string,
+    filePath: string,
+    workspaceId?: string
+  ): string {
+    return this.withWorkspaceId(
+      `${this.apiUrl}/workspace/${processId}/file?path=${encodeURIComponent(filePath)}`,
+      workspaceId
+    );
   }
 
   async uploadFiles(
     processId: string,
     files: File[],
-    targetPath?: string
+    targetPath?: string,
+    workspaceId?: string
   ): Promise<void> {
     // Pre-flight size check — reject the whole batch if any file is too large,
     // BEFORE issuing any HTTP request (AC7). Strict `>`: 10_485_760 is allowed.
@@ -138,8 +169,14 @@ export class WorkspaceService {
       fd.append('path', uploadPath);
       fd.append('file', file);
 
+      // The POST URL is a bare `/file` (path lives in the FormData body), so
+      // `workspace_id` is the FIRST query param here — the helper appends with
+      // `?`, not `&`. Absent id ⇒ unchanged `.../file` (AC4).
       await this.fetchService.fetch({
-        url: `${this.apiUrl}/workspace/${processId}/file`,
+        url: this.withWorkspaceId(
+          `${this.apiUrl}/workspace/${processId}/file`,
+          workspaceId
+        ),
         options: {
           method: 'POST',
           body: fd,

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -36,11 +36,6 @@ export interface BaseConfig {
   user_id: string;
   user_email: string;
   squad_id: string;
-  /** NOT serialised by the backend `AgentConfig` (which carries only
-   *  name/role/squad_id/prompt/tools/…) — absent on the wire. Use the
-   *  message-level `team_id` (`StartMessage.team_id`) instead. */
-  team_id?: string;
-  parent?: ActorAddress;
   orchestrator: ActorAddress;
   /** Tools bound to this agent, serialised in full on the start config
    *  (Epic 23 / ADR-019). Optional: older payloads / agents without tools

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -36,7 +36,10 @@ export interface BaseConfig {
   user_id: string;
   user_email: string;
   squad_id: string;
-  team_id: string;
+  /** NOT serialised by the backend `AgentConfig` (which carries only
+   *  name/role/squad_id/prompt/tools/…) — absent on the wire. Use the
+   *  message-level `team_id` (`StartMessage.team_id`) instead. */
+  team_id?: string;
   parent?: ActorAddress;
   orchestrator: ActorAddress;
   /** Tools bound to this agent, serialised in full on the start config

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -16,6 +16,20 @@ export interface ActorAddress {
   user_message: boolean;
 }
 
+/**
+ * Lightweight projection of a backend `ToolCard` as it arrives on the wire
+ * inside `StartMessage.config.tools` (Epic 23 / ADR-019). The config is
+ * serialised in full (`msg.model_dump(mode="json")`, no projection), so each
+ * tool carries at least its recursive `__model__` discriminator (e.g.
+ * `"akgentic.tool.workspace.tool.WorkspaceTool"`) and, for a `WorkspaceTool`,
+ * an optional `workspace_id`. We only type the fields the registry fold reads;
+ * every other tool field is intentionally ignored.
+ */
+export interface ToolCardLite {
+  __model__: string;
+  workspace_id?: string | null;
+}
+
 export interface BaseConfig {
   name: string;
   role: string;
@@ -25,6 +39,10 @@ export interface BaseConfig {
   team_id: string;
   parent?: ActorAddress;
   orchestrator: ActorAddress;
+  /** Tools bound to this agent, serialised in full on the start config
+   *  (Epic 23 / ADR-019). Optional: older payloads / agents without tools
+   *  omit it. The WorkspaceRegistry fold reads `WorkspaceTool` entries here. */
+  tools?: ToolCardLite[];
 }
 
 export interface BaseState {
@@ -242,6 +260,18 @@ export function isUserMessage(msg: BaseMessage): msg is UserMessage {
 
 export function isResultMessage(msg: BaseMessage): msg is ResultMessage {
   return msg.__model__.includes('ResultMessage');
+}
+
+/**
+ * ToolCard discriminator check (Epic 23 / ADR-019): true when `t` is a
+ * `WorkspaceTool`. Matches on the recursive `__model__` *ending in*
+ * `WorkspaceTool` (so `"akgentic.tool.workspace.tool.WorkspaceTool"` matches),
+ * deliberately stricter than the `.includes()` used by the message guards: a
+ * `__model__` that merely contains `WorkspaceTool` mid-string (or a different
+ * tool such as `...KnowledgeGraphTool`, or the empty string) is rejected.
+ */
+export function isWorkspaceTool(t: ToolCardLite): t is ToolCardLite {
+  return t.__model__.endsWith('WorkspaceTool');
 }
 
 /**


### PR DESCRIPTION
## Epic 23 — Workspace sub-tabs from a per-agent WorkspaceTool registry (ADR-019)

Umbrella PR for Epic 23. Discovers every workspace in a team by folding each agent's `StartMessage.config.tools` into a reactive `WorkspaceRegistry` selector over the unified message log (mirror of `tool-presence.selector.ts`), then threads an optional `workspace_id` through `WorkspaceService` + `WorkspaceExplorerComponent` and renders one PrimeNG sub-tab per discovered workspace. ADR-020 then adds a per-workspace member-chip header strip surfacing who can access each workspace.

This PR is reused by all stories in the epic; it is updated as each story lands on the shared epic branch.

### Stories

- [x] 23-1-workspace-protocol-model-and-workspace-registry-selector — protocol model + WorkspaceRegistry selector (Relates to #176)
- [x] 23-2-workspace-id-plumbing-workspace-service-and-explorer — optional `workspaceId` threaded through `WorkspaceService` + `WorkspaceExplorerComponent` (Relates to #178)
- [x] 23-3-workspace-sub-tabs-ui — `WorkspaceTabsComponent` rendering one PrimeNG `<p-tabpanel>` per descriptor; registry wired into `ProcessComponent` (Relates to #179)
- [x] 23-4-workspace-access-member-chips — per-workspace member chips, ADR-020 (Relates to #181)

### Story 23-1 scope

- `protocol/message.types.ts`: `ToolCardLite { __model__; workspace_id? }`, optional `tools?: ToolCardLite[]` on `BaseConfig`, `isWorkspaceTool` guard (`endsWith('WorkspaceTool')`).
- `components/process/selectors/workspace-registry.selector.ts` (new): `WorkspaceDescriptor`, pure module-scope `workspaceRegistryReduce(log, teamId)` (ordered last-wins, effective id = `workspace_id ?? team_id`, always-present default descriptor, Stop drops the stopped agent's contribution), and a component-scoped `WorkspaceRegistryService` exposing `workspaces$` with a structural `distinctUntilChanged` comparator (OnPush-safe).
- `components/process/selectors/workspace-registry.selector.spec.ts` (new): pure-fold + TestBed service suites + a realistic serialized `StartMessage` fixture guarding the `tools` serialization contract (NFR4).

No UI and no `process.component` provider wiring yet — `WorkspaceRegistryService` is created here, provided/consumed in 23-3.

### Story 23-2 scope

- `components/process/workspace/workspace.service.ts`: single private `withWorkspaceId(url, workspaceId?)` helper encodes the append rule once (AC5) — appends `workspace_id=<encodeURIComponent(id)>` only when the id is a non-empty string, choosing `&` when the URL already carries `?path=` and `?` for the bare `/file` upload POST; falsy id ⇒ URL byte-for-byte unchanged (team_id fallback). Optional trailing `workspaceId?` threaded through `getWorkspaceTree`, `getFileContent`, `getDownloadUrl`, `uploadFiles`; all existing parse/decode/credentials/pre-flight/halt-on-error behaviour preserved.
- `components/process/components/workspace-explorer/workspace-explorer.component.ts`: `@Input() workspaceId?: string`, `OnChanges` refetch (guards `firstChange` and unchanged-value so init does not double-fetch), and the id threaded through all six call sites. The unset path keeps the existing 2-arg `getWorkspaceTree` call shape via a private `fetchTree` helper.

No `<p-tabs>` UI and no `process.component` wiring yet — that is Story 23-3.

### Story 23-3 scope

- `components/process/components/workspace-tabs/workspace-tabs.component.{ts,html}` (new): standalone `OnPush` `app-workspace-tabs` consuming `WorkspaceRegistryService.workspaces$ | async`. Branches on descriptor count: a single default descriptor (`ws.length <= 1`) renders a bare `<app-workspace-explorer>` with **no** `[workspaceId]` binding and **no** tab chrome (visually identical to today, FR13); `ws.length > 1` renders `<p-tabs>` chrome with one `<p-tab>`/`<p-tabpanel>` per descriptor (FR12/FR13). Default panel binds `[workspaceId]="undefined"` (team-id-only); named panels bind their `workspaceId`. Tab labels read directly from `descriptor.label` (FR12).
- `components/process/components/workspace-tabs/workspace-tabs.component.spec.ts` (new): fake `WorkspaceRegistryService` with a controllable `BehaviorSubject`; asserts the default-only (no chrome, `workspaceId` undefined), default+named (chrome, one panel per descriptor, correct per-panel `workspaceId` bindings inspected by activating each tab — PrimeNG 19 lazy-renders only the active panel), label rendering, and reactive re-emission cases.
- `process.component.ts`: `WorkspaceRegistryService` added to `providers` (after `MessageLogService`, which it injects); `WorkspaceExplorerComponent` → `WorkspaceTabsComponent` swapped in `imports`, unused explorer import removed (FR14).
- `process.component.html`: workspace-slot `<app-workspace-explorer>` swapped 1:1 for `<app-workspace-tabs>`, preserving the `*ngIf="hasWorkspace"` gate and `[class.moved-offscreen]="isHidden('workspace')"` show/hide (FR13/FR14).

### Story 23-4 scope (ADR-020 — workspace access member chips)

- `components/process/selectors/agents-by-id.selector.ts` (new): exported `AgentIdentity { name; role }` + `AgentsById = Record<string, AgentIdentity>`, a pure module-scope `agentsByIdReduce(log)` fold recording each `StartMessage.sender.agent_id → { name, role }` (last-wins; `StopMessage`s deliberately NOT folded out — this map resolves DISPLAY identity, membership stays governed by `workspaceRegistryReduce`), and a component-scoped `AgentsByIdService` exposing `agentsById$` with a **structural** `distinctUntilChanged` (`agentsByIdEqual`). Mirrors the `tool-presence` / `workspace-registry` selector idiom exactly; `WorkspaceDescriptor` and the 23-1 fold are untouched (no descriptor churn).
- `components/process/selectors/agents-by-id.selector.spec.ts` (new): pure-fold suite (empty log, two starts, last-wins, Stop-ignored) + TestBed service suite (initial empty, live append, structural `distinctUntilChanged` suppression, `reset()` on team switch).
- `components/process/components/workspace-tabs/workspace-tabs.component.{ts,html,scss}`: combines `workspaces$` + `agentsById$` into one `vm$` (`combineLatest` + `map`), adds a pure `resolveMembers(d, agentsById)` helper (descriptor `agentIds` → `{ name, role }` in order; defensive fallback to the raw `agent_id` when missing). A slim `.workspace-header-strip` renders ABOVE the explorer in **both** branches via a reusable `#memberRow` template — the single-default branch keeps **no** `<p-tabs>` chrome (FR13: the strip is not a tab bar). Member chips use `<p-chip [label]="name" [pTooltip]="role">` (v1 = membership only — no read/write level indicator). An empty default descriptor (`isDefault && agentIds.length === 0`) renders the neutral "Team default — all members" affordance. Imports `ChipModule`/`AvatarModule`/`TooltipModule`; OnPush preserved.
- `components/process/components/workspace-tabs/workspace-tabs.component.spec.ts`: fake `AgentsByIdService` (BehaviorSubject) alongside the existing fake registry; new tests cover AC2 (single-default strip, no tab chrome), AC3 (two chips Bob/Amelia in order + role via `Tooltip.content`), AC4 (empty-default affordance, no chips), AC5 (sub-tab switch updates the chip row), plus the defensive unknown-`agent_id` fallback. The four 23-3 sub-tab tests stay green (AC6).
- `process.component.ts`: `AgentsByIdService` added to `providers` (after `MessageLogService`, which it injects; never `providedIn: 'root'`). No other provider/import/slot touched.

## Review status

**Story 23-1 — DONE (Rex).** All 10 acceptance criteria verified implemented:
- AC1/AC2 protocol model + guard correct; `endsWith` rejects `KnowledgeGraphTool`, empty, and mid-string `WorkspaceToolFactory`.
- AC3–AC7 pure fold: dedupe by effective id, all contributing `agentIds` recorded, always-present default descriptor, ordered last-wins, Stop-drop, default immune to Stop — all covered by tests.
- AC8/AC10 service component-scoped (not `providedIn: 'root'`), `distinctUntilChanged` uses a **structural** comparator (`descriptorsEqual`), not the default reference comparator.
- AC9 NFR4 realistic serialized fixture present.
- Golden Rule #8 satisfied: ADR references appear only in docstrings/comments; no test asserts on an `ADR-NNN` string and no runtime logic branches on one.

No HIGH or MEDIUM issues found, so no fixup commit was created. Local verification: lint clean, Karma 987 SUCCESS, production build succeeds.

- 23-2 review: PASS (Rex). All 9 ACs implemented and tested. Service URL append centralised in `withWorkspaceId` (AC5); byte-unchanged URL when absent, encoded `&workspace_id=`/`?workspace_id=` append when set, verified for values containing `/` and a space. `@Input() workspaceId` threaded through all six component call sites (AC6/AC7); `ngOnChanges` refetches only on a non-first, value-changed `workspaceId` (AC8). Scope held — no `<p-tabs>` / `process.component` wiring (deferred to 23-3). Golden Rule #8 respected (ADR refs only in docstrings/comments). No HIGH/MEDIUM issues ⇒ no fixup commit. Local: lint clean, Karma **1000/1000 SUCCESS**, production build succeeds.

- 23-3 review: PASS (Rex). All 7 ACs implemented and tested. One `<p-tabpanel>` per descriptor each hosting `<app-workspace-explorer>` (AC1); default panel binds no `workspaceId` / named panels bind theirs (AC2); single-default renders no tab chrome (AC3); chrome appears at length ≥ 2 (AC4); labels read from `descriptor.label` (AC5); `WorkspaceRegistryService` provided in `ProcessComponent` after `MessageLogService` and reactive emissions re-render (AC6); mounted 1:1 in the workspace slot preserving `*ngIf="hasWorkspace"` + `moved-offscreen` (AC7). Scope held — frontend-only, all five touched files inside `packages/akgentic-frontend/`, no infra/ADR-029 change. Golden Rule #8 respected (ADR refs only in docstrings/comments; spec has none). No HIGH/MEDIUM issues ⇒ no fixup commit. Local: lint clean, Karma **1004/1004 SUCCESS**, production build succeeds.

- 23-4 review: PASS (Rex). All 7 ACs implemented and tested. New `agentsById$` selector is a pure last-wins fold over the message log with a **structural** `distinctUntilChanged`, component-scoped on `ProcessComponent` after `MessageLogService` (never `providedIn: 'root'`), `AgentIdentity` typed and exported (AC1, AC6). The slim header strip renders ABOVE the explorer in **both** branches; the single-default branch keeps no `<p-tabs>` chrome — `hasTabChrome()` stays false (FR13 / AC2). Chips render the resolved member **names** in `agentIds` order with the **role** as `pTooltip` (AC3); an empty default descriptor shows "Team default — all members" with no chips (AC4); switching sub-tabs updates the chip row to the selected descriptor's members (AC5). `WorkspaceDescriptor` and the 23-1 fold are untouched — no descriptor churn, the 23-3 sub-tab tests stay green (AC6). v1 = membership only — no read/write access-level indicator, no inverse view, no matrix (AC7, deferred per ADR-020). Scope held — frontend-only, all seven touched files inside `packages/akgentic-frontend/`; no backend/protocol/`WorkspaceDescriptor`/`WorkspaceService`/`WorkspaceExplorer` change. Golden Rule #8 respected (ADR refs only in docstrings/comments; specs assert behaviour, not ADR strings). No HIGH/MEDIUM issues ⇒ no fixup commit. Local: lint clean, Karma **1017/1017 SUCCESS**, production build succeeds.

## Epic 23 slice complete

All stories of Epic 23 have landed on the shared epic branch:

- **23-1** — protocol model (`ToolCardLite`, `isWorkspaceTool`) + the `WorkspaceRegistry` selector/service that folds the message log into a deduped, ordered set of `WorkspaceDescriptor`s (default descriptor always present).
- **23-2** — optional `workspace_id` plumbed through `WorkspaceService` (`withWorkspaceId` append rule) and exposed as `WorkspaceExplorerComponent.@Input() workspaceId` (unset ⇒ today's team-id-only behaviour).
- **23-3** — `WorkspaceTabsComponent` renders one sub-tab per descriptor under the Workspace view; the single-default case is visually identical to today (no tab chrome). Registry wired into `ProcessComponent`.
- **23-4 (ADR-020)** — a per-workspace member-chip header strip surfacing **who** can access each workspace (membership only), built from `WorkspaceDescriptor.agentIds` resolved to `{ name, role }` via a new `agentsById$` identity map; the strip renders in both layout branches without reintroducing tab chrome (FR13). Access **level** (read/write) is a deferred v1.1 fast-follow (`ToolCardLite` capability-flag extension), and the per-member inverse "member X reaches workspaces A, B" view is a future Member-tab story — both intentionally out of scope here.

This is a self-contained frontend slice and merges independently. Named-workspace addressing (a non-default tab actually browsing a distinct directory) has a **runtime dependency on akgentic-infra ADR-029** — the backend `workspace_id` HTTP query parameter. Until ADR-029 deploys, every team still presents only the default descriptor, so the UI is unchanged from today; once ADR-029 ships, agents declaring named `WorkspaceTool`s light up their own sub-tabs with no further frontend change. ADR-029 is tracked separately and is never modified by this PR (CLAUDE.md Golden Rule #4).

## Scope guard

All changes for this epic stay inside `packages/akgentic-frontend/`. The `workspace_id` HTTP query parameter is akgentic-infra ADR-029 — a runtime dependency only, never modified here (CLAUDE.md Golden Rule #4). No other submodule is touched.

Closes #176
