### PR TITLE
feat(akgentic-frontend): tidy the Member tab — drop unused State tab, filter actor-tools

### DIFF
--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.html
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.html
@@ -4,12 +4,6 @@
       <p-tab value="0" *ngIf="chatTabVisible$ | async">
         Chat with "{{ selectedAgent?.label }}"
       </p-tab>
-      <p-tab
-        [value]="(chatTabVisible$ | async) ? '1' : '0'"
-        *ngIf="state$ | async"
-      >
-        State of "{{ selectedAgent?.label }}"
-      </p-tab>
       <div
         style="
           margin-left: auto;
@@ -42,15 +36,6 @@
           [agentId]="akgentId"
           [agentName]="akgentName"
         ></app-akgent-chat>
-      </p-tabpanel>
-      <p-tabpanel
-        [value]="(chatTabVisible$ | async) ? '1' : '0'"
-        *ngIf="state$ | async"
-      >
-        <app-akgent-state
-          [state$]="state$"
-          [agentId]="akgentId"
-        ></app-akgent-state>
       </p-tabpanel>
     </p-tabpanels>
   </p-tabs>

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
@@ -18,7 +18,6 @@ import {
 import { IngestionService } from '../../event/ingestion.service';
 
 import { AkgentChatComponent } from './akgent-chat/akgent-chat.component';
-import { AkgentStateComponent } from './akgent-state/akgent-state.component';
 
 @Component({
   selector: 'app-agent-tabs',
@@ -29,7 +28,6 @@ import { AkgentStateComponent } from './akgent-state/akgent-state.component';
     TabsModule,
     DropdownModule,
     AkgentChatComponent,
-    AkgentStateComponent,
   ],
   templateUrl: './agent-tabs.component.html',
   styleUrl: './agent-tabs.component.scss',
@@ -137,9 +135,13 @@ export class AgentTabsComponent implements OnInit {
           this.selectedAgent = null;
           return;
         }
-        // Remove agents with role 'human_proxy'
+        // Remove human-proxy agents, and tool actors (their actorName starts
+        // with '#', e.g. #VectorStore / #KnowledgeGraphTool) — the Member
+        // dropdown lists real agents only.
         const filteredAgents = agents.filter(
-          (a: any) => (a.role || '') !== HUMAN_PROXY_ROLE
+          (a: any) =>
+            (a.role || '') !== HUMAN_PROXY_ROLE &&
+            !String(a.actorName ?? '').startsWith('#')
         );
 
         // Helper to build dropdown item


### PR DESCRIPTION
## Member tab cleanup

Closes #182.

- **Remove the unused "State of …" tab** — the Member tab now shows only the chat. `state$` is retained because it still drives the never-run backstory head-block and chat-tab visibility (it was only the State *panel* UI that was unused).
- **Filter actor-tools from the agent dropdown** — agents whose `actorName` starts with `#` (e.g. `#VectorStore`, `#KnowledgeGraphTool`) are excluded alongside the existing human-proxy exclusion, so the dropdown lists real agents only.

Frontend-only. Local: lint clean, Karma 1025/1025, build green.

## Scope guard
All changes are inside `packages/akgentic-frontend/src/app/components/process/components/agent-tabs/`.
