### PR TITLE
Frontend UI polish: right-align chat footer + Knowledge Graph empty-state placeholder

### DIFF
--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.html
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.html
@@ -12,6 +12,18 @@
         [options]="graphOptions"
         (chartInit)="onChartInit($event)"
       ></div>
+      <!-- Empty-state placeholder (overlay), styled like the Workspace
+           placeholder. Shown when the graph has no entities. -->
+      <div
+        class="kg-graph-empty"
+        *ngIf="!(graphData$ | async)?.nodes?.length"
+      >
+        <i class="pi pi-sitemap kg-graph-empty-icon"></i>
+        <div class="kg-graph-empty-title">No Knowledge Graph</div>
+        <div class="kg-graph-empty-desc">
+          No entities yet — the graph will populate as agents add knowledge.
+        </div>
+      </div>
     </div>
   </div>
 </ng-template>

--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.scss
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.scss
@@ -613,6 +613,41 @@
         height: 100%;
         min-height: 350px;
     }
+
+    // Empty-state placeholder overlay, mirroring the Workspace placeholder
+    // look (dashed box, icon + title + description, centered).
+    .kg-graph-empty {
+        position: absolute;
+        inset: 0;
+        margin: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        gap: 0.5rem;
+        color: #6c757d;
+        background: #f8f9fa;
+        border-radius: 8px;
+        border: 2px dashed #dee2e6;
+
+        &-icon {
+            font-size: 3.5rem;
+            margin-bottom: 1rem;
+            color: #adb5bd;
+        }
+
+        &-title {
+            font-size: 1.25rem;
+            font-weight: 500;
+        }
+
+        &-desc {
+            font-size: 0.95rem;
+            color: #aaa;
+            max-width: 400px;
+        }
+    }
 }
 
 .nodes-section h4,

--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.ts
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.ts
@@ -224,7 +224,7 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
 
     const chartOptions: EChartsCoreOption = {
       title: {
-        text: data.nodes.length === 0 ? 'No Knowledge Graph' : null,
+        text: null, // empty state rendered as an HTML placeholder overlay
         top: '50%',
         left: 'center',
       },
@@ -297,7 +297,7 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
     // Complete series update with all necessary configuration
     this.echartsInstance.setOption({
       title: {
-        text: data.nodes.length === 0 ? 'No Knowledge Graph' : null,
+        text: null, // empty state rendered as an HTML placeholder overlay
       },
       legend: {
         data: categories.length > 0 ? categories.map((c) => c.name) : [],

--- a/src/app/components/process/components/user-input/user-input.component.scss
+++ b/src/app/components/process/components/user-input/user-input.component.scss
@@ -62,7 +62,11 @@
 .button-group {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  // Right-align the controls as a group. With "Send as" present its
+  // `.send-as-group { margin-left: auto }` already pushes the cluster right;
+  // flex-end makes the no-"Send as" case (Send to + multiselect + Submit)
+  // right-align the same way instead of spreading across the row.
+  justify-content: flex-end;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Frontend UI polish

Closes #184.

- **Right-align chat footer controls** — without a "Send as" selector, the Send to label / multiselect / Submit spread across the footer (`justify-content: space-between`). Switched to `flex-end` so they right-align as a group, matching the "Send as" layout.
- **Knowledge Graph empty state** — replaced the plain echarts "No Knowledge Graph" canvas label with an HTML placeholder overlay (sitemap icon + title + description in a dashed box), consistent with the Workspace empty-state placeholder. The echarts container stays mounted; the overlay shows when the graph has no entities.

Frontend-only. Local: lint clean, Karma 1025/1025, build green.

## Scope guard
Changes are inside `packages/akgentic-frontend/src/app/components/process/components/` (user-input + knowledge-graph).
