### PR TITLE
fix(akgentic-frontend): append KG modal to body so it layers above the chat chip

### DIFF
--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.html
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.html
@@ -138,7 +138,9 @@
     [draggable]="false"
     [dismissableMask]="true"
     (onHide)="isModalView = false"
-    class="kg-pdialog"
+    appendTo="body"
+    styleClass="kg-pdialog"
+    maskStyleClass="kg-pdialog-mask"
   >
     <ng-template pTemplate="header">
       <div class="dialog-header-container">

--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.scss
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.scss
@@ -504,15 +504,20 @@
 
 // Z-Index Management for Proper Layering
 ::ng-deep {
-    // Main Knowledge Graph modal (highest priority - must be above any parent panels)
-    .kg-pdialog {
-        .p-dialog-mask {
-            z-index: 9999 !important; // Very high to ensure it's above parent panels
-        }
-        
-        .p-dialog {
-            z-index: 10000 !important; // Highest priority
-        }
+    // Main Knowledge Graph modal (highest priority - must be above any parent panels).
+    // The dialog uses appendTo="body", so its mask/dialog are lifted out of this
+    // component's subtree to the document root — that is what actually makes the
+    // z-index win globally (a confined high z-index loses to a sibling stacking
+    // context; see chat's z-5 "Auto scrolling" chip leaking through). The classes
+    // are applied directly to the moved elements via maskStyleClass/styleClass, so
+    // these rules keep matching after the move (a descendant `.kg-pdialog .p-dialog-mask`
+    // selector would not, since the mask is no longer a descendant of the host).
+    .kg-pdialog-mask {
+        z-index: 9999 !important; // Very high to ensure it's above parent panels
+    }
+
+    .kg-pdialog.p-dialog {
+        z-index: 10000 !important; // Highest priority
     }
     
     // Floating dialog in tab view (medium priority)


### PR DESCRIPTION
## Summary

Fixes the Knowledge Graph modal stacking bug: the chat **"Messages" / "Auto scrolling"** pill (`.jump-to-latest`, `z-index: 5`) was painting **on top of** the KG modal.

## Root cause

The KG modal `p-dialog` (`knowledge-graph.component.html`) rendered **inline** in the component subtree (no `appendTo`). Its `baseZIndex=9999` / `.kg-pdialog … z-index: 9999/10000 !important` therefore only applied **within that local stacking context** — and z-index does not compare across stacking contexts. The `akgent-chat` "Auto scrolling" chip (`z-index: 5`) sits in a sibling stacking context that paints later, so a `5` leaked over a `9999`.

## Change

- `knowledge-graph.component.html` — add `appendTo="body"` to the KG modal dialog so its mask + content are lifted to the document root and the z-index competes globally. Because that moves the mask/dialog out of the component host, the class is applied directly via `styleClass="kg-pdialog"` + `maskStyleClass="kg-pdialog-mask"` (instead of `class`).
- `knowledge-graph.component.scss` — retarget the z-index rules to `.kg-pdialog-mask` (9999) and `.kg-pdialog.p-dialog` (10000) so they keep matching after the move, with an explanatory comment.

Scope: the two KG component files only. No change to the chat panel, other components, or any other submodule.

## Verification

- ESLint: clean
- `ng build`: succeeds (only the pre-existing lodash CommonJS warning)
- Karma: 1037/1037 pass

Relates to #189
