### PR TITLE
feat(akgentic-frontend): epic 26 — LLM Token-Usage Selector + Chat / Team Displays (26-1-token-usage-data-layer -> 26-3-team-tree-footer-total)

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -139,6 +139,32 @@
         <span *ngIf="item.description" class="mention-item-desc">{{ item.description }}</span>
       </ng-template>
       <div class="input-row-buttons">
+        <!--
+          ADR-022 §Decision 5 — non-interactive token-usage pill, first child of
+          `.input-row-buttons` (left of Submit). Bound to
+          `tokenUsageSelector.perAgent$(agentId) | async`: a defined usage renders
+          `ctx <ctx> · ↑<sent> ↓<received>` (every number via `tokenCount`); a
+          never-run agent (`undefined`) renders the neutral `ctx — · ↑0 ↓0`
+          empty-state (the VIEW owns the empty-state, ADR-022 §OQ2). A native
+          `title` tooltip spells out the words + model, degrading to "No usage
+          yet" when never-run. Non-interactive `<span>` — no click, no routerLink.
+        -->
+        <span
+          *ngIf="usage$ | async as usage; else emptyPill"
+          class="usage-pill"
+          [title]="
+            'Context window ' + (usage.lastContextWindow | number) +
+            ' · Sent ' + (usage.totalSent | number) +
+            ' · Received ' + (usage.totalReceived | number) +
+            ' · ' + usage.lastModelName
+          "
+        >
+          ctx {{ usage.lastContextWindow | tokenCount }} ·
+          ↑{{ usage.totalSent | tokenCount }} ↓{{ usage.totalReceived | tokenCount }}
+        </span>
+        <ng-template #emptyPill>
+          <span class="usage-pill" title="No usage yet">ctx — · ↑0 ↓0</span>
+        </ng-template>
         <button
           pButton
           type="button"

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
@@ -27,6 +27,26 @@
     .pi-spinner {
       font-size: 1rem;
     }
+
+    // ADR-022 §Decision 5 — token-usage pill: compact, muted, non-interactive.
+    // Visually subordinate to Submit (small, muted). `white-space: nowrap`
+    // keeps `ctx … · ↑… ↓…` on one line; `default` cursor signals it is not a
+    // control. Shrinks before Submit at narrow widths so it never pushes the
+    // button off the row.
+    .usage-pill {
+      flex: 0 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      cursor: default;
+      color: #64748b;
+      font-size: 0.75rem;
+      font-variant-numeric: tabular-nums;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      background-color: #f1f5f9;
+    }
   }
 }
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -2,7 +2,7 @@ import { SimpleChange } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 
 import { AkgentChatComponent } from './akgent-chat.component';
 import { ApiService } from '../../../../../core/http/api.service';
@@ -17,10 +17,27 @@ import {
   systemPromptMatch,
   systemPromptReduce,
 } from '../../../selectors/system-prompt.selector';
+import { TokenUsageSelector } from '../../../selectors/token-usage.selector';
+import { AgentTokenUsage } from '../../../event/per-agent-specs';
 import {
   AkgenticMessage,
   CommandDescriptor,
 } from '../../../../../protocol/message.types';
+
+/**
+ * Story 26-2 — the component injects the component-scoped TokenUsageSelector for
+ * the member-chat usage pill. Existing TestBeds (head block / follow mode /
+ * keyboard) don't exercise the pill, so they provide this neutral stub whose
+ * `perAgent$` always emits `undefined` (never-run empty-state) — enough to let
+ * the component construct without re-wiring the full tokenUsage store.
+ */
+const NEUTRAL_TOKEN_USAGE_SELECTOR = {
+  provide: TokenUsageSelector,
+  useValue: {
+    perAgent$: (_id: string): Observable<AgentTokenUsage | undefined> =>
+      of(undefined),
+  },
+};
 
 /**
  * Story 15-1 (ADR-013) — member-chat `/` slash-command mention. The member
@@ -88,6 +105,7 @@ describe('AkgentChatComponent — slash-command mention (Story 15-1 / 17-3)', ()
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
       ],
     });
 
@@ -346,6 +364,7 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
         // PrimeNG p-fieldset registers a synthetic animation listener.
         provideNoopAnimations(),
       ],
@@ -609,6 +628,7 @@ describe('AkgentChatComponent — never-run backstory head block (Story 20-1)', 
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
         provideNoopAnimations(),
       ],
     });
@@ -740,6 +760,7 @@ describe('AkgentChatComponent — never-run backstory head block (Story 20-1)', 
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
         provideNoopAnimations(),
       ],
     });
@@ -795,6 +816,7 @@ describe('AkgentChatComponent — follow mode + status pill', () => {
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
         provideNoopAnimations(),
       ],
     });
@@ -968,6 +990,7 @@ describe('AkgentChatComponent — keyboard submit parity', () => {
           deps: [PerAgentStoreRegistry],
         },
         SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
         provideNoopAnimations(),
       ],
     });
@@ -1011,5 +1034,206 @@ describe('AkgentChatComponent — keyboard submit parity', () => {
     component.userInputEnterKeySubmit = false;
     textareaEl().triggerEventHandler('keydown.control.enter', {});
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 26-2 (ADR-022 §Decision 5) — member-chat token-usage pill. A compact,
+// non-interactive pill sits as the FIRST child of `.input-row-buttons` (left of
+// Submit), bound to `tokenUsageSelector.perAgent$(agentId) | async`: populated
+// → `ctx <ctx> · ↑<sent> ↓<received>` (every number via `tokenCount`); never-run
+// (`undefined`) → the neutral `ctx — · ↑0 ↓0`. Driven through a fake selector
+// whose `perAgent$` returns a controllable BehaviorSubject so render / live-update
+// / empty-state are deterministic.
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
+  const AGENT = 'a-mgr';
+
+  function usage(partial: Partial<AgentTokenUsage>): AgentTokenUsage {
+    return {
+      lastContextWindow: 0,
+      lastRunId: 'run-1',
+      lastModelName: 'gpt-4o',
+      totalSent: 0,
+      totalReceived: 0,
+      ...partial,
+    };
+  }
+
+  function setup(initial: AgentTokenUsage | undefined): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    component: AkgentChatComponent;
+    usage$: BehaviorSubject<AgentTokenUsage | undefined>;
+  } {
+    const usage$ = new BehaviorSubject<AgentTokenUsage | undefined>(initial);
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        // Fake selector: `perAgent$` returns the controllable subject so the
+        // spec drives populated / updated / empty emissions deterministically.
+        {
+          provide: TokenUsageSelector,
+          useValue: {
+            perAgent$: (_id: string) => usage$.asObservable(),
+          },
+        },
+        provideNoopAnimations(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, component, usage$ };
+  }
+
+  /** The `.input-row-buttons` row element. */
+  function buttonsRow(
+    fixture: ComponentFixture<AkgentChatComponent>,
+  ): HTMLElement {
+    const el: HTMLElement = fixture.nativeElement;
+    return el.querySelector('.input-row-buttons') as HTMLElement;
+  }
+
+  /** The pill element (the `.usage-pill` span). */
+  function pill(
+    fixture: ComponentFixture<AkgentChatComponent>,
+  ): HTMLElement | null {
+    return buttonsRow(fixture).querySelector('.usage-pill');
+  }
+
+  /** The pill's rendered text with whitespace collapsed (OQ3: glyphs/order are
+   *  the contract, not exact spacing). */
+  function pillText(fixture: ComponentFixture<AkgentChatComponent>): string {
+    return (pill(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  it('(a) renders left of Submit inside `.input-row-buttons` with the populated `ctx … · ↑… ↓…` format', () => {
+    const { fixture } = setup(
+      usage({
+        lastContextWindow: 12_300,
+        totalSent: 45_000,
+        totalReceived: 12_100,
+        lastModelName: 'gpt-4o',
+      }),
+    );
+    fixture.detectChanges();
+
+    // tokenCount: 12_300 → "12.3k", 45_000 → "45.0k", 12_100 → "12.1k".
+    expect(pillText(fixture)).toBe('ctx 12.3k · ↑45.0k ↓12.1k');
+
+    // The pill is the FIRST child of the buttons row, and Submit comes after it.
+    const row = buttonsRow(fixture);
+    expect(row.firstElementChild?.classList.contains('usage-pill')).toBeTrue();
+    const children = Array.from(row.children);
+    const pillIdx = children.findIndex((c) => c.classList.contains('usage-pill'));
+    const submitIdx = children.findIndex((c) => c.tagName.toLowerCase() === 'button');
+    expect(pillIdx).toBeLessThan(submitIdx);
+
+    // Non-interactive: a <span>, not a <button>, no routerLink.
+    const p = pill(fixture)!;
+    expect(p.tagName.toLowerCase()).toBe('span');
+    expect(p.getAttribute('href')).toBeNull();
+
+    // Tooltip spells out the words + model (full grouped numbers).
+    expect(p.getAttribute('title')).toBe(
+      'Context window 12,300 · Sent 45,000 · Received 12,100 · gpt-4o',
+    );
+  });
+
+  it('(b) live update: a fresh emission with a SMALLER newest ctx updates ctx to the newest value; totals reflect the sums', () => {
+    const { fixture, usage$ } = setup(
+      usage({ lastContextWindow: 30_000, totalSent: 30_000, totalReceived: 9_000 }),
+    );
+    fixture.detectChanges();
+    expect(pillText(fixture)).toBe('ctx 30.0k · ↑30.0k ↓9.0k');
+
+    // Newest event has a SMALLER context window than the prior one — ctx tracks
+    // the newest input_tokens (ADR-022 §Decision 3, overwrite semantics), while
+    // the totals keep accumulating.
+    usage$.next(
+      usage({ lastContextWindow: 8_000, totalSent: 38_000, totalReceived: 11_500 }),
+    );
+    fixture.detectChanges();
+    expect(pillText(fixture)).toBe('ctx 8.0k · ↑38.0k ↓11.5k');
+  });
+
+  it('(c) never-run agent (`perAgent$` emits undefined) renders the neutral `ctx — · ↑0 ↓0` empty-state', () => {
+    const { fixture } = setup(undefined);
+    fixture.detectChanges();
+
+    expect(pillText(fixture)).toBe('ctx — · ↑0 ↓0');
+    // Still non-interactive, and its tooltip must not render undefined/null.
+    const p = pill(fixture)!;
+    expect(p.tagName.toLowerCase()).toBe('span');
+    expect(p.getAttribute('title')).toBe('No usage yet');
+  });
+
+  it('the pill follows an agent switch (perAgent$ re-bound in ngOnChanges)', () => {
+    const { fixture, component } = setup(
+      usage({ lastContextWindow: 5_000, totalSent: 5_000, totalReceived: 1_000 }),
+    );
+    fixture.detectChanges();
+    const before = pillText(fixture);
+    expect(before).toBe('ctx 5.0k · ↑5.0k ↓1.0k');
+
+    // Switching members reuses this component; ngOnChanges re-binds usage$.
+    component.agentId = 'b-other';
+    component.ngOnChanges({ agentId: new SimpleChange(AGENT, 'b-other', false) });
+    fixture.detectChanges();
+    // The fake selector returns the same subject for any id, so the pill still
+    // renders (the re-bind path did not throw / null the stream).
+    expect(pillText(fixture)).toBe('ctx 5.0k · ↑5.0k ↓1.0k');
+  });
+
+  it('(AC #7) adding the pill leaves the Submit disabled binding intact', () => {
+    const { fixture, component } = setup(
+      usage({ lastContextWindow: 1_000, totalSent: 1_000, totalReceived: 100 }),
+    );
+    fixture.detectChanges();
+
+    const submit = buttonsRow(fixture).querySelector('button') as HTMLButtonElement;
+    // Empty input → Submit disabled (existing rule unchanged).
+    expect(submit.disabled).toBeTrue();
+
+    // Typing enables it (team is running in this harness).
+    component.userInput = 'hello';
+    fixture.detectChanges();
+    expect(submit.disabled).toBeFalse();
   });
 });

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -26,6 +26,7 @@ import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { CapitalizePipe } from '../../../../../shared/pipes/capitalise.pipe';
+import { TokenCountPipe } from '../../../../../shared/pipes/token-count.pipe';
 import { ApiService } from '../../../../../core/http/api.service';
 import { UtilService } from '../../../../../core/ui/utils.service';
 import { ContextService } from '../../../../../core/context/context.service';
@@ -36,6 +37,8 @@ import {
   SystemPromptSelector,
   systemPromptLabel,
 } from '../../../selectors/system-prompt.selector';
+import { TokenUsageSelector } from '../../../selectors/token-usage.selector';
+import { AgentTokenUsage } from '../../../event/per-agent-specs';
 import { CommandDescriptor } from '../../../../../protocol/message.types';
 
 import { CopyButtonComponent } from '../../../../../shared/components/copy-button/copy-button.component';
@@ -58,6 +61,7 @@ import { CopyButtonComponent } from '../../../../../shared/components/copy-butto
     ProgressSpinnerModule,
     MentionModule,
     CapitalizePipe,
+    TokenCountPipe,
     CopyButtonComponent,
   ],
   templateUrl: './akgent-chat.component.html',
@@ -87,6 +91,10 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   private systemPromptSelector: SystemPromptSelector = inject(
     SystemPromptSelector
   );
+  // ADR-022 §Decision 5: same component-scoped selector pattern as
+  // SystemPromptSelector — resolves the same team-scoped IngestionService as
+  // this subtree, so the usage pill reads THIS team's per-agent totals.
+  private tokenUsageSelector: TokenUsageSelector = inject(TokenUsageSelector);
   private destroyRef = inject(DestroyRef);
 
   context: any[] = [];
@@ -118,6 +126,16 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   headRows$!: Observable<SystemPromptRow[]>;
 
   /**
+   * ADR-022 §Decision 5 — the member-chat usage pill stream. A thin
+   * `perAgent$(agentId) | async` binding (the view owns the never-run empty-state
+   * via `undefined`, ADR-022 §OQ2). Re-pointed at the selected agent in
+   * `bindUsage()` (called from `ngOnInit` + `ngOnChanges`), so the pill follows
+   * member switches like `systemPrompt$`. OnPush-faithful by construction: bound
+   * through `async`, no stored mutable copy, no manual subscription.
+   */
+  usage$!: Observable<AgentTokenUsage | undefined>;
+
+  /**
    * The agent-tabs dropdown REUSES this component across member selections (it
    * lives under `*ngIf="context$.length"`, which stays truthy when switching
    * between agents that both have context), so `ngOnInit` does NOT re-run on a
@@ -129,6 +147,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['agentId'] && !changes['agentId'].firstChange) {
       this.bindSystemPrompt();
+      this.bindUsage();
       // Switching members reuses this component (only the table content swaps),
       // so start FRESH: drop any carried-over follow mode and jump the trace to
       // the TOP — instantly, after the new content renders. `scrollTop = 0` is the
@@ -147,6 +166,9 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     // Initial head system block for this panel's agent (ADR-004 §5b step 2).
     // Subsequent agent switches re-bind it in ngOnChanges — see above.
     this.bindSystemPrompt();
+    // Initial usage-pill stream for this panel's agent (ADR-022 §Decision 5);
+    // re-bound on agent switch in ngOnChanges alongside the head block.
+    this.bindUsage();
 
     // Subscribe to context$ for the selected agent. No scroll on enter / on every
     // message — the panel only auto-scrolls while in FOLLOW mode (see updateContext).
@@ -194,6 +216,15 @@ export class AkgentChatComponent implements OnInit, OnChanges {
         return [];
       }),
     );
+  }
+
+  /** Point `usage$` at the current `agentId`'s token-usage stream (ADR-022
+   *  §Decision 5). The async pipe in the template resubscribes on reassignment,
+   *  so a member switch repoints the pill. `perAgent$` passes the store's
+   *  `undefined` through for a never-run agent — the template renders the
+   *  neutral empty-state (ADR-022 §OQ2). */
+  private bindUsage(): void {
+    this.usage$ = this.tokenUsageSelector.perAgent$(this.agentId);
   }
 
   /**

--- a/src/app/components/process/components/team-tabs/tree/tree.component.html
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.html
@@ -27,5 +27,15 @@
       </ng-template>
     </p-tree>
   </div>
+  <!-- Epic 26 (ADR-022 §Decision 6): team-wide token total. ↑ = sent = Σ input;
+       ↓ = received = Σ output. Always rendered (empty team → ↑0 ↓0). -->
+  <div
+    *ngIf="teamTotals$ | async as totals"
+    class="team-total-footer"
+  >
+    Team total ↑{{ totals.totalSent | tokenCount }} ↓{{
+      totals.totalReceived | tokenCount
+    }}
+  </div>
   <app-human-request [nodes]="nodes"></app-human-request>
 </div>

--- a/src/app/components/process/components/team-tabs/tree/tree.component.scss
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.scss
@@ -1,6 +1,29 @@
+// Epic 26 (ADR-022 §Decision 6): column layout so the footer pins beneath the
+// tree (DOM order guarantees "below the tree"; a constrained-height ancestor
+// pushes it to the bottom).
+.tree-component-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .tree-container {
   width: 100%;
   margin: auto;
+  flex: 1;
+}
+
+// Epic 26 (ADR-022 §Decision 6): slim, muted, non-interactive team-total strip.
+// Muted colour matches the member-chat usage pill (Story 26.2); tabular-nums
+// keeps the digits steady on live update.
+.team-total-footer {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border-top: 1px solid #e2e8f0;
+  font-size: 0.8rem;
+  color: #64748b;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
 }
 
 .human-node {

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -1,0 +1,186 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { TreeComponent } from './tree.component';
+import { ApiService } from '../../../../../core/http/api.service';
+import { GraphDataService } from '../../../selectors/graph.selector';
+import { SelectionService } from '../../../ui-state/selection.service';
+import {
+  TeamTokenTotals,
+  TokenUsageSelector,
+} from '../../../selectors/token-usage.selector';
+import { NodeInterface } from '../../../models/types';
+
+/**
+ * Story 26-3 (ADR-022 §Decision 6) — team-tree footer total. A slim,
+ * non-interactive footer strip sits BETWEEN the tree (`.tree-container`) and
+ * `<app-human-request>` inside `.tree-component-container`, bound to
+ * `tokenUsageSelector.teamTotals$ | async`: `Team total ↑<sent> ↓<received>`
+ * (each number via `tokenCount`); empty team (`{0,0}`) → `Team total ↑0 ↓0`.
+ *
+ * The fake `TokenUsageSelector` exposes a driveable `teamTotals$` subject so
+ * render / live-update / empty-state are deterministic. The tree + its
+ * `<app-human-request>` child also need `SelectionService` / `GraphDataService`
+ * / `ApiService`.
+ */
+describe('TreeComponent — team-total footer (Story 26-3)', () => {
+  /** Drives the footer; emits the team totals the spec asserts on. */
+  let totals$: BehaviorSubject<TeamTokenTotals>;
+  /** Feeds the tree's nodes (the host subscribes in ngOnInit). */
+  let nodes$: BehaviorSubject<NodeInterface[]>;
+  let handleSelection: jasmine.Spy;
+
+  function makeNode(name: string): NodeInterface {
+    return {
+      name,
+      role: 'Agent',
+      actorName: name,
+      parentId: '',
+      squadId: 's1',
+      symbol: 'roundRect',
+      category: 0,
+      userMessage: false,
+    };
+  }
+
+  function setup(
+    initial: TeamTokenTotals = { totalSent: 0, totalReceived: 0 },
+  ): ComponentFixture<TreeComponent> {
+    totals$ = new BehaviorSubject<TeamTokenTotals>(initial);
+    nodes$ = new BehaviorSubject<NodeInterface[]>([]);
+    handleSelection = jasmine.createSpy('handleSelection');
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TreeComponent],
+      providers: [
+        // Fake selector provided at the (root) injector level — TreeComponent's
+        // bare `inject(TokenUsageSelector)` resolves THIS shared instance.
+        {
+          provide: TokenUsageSelector,
+          useValue: {
+            teamTotals$: totals$.asObservable(),
+            perAgent$: (_id: string) => of(undefined),
+          },
+        },
+        {
+          provide: GraphDataService,
+          useValue: {
+            nodes$,
+            edges$: new BehaviorSubject<unknown[]>([]),
+            categories$: new BehaviorSubject<unknown[]>([]),
+            categoryService: { COLORS: ['#fff', '#000'] },
+            set isLoading(_v: boolean) {
+              /* swallowed — buildTree side effect, irrelevant to the footer */
+            },
+          },
+        },
+        {
+          provide: SelectionService,
+          useValue: {
+            handleSelection,
+            userRequest$: new BehaviorSubject<unknown>({}),
+            modalVisible$: new BehaviorSubject<boolean>(false),
+            onSave: jasmine.createSpy('onSave'),
+          },
+        },
+        { provide: ApiService, useValue: {} },
+        provideNoopAnimations(),
+      ],
+    });
+
+    return TestBed.createComponent(TreeComponent);
+  }
+
+  /** The footer strip element. */
+  function footer(fixture: ComponentFixture<TreeComponent>): HTMLElement | null {
+    return (fixture.nativeElement as HTMLElement).querySelector(
+      '.team-total-footer',
+    );
+  }
+
+  /** Footer text with whitespace collapsed (glyphs/order are the contract,
+   *  not exact spacing). */
+  function footerText(fixture: ComponentFixture<TreeComponent>): string {
+    return (footer(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  it('(a) renders the populated `Team total ↑X ↓Y` BETWEEN the tree and app-human-request', () => {
+    const fixture = setup({ totalSent: 57_000, totalReceived: 12_500 });
+    fixture.detectChanges();
+
+    // tokenCount: 57_000 → "57.0k", 12_500 → "12.5k".
+    expect(footerText(fixture)).toBe('Team total ↑57.0k ↓12.5k');
+
+    // Non-interactive: a <div>, not a <button>; no click handler / routerLink.
+    const f = footer(fixture)!;
+    expect(f.tagName.toLowerCase()).toBe('div');
+
+    // DOM order: footer AFTER the tree region, BEFORE app-human-request, all
+    // direct children of `.tree-component-container`.
+    const container = (fixture.nativeElement as HTMLElement).querySelector(
+      '.tree-component-container',
+    )!;
+    const kids = Array.from(container.children);
+    const treeIdx = kids.findIndex((c) =>
+      c.classList.contains('tree-container'),
+    );
+    const footerIdx = kids.findIndex((c) =>
+      c.classList.contains('team-total-footer'),
+    );
+    const humanIdx = kids.findIndex(
+      (c) => c.tagName.toLowerCase() === 'app-human-request',
+    );
+    expect(treeIdx).toBeGreaterThanOrEqual(0);
+    expect(footerIdx).toBeGreaterThan(treeIdx);
+    expect(humanIdx).toBeGreaterThan(footerIdx);
+  });
+
+  it('(b) live update: a fresh `teamTotals$` emission re-renders the ↑/↓ sums', () => {
+    const fixture = setup({ totalSent: 1_000, totalReceived: 200 });
+    fixture.detectChanges();
+    expect(footerText(fixture)).toBe('Team total ↑1.0k ↓200');
+
+    // A new LlmUsageEvent landed for some agent → the selector re-emits a larger
+    // structural sum; the async pipe re-renders without any imperative refresh.
+    totals$.next({ totalSent: 73_400, totalReceived: 18_900 });
+    fixture.detectChanges();
+    expect(footerText(fixture)).toBe('Team total ↑73.4k ↓18.9k');
+  });
+
+  it('(c) empty team (`{0,0}`) renders the `Team total ↑0 ↓0` fallback', () => {
+    const fixture = setup({ totalSent: 0, totalReceived: 0 });
+    fixture.detectChanges();
+
+    // The zero-totals object IS the empty state — the footer is still rendered.
+    expect(footer(fixture)).not.toBeNull();
+    expect(footerText(fixture)).toBe('Team total ↑0 ↓0');
+  });
+
+  it('(d) resolves the SHARED selector instance (no self-provider) and leaves the tree behavior intact', () => {
+    const fixture = setup({ totalSent: 100, totalReceived: 50 });
+    const component = fixture.componentInstance;
+
+    // The component must NOT re-provide TokenUsageSelector — it resolves the
+    // single instance from the (root) injector. The exact fake we provided is
+    // what the component holds, proving the bare inject walked UP.
+    const shared = TestBed.inject(TokenUsageSelector);
+    expect((component as unknown as { tokenUsageSelector: TokenUsageSelector })
+      .tokenUsageSelector).toBe(shared);
+
+    // And the standalone component definition declares no own providers for it.
+    const def = (TreeComponent as unknown as { ɵcmp?: { providers?: unknown } })
+      .ɵcmp;
+    expect(def?.providers ?? null).toBeNull();
+
+    // The tree still renders nodes and node-click still flows to the selection
+    // service (footer addition is non-disruptive — AC #7).
+    nodes$.next([makeNode('a-mgr')]);
+    fixture.detectChanges();
+    expect(component.treeNodes.length).toBe(1);
+
+    component.onNodeClick({ node: { data: makeNode('a-mgr') } });
+    expect(handleSelection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/components/process/components/team-tabs/tree/tree.component.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.ts
@@ -11,11 +11,13 @@ import { Subscription } from 'rxjs';
 import { makeAgentNameUserFriendly } from '../../../../../shared/util/util';
 import { ApiService } from '../../../../../core/http/api.service';
 import { GraphDataService } from '../../../selectors/graph.selector';
+import { TokenUsageSelector } from '../../../selectors/token-usage.selector';
 import {
   Selectable,
   SelectionService,
 } from '../../../ui-state/selection.service';
 import { HumanRequestComponent } from '../../human-request/human-request.component';
+import { TokenCountPipe } from '../../../../../shared/pipes/token-count.pipe';
 import { EdgeInterface, NodeInterface } from '../../../models/types';
 
 @Component({
@@ -31,10 +33,19 @@ import { EdgeInterface, NodeInterface } from '../../../models/types';
     TabViewModule,
     TextareaModule,
     HumanRequestComponent,
+    TokenCountPipe,
   ],
 })
 export class TreeComponent implements OnInit, OnDestroy {
   selectionService: SelectionService = inject(SelectionService);
+
+  // Epic 26 (ADR-022 §Decision 6): the team-wide token total shown in the
+  // footer strip below the tree. Bare inject — resolves the SAME
+  // component-scoped TokenUsageSelector provided on ProcessComponent (shared
+  // with the member-chat pill), so the footer reads THIS team's scoped totals.
+  // Bound via `async` in the template; never `undefined` (empty team → zeros).
+  private readonly tokenUsageSelector = inject(TokenUsageSelector);
+  readonly teamTotals$ = this.tokenUsageSelector.teamTotals$;
 
   treeNodes: TreeNode[] = []; // Correct initialization as an array of TreeNode
   expandedKeys: { [key: string]: boolean } = {};

--- a/src/app/components/process/event/ingestion.service.ts
+++ b/src/app/components/process/event/ingestion.service.ts
@@ -23,11 +23,13 @@ import {
 } from './per-agent-store';
 import {
   AgentStateValue,
+  AgentTokenUsage,
   commandsSpec,
   contextSpec,
   stateSpec,
   systemPromptSpec,
   SystemPromptValue,
+  tokenUsageSpec,
 } from './per-agent-specs';
 import { MessageService } from 'primeng/api';
 
@@ -177,6 +179,17 @@ export class IngestionService {
    */
   readonly systemPrompt: PerAgentStore<SystemPromptValue> =
     this.registry.register<SystemPromptValue>(systemPromptSpec);
+
+  /**
+   * Epic 26 (ADR-022 §Decision 2): per-agent token-usage derived from
+   * `LlmUsageEvent` riding the `EventMessage` passthrough. Default key
+   * `sender.agent_id` (the agent that ran the model). Folded by the same
+   * component-scoped registry as `state` / `context` / `commands` /
+   * `systemPrompt` — replay + reset for free. Read via `tokenUsage.forAgent(id)`
+   * (per-agent) and `tokenUsage.all$` (the `TokenUsageSelector.teamTotals$` sum).
+   */
+  readonly tokenUsage: PerAgentStore<AgentTokenUsage> =
+    this.registry.register<AgentTokenUsage>(tokenUsageSpec);
 
   processId: string = '';
 

--- a/src/app/components/process/event/per-agent-specs.spec.ts
+++ b/src/app/components/process/event/per-agent-specs.spec.ts
@@ -1,0 +1,294 @@
+import { TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
+
+import { AkgenticMessage } from '../../../protocol/message.types';
+import { ApiService } from '../../../core/http/api.service';
+import { IngestionService } from './ingestion.service';
+import { MessageLogService } from './message-log.service';
+import { PerAgentStore, PerAgentStoreRegistry } from './per-agent-store';
+import {
+  AgentTokenUsage,
+  tokenUsageReduce,
+  tokenUsageSpec,
+} from './per-agent-specs';
+
+// ---------------------------------------------------------------------
+// Fixtures — EventMessage(LlmUsageEvent) envelopes (ADR-022 §Decision 1
+// wire JSON). Driven through the REAL registry via MessageLogService so the
+// tests exercise the actual `tokenUsageSpec` fold (no mocking).
+// ---------------------------------------------------------------------
+
+function sender(agentId: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name: '@' + agentId,
+    role: 'Worker',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+let envCounter = 0;
+
+interface UsageFields {
+  run_id?: string;
+  model_name?: string;
+  provider_name?: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  requests?: number;
+}
+
+/** EventMessage envelope carrying an LlmUsageEvent for `agentId`. */
+function makeUsageEnvelope(agentId: string, ev: UsageFields): AkgenticMessage {
+  return {
+    id: 'usage-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmUsageEvent',
+      run_id: ev.run_id ?? 'run-1',
+      model_name: ev.model_name ?? 'claude-sonnet',
+      provider_name: ev.provider_name ?? 'anthropic',
+      input_tokens: ev.input_tokens,
+      output_tokens: ev.output_tokens,
+      cache_read_tokens: ev.cache_read_tokens ?? 0,
+      cache_write_tokens: ev.cache_write_tokens ?? 0,
+      requests: ev.requests ?? 1,
+    },
+  } as unknown as AkgenticMessage;
+}
+
+/** An unrelated inner event (must never fold into the tokenUsage store). */
+function makeUnrelatedEnvelope(id: string): AkgenticMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender('whoever'),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: { __model__: 'akgentic.llm.event.LlmSystemPromptEvent' },
+  } as unknown as AkgenticMessage;
+}
+
+// ---------------------------------------------------------------------
+// TestBed wiring — drive the REAL store via MessageLogService.
+// ---------------------------------------------------------------------
+
+function configureBed(): {
+  log: MessageLogService;
+  service: IngestionService;
+} {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      MessageLogService,
+      PerAgentStoreRegistry,
+      IngestionService,
+      {
+        provide: ApiService,
+        useValue: {
+          getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+        },
+      },
+      {
+        provide: MessageService,
+        useValue: {
+          add: jasmine.createSpy('add'),
+          clear: jasmine.createSpy('clear'),
+        },
+      },
+    ],
+  });
+  return {
+    log: TestBed.inject(MessageLogService),
+    service: TestBed.inject(IngestionService),
+  };
+}
+
+function usage(
+  store: PerAgentStore<AgentTokenUsage>,
+  agentId: string,
+): AgentTokenUsage | undefined {
+  return store.snapshot(agentId);
+}
+
+// ---------------------------------------------------------------------
+// AC #6 — tokenUsageSpec reducer correctness (via the real registry fold).
+// ---------------------------------------------------------------------
+
+describe('tokenUsageSpec reducer (Epic 26 / ADR-022 §Decision 2-4)', () => {
+  it('AC #6 single event: seeds lastContextWindow / totalSent / totalReceived and captures labels', () => {
+    const { log, service } = configureBed();
+    log.append(
+      makeUsageEnvelope('A', {
+        run_id: 'run-7',
+        model_name: 'claude-opus',
+        input_tokens: 12_031,
+        output_tokens: 412,
+      }),
+    );
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 12_031,
+      lastRunId: 'run-7',
+      lastModelName: 'claude-opus',
+      totalSent: 12_031,
+      totalReceived: 412,
+    });
+  });
+
+  it('AC #6 multi-event: sums totals and overwrites lastContextWindow with the newest input (even when smaller)', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', {
+        run_id: 'run-1',
+        input_tokens: 1000,
+        output_tokens: 100,
+      }),
+      makeUsageEnvelope('A', {
+        run_id: 'run-2',
+        model_name: 'claude-haiku',
+        input_tokens: 200, // newest is SMALLER than the prior 1000
+        output_tokens: 50,
+      }),
+    ]);
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 200, // overwritten with the newest input_tokens
+      lastRunId: 'run-2',
+      lastModelName: 'claude-haiku',
+      totalSent: 1200, // 1000 + 200
+      totalReceived: 150, // 100 + 50
+    });
+  });
+
+  it('AC #6 multi-agent: independent entries; A never bleeds into B', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', { input_tokens: 100, output_tokens: 10 }),
+      makeUsageEnvelope('B', { input_tokens: 999, output_tokens: 88 }),
+      makeUsageEnvelope('A', { input_tokens: 5, output_tokens: 1 }),
+    ]);
+    expect(usage(service.tokenUsage, 'A')).toEqual(
+      jasmine.objectContaining({ totalSent: 105, totalReceived: 11 }),
+    );
+    expect(usage(service.tokenUsage, 'B')).toEqual(
+      jasmine.objectContaining({ totalSent: 999, totalReceived: 88 }),
+    );
+  });
+
+  it('AC #6 reset on log-shrink: MessageLogService.reset() clears the store', () => {
+    const { log, service } = configureBed();
+    log.append(makeUsageEnvelope('A', { input_tokens: 100, output_tokens: 10 }));
+    expect(usage(service.tokenUsage, 'A')).toBeTruthy();
+
+    let allAfterReset: ReadonlyMap<string, AgentTokenUsage> | undefined;
+    const sub = service.tokenUsage.all$.subscribe((m) => (allAfterReset = m));
+
+    log.reset();
+
+    expect(usage(service.tokenUsage, 'A')).toBeUndefined();
+    expect(allAfterReset?.size).toBe(0);
+    sub.unsubscribe();
+  });
+
+  it('only LlmUsageEvent folds: unrelated inner events leave the store empty', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUnrelatedEnvelope('u1'),
+      makeUnrelatedEnvelope('u2'),
+    ]);
+    expect(usage(service.tokenUsage, 'whoever')).toBeUndefined();
+  });
+
+  it('a fresh object is returned on each change (OnPush safety)', () => {
+    const { log, service } = configureBed();
+    log.append(makeUsageEnvelope('A', { input_tokens: 100, output_tokens: 10 }));
+    const first = usage(service.tokenUsage, 'A');
+    log.append(makeUsageEnvelope('A', { input_tokens: 5, output_tokens: 1 }));
+    const second = usage(service.tokenUsage, 'A');
+    expect(first).not.toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------
+// tokenUsageReduce — direct pure-function unit tests (no registry).
+// ---------------------------------------------------------------------
+
+describe('tokenUsageReduce (pure reducer)', () => {
+  function envelope(input: number, output: number): AkgenticMessage {
+    return makeUsageEnvelope('A', { input_tokens: input, output_tokens: output });
+  }
+
+  it('seeds from undefined prev (first event)', () => {
+    const next = tokenUsageReduce(undefined, envelope(300, 40));
+    expect(next).toEqual({
+      lastContextWindow: 300,
+      lastRunId: 'run-1',
+      lastModelName: 'claude-sonnet',
+      totalSent: 300,
+      totalReceived: 40,
+    });
+  });
+
+  it('accumulates onto a prior value', () => {
+    const prev: AgentTokenUsage = {
+      lastContextWindow: 300,
+      lastRunId: 'run-1',
+      lastModelName: 'claude-sonnet',
+      totalSent: 300,
+      totalReceived: 40,
+    };
+    const next = tokenUsageReduce(prev, envelope(7, 3));
+    expect(next).toEqual(
+      jasmine.objectContaining({
+        lastContextWindow: 7,
+        totalSent: 307,
+        totalReceived: 43,
+      }),
+    );
+  });
+
+  it('passes prev through for a non-usage message (defensive)', () => {
+    const prev: AgentTokenUsage = {
+      lastContextWindow: 1,
+      lastRunId: 'r',
+      lastModelName: 'm',
+      totalSent: 1,
+      totalReceived: 1,
+    };
+    expect(tokenUsageReduce(prev, makeUnrelatedEnvelope('x'))).toBe(prev);
+  });
+
+  it('coalesces a missing numeric field to 0 (no NaN)', () => {
+    const malformed = {
+      id: 'm1',
+      __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+      sender: sender('A'),
+      event: {
+        __model__: 'akgentic.llm.event.LlmUsageEvent',
+        run_id: 'run-x',
+        model_name: 'm',
+        // input_tokens / output_tokens deliberately absent
+      },
+    } as unknown as AkgenticMessage;
+    const next = tokenUsageReduce(undefined, malformed);
+    expect(next).toEqual(
+      jasmine.objectContaining({
+        lastContextWindow: 0,
+        totalSent: 0,
+        totalReceived: 0,
+      }),
+    );
+  });
+});

--- a/src/app/components/process/event/per-agent-specs.ts
+++ b/src/app/components/process/event/per-agent-specs.ts
@@ -6,7 +6,9 @@ import {
   isCommandsAnnouncedEvent,
   isEventMessage,
   isLlmSystemPromptEvent,
+  isLlmUsageEvent,
   isStateChangedMessage,
+  LlmUsageEvent,
   StateChangedMessage,
   SystemPromptPartSnapshot,
 } from '../../../protocol/message.types';
@@ -308,4 +310,79 @@ export const systemPromptSpec: PerAgentSpec<SystemPromptValue> = {
   name: 'systemPrompt',
   match: systemPromptMatch,
   reduce: systemPromptReduce,
+};
+
+// ===========================================================================
+// token-usage reducer surface (Epic 26 / ADR-022 §Decision 2-4)
+// ===========================================================================
+
+/**
+ * Per-agent reduced token-usage value (Epic 26 / ADR-022 §Decision 2). Derived
+ * by folding every `EventMessage(LlmUsageEvent)` for the agent (keyed by the
+ * outer `sender.agent_id`, which IS the agent that ran the model). Terminology
+ * (ADR-022 §Decision 4): `totalSent` Σ `input_tokens`, `totalReceived` Σ
+ * `output_tokens`. `lastContextWindow` is the NEWEST event's `input_tokens`
+ * (ADR-022 §Decision 3 — there is no context-window field on the wire, so the
+ * most-recent prompt size is the proxy). `lastRunId` / `lastModelName` are labels
+ * only. Cache / `requests` fields ride the wire but are excluded from v1.
+ */
+export interface AgentTokenUsage {
+  /** input_tokens of the most-recent event (overwritten each event). */
+  lastContextWindow: number;
+  /** run_id of that most-recent event (label only). */
+  lastRunId: string;
+  /** model_name of that most-recent event (label only). */
+  lastModelName: string;
+  /** running Σ of input_tokens across all this agent's events. */
+  totalSent: number;
+  /** running Σ of output_tokens across all this agent's events. */
+  totalReceived: number;
+}
+
+/** Read the inner `LlmUsageEvent` off an `EventMessage`, or `undefined`. */
+function innerLlmUsage(msg: AkgenticMessage): LlmUsageEvent | undefined {
+  if (!isEventMessage(msg)) return undefined;
+  const inner = (msg as EventMessage).event;
+  return isLlmUsageEvent(inner) ? inner : undefined;
+}
+
+/**
+ * Incremental per-message reducer (the store's `(prev, msg) => next` contract,
+ * ADR-022 §Decision 2). NOT a stock factory: it BOTH accumulates (sums
+ * sent/received) AND overwrites (context window + labels) per event. The first
+ * event seeds from `prev ?? zero`; every event returns a FRESH object (OnPush
+ * safety). A non-usage message passes `prev` through unchanged (the spec's
+ * `match` already gates these out, but the reducer stays defensive). Numeric
+ * reads coalesce a missing/malformed field to `0` so a partial event never
+ * yields `NaN` totals.
+ */
+export function tokenUsageReduce(
+  prev: AgentTokenUsage | undefined,
+  msg: AkgenticMessage,
+): AgentTokenUsage | undefined {
+  const ev = innerLlmUsage(msg);
+  if (ev === undefined) return prev;
+  const input = ev.input_tokens ?? 0;
+  const output = ev.output_tokens ?? 0;
+  return {
+    lastContextWindow: input,
+    lastRunId: ev.run_id,
+    lastModelName: ev.model_name,
+    totalSent: (prev?.totalSent ?? 0) + input,
+    totalReceived: (prev?.totalReceived ?? 0) + output,
+  };
+}
+
+/**
+ * Epic 26 (ADR-022 §Decision 2): per-agent token-usage store derived from
+ * `LlmUsageEvent` riding the `EventMessage` passthrough. Default key
+ * `sender.agent_id` (the agent that ran the model). The custom
+ * `tokenUsageReduce` both accumulates and overwrites, so no stock factory fits.
+ * Read via `tokenUsage.forAgent(id)` / `tokenUsage.all$`; the team total is a
+ * pure derivation over `all$` (TokenUsageSelector), never a separate aggregate.
+ */
+export const tokenUsageSpec: PerAgentSpec<AgentTokenUsage> = {
+  name: 'tokenUsage',
+  match: (m) => isEventMessage(m) && isLlmUsageEvent((m as EventMessage).event),
+  reduce: tokenUsageReduce,
 };

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -10,6 +10,7 @@ import { MessageLogService } from './event/message-log.service';
 import { IngestionService } from './event/ingestion.service';
 import { PerAgentStoreRegistry } from './event/per-agent-store';
 import { SystemPromptSelector } from './selectors/system-prompt.selector';
+import { TokenUsageSelector } from './selectors/token-usage.selector';
 import { ToolPresenceService } from './selectors/tool-presence.selector';
 import { WorkspaceRegistryService } from './selectors/workspace-registry.selector';
 import { AgentsByIdService } from './selectors/agents-by-id.selector';
@@ -79,6 +80,11 @@ interface VisualizationOption {
     // single `log$` subscription (same lifecycle guarantee as MessageLogService).
     PerAgentStoreRegistry,
     IngestionService,
+    // Epic 26 (ADR-022): component-scoped read surface over the `tokenUsage`
+    // PerAgentStore. Provided AFTER IngestionService (which it injects); never
+    // `providedIn: 'root'` — it shares the team-scoped log lifecycle, so a team
+    // switch destroys it and the usage pill always reads THIS team's totals.
+    TokenUsageSelector,
     GraphDataService,
     ChatService,
     SelectionService,

--- a/src/app/components/process/selectors/token-usage.selector.spec.ts
+++ b/src/app/components/process/selectors/token-usage.selector.spec.ts
@@ -1,0 +1,183 @@
+import { TestBed } from '@angular/core/testing';
+import { MessageService } from 'primeng/api';
+
+import { AkgenticMessage } from '../../../protocol/message.types';
+import { ApiService } from '../../../core/http/api.service';
+import { IngestionService } from '../event/ingestion.service';
+import { MessageLogService } from '../event/message-log.service';
+import { PerAgentStoreRegistry } from '../event/per-agent-store';
+import { AgentTokenUsage } from '../event/per-agent-specs';
+import { TeamTokenTotals, TokenUsageSelector } from './token-usage.selector';
+
+// ---------------------------------------------------------------------
+// Fixtures — EventMessage(LlmUsageEvent) envelopes driven through the REAL
+// registry + selector via MessageLogService (no mocking of the fold).
+// ---------------------------------------------------------------------
+
+function sender(agentId: string) {
+  return {
+    __actor_address__: true as const,
+    agent_id: agentId,
+    name: '@' + agentId,
+    role: 'Worker',
+    squad_id: 's1',
+    user_message: false,
+  };
+}
+
+let envCounter = 0;
+
+function makeUsageEnvelope(
+  agentId: string,
+  input_tokens: number,
+  output_tokens: number,
+): AkgenticMessage {
+  return {
+    id: 'usage-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmUsageEvent',
+      run_id: 'run-' + envCounter,
+      model_name: 'claude-sonnet',
+      provider_name: 'anthropic',
+      input_tokens,
+      output_tokens,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      requests: 1,
+    },
+  } as unknown as AkgenticMessage;
+}
+
+/** An unrelated event that does NOT change any usage total. */
+function makeUnrelatedEnvelope(id: string): AkgenticMessage {
+  return {
+    id,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender('whoever'),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: { __model__: 'akgentic.llm.event.LlmSystemPromptEvent' },
+  } as unknown as AkgenticMessage;
+}
+
+function configureBed(): {
+  log: MessageLogService;
+  selector: TokenUsageSelector;
+} {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      MessageLogService,
+      PerAgentStoreRegistry,
+      IngestionService,
+      TokenUsageSelector,
+      {
+        provide: ApiService,
+        useValue: {
+          getEvents: jasmine.createSpy('getEvents').and.resolveTo([]),
+        },
+      },
+      {
+        provide: MessageService,
+        useValue: {
+          add: jasmine.createSpy('add'),
+          clear: jasmine.createSpy('clear'),
+        },
+      },
+    ],
+  });
+  return {
+    log: TestBed.inject(MessageLogService),
+    selector: TestBed.inject(TokenUsageSelector),
+  };
+}
+
+// ---------------------------------------------------------------------
+// AC #8 — perAgent$ behaviour
+// ---------------------------------------------------------------------
+
+describe('TokenUsageSelector.perAgent$ (AC #8)', () => {
+  it('emits the agent current usage and re-emits on change', () => {
+    const { log, selector } = configureBed();
+    const emissions: (AgentTokenUsage | undefined)[] = [];
+    const sub = selector.perAgent$('A').subscribe((v) => emissions.push(v));
+
+    log.append(makeUsageEnvelope('A', 100, 10));
+    log.append(makeUsageEnvelope('A', 5, 1));
+
+    // [undefined (never-run), after first event, after second event]
+    expect(emissions.length).toBe(3);
+    expect(emissions[0]).toBeUndefined();
+    expect(emissions[1]).toEqual(
+      jasmine.objectContaining({ totalSent: 100, totalReceived: 10 }),
+    );
+    expect(emissions[2]).toEqual(
+      jasmine.objectContaining({ totalSent: 105, totalReceived: 11 }),
+    );
+    sub.unsubscribe();
+  });
+
+  it('passes undefined THROUGH for a never-run agent (OQ2: view owns empty-state)', () => {
+    const { selector } = configureBed();
+    let received: AgentTokenUsage | undefined = {
+      lastContextWindow: -1,
+    } as AgentTokenUsage;
+    const sub = selector.perAgent$('ghost').subscribe((v) => (received = v));
+    expect(received).toBeUndefined();
+    sub.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// AC #8 — teamTotals$ behaviour
+// ---------------------------------------------------------------------
+
+describe('TokenUsageSelector.teamTotals$ (AC #8)', () => {
+  it('empty team yields { totalSent: 0, totalReceived: 0 }', () => {
+    const { selector } = configureBed();
+    let received: TeamTokenTotals | undefined;
+    const sub = selector.teamTotals$.subscribe((t) => (received = t));
+    expect(received).toEqual({ totalSent: 0, totalReceived: 0 });
+    sub.unsubscribe();
+  });
+
+  it('emits the structural sum across all agents', () => {
+    const { log, selector } = configureBed();
+    let received: TeamTokenTotals | undefined;
+    const sub = selector.teamTotals$.subscribe((t) => (received = t));
+
+    log.appendAll([
+      makeUsageEnvelope('A', 100, 10),
+      makeUsageEnvelope('B', 200, 20),
+      makeUsageEnvelope('A', 50, 5),
+    ]);
+
+    expect(received).toEqual({ totalSent: 350, totalReceived: 35 });
+    sub.unsubscribe();
+  });
+
+  it('de-dupes: a log frame that changes no usage total produces no new emission', () => {
+    const { log, selector } = configureBed();
+    const emissions: TeamTokenTotals[] = [];
+    const sub = selector.teamTotals$.subscribe((t) => emissions.push(t));
+
+    log.append(makeUsageEnvelope('A', 100, 10)); // changes totals → emit
+    log.append(makeUnrelatedEnvelope('u1')); // no usage change → NO emit
+
+    // initial zeros + one usage change = 2 emissions; the unrelated tick adds none
+    expect(emissions.length).toBe(2);
+    expect(emissions[0]).toEqual({ totalSent: 0, totalReceived: 0 });
+    expect(emissions[1]).toEqual({ totalSent: 100, totalReceived: 10 });
+    sub.unsubscribe();
+  });
+});

--- a/src/app/components/process/selectors/token-usage.selector.ts
+++ b/src/app/components/process/selectors/token-usage.selector.ts
@@ -1,0 +1,71 @@
+import { inject, Injectable } from '@angular/core';
+import { distinctUntilChanged, map, Observable, shareReplay } from 'rxjs';
+
+import { AgentTokenUsage } from '../event/per-agent-specs';
+import { IngestionService } from '../event/ingestion.service';
+
+/** Headline team-wide totals (ADR-022 §Decision 2/4): Σ sent / Σ received. */
+export interface TeamTokenTotals {
+  totalSent: number;
+  totalReceived: number;
+}
+
+/** Structural equality of two totals (NFR / OnPush): the summed object is a
+ *  fresh reference each frame, so the default reference comparator would never
+ *  suppress no-op re-emissions. */
+function totalsEqual(a: TeamTokenTotals, b: TeamTokenTotals): boolean {
+  return a.totalSent === b.totalSent && a.totalReceived === b.totalReceived;
+}
+
+/** Pure Σ over every agent's usage (ADR-022 §Decision 2): the team total is a
+ *  DERIVATION, never a separately stored aggregate. An empty map yields zeros. */
+function sumTotals(all: ReadonlyMap<string, AgentTokenUsage>): TeamTokenTotals {
+  let totalSent = 0;
+  let totalReceived = 0;
+  for (const usage of all.values()) {
+    totalSent += usage.totalSent;
+    totalReceived += usage.totalReceived;
+  }
+  return { totalSent, totalReceived };
+}
+
+/**
+ * TokenUsageSelector — Epic 26 / Story 26-1 (ADR-022 §Decision 2).
+ *
+ * Thin read surface over the `tokenUsage` `PerAgentStore` owned by
+ * `IngestionService` (registered on the single `PerAgentStoreRegistry` alongside
+ * `state` / `context` / `commands` / `systemPrompt`). Holds NO state of its own.
+ *
+ * - `perAgent$(agentId)` is a façade over `tokenUsage.forAgent(id)`, mirroring
+ *   `SystemPromptSelector`. It passes the store's `undefined` (never-run agent)
+ *   THROUGH unchanged (ADR-022 §Open Question 2): the data layer stays faithful,
+ *   and the member-chat pill (Story 26.2) owns the neutral empty-state render.
+ *   `forAgent` already applies a reference `distinctUntilChanged` +
+ *   `shareReplay({ bufferSize: 1, refCount: true })` with lazy current-value
+ *   replay, so no extra pipeline is needed here.
+ * - `teamTotals$` is a PURE sum over `tokenUsage.all$` (Σ every agent's
+ *   `totalSent` / `totalReceived`) — NOT a separately stored aggregate. Because
+ *   `ProcessComponent` + its scoped registry are destroyed/recreated on every
+ *   team switch, `all$` holds exactly the CURRENT team's agents, so the total is
+ *   correct by construction with no team-id bookkeeping. The sum is a fresh
+ *   reference each frame, so it needs a STRUCTURAL `distinctUntilChanged`
+ *   (`totalsEqual`) to suppress no-op frames, plus `shareReplay` for OnPush.
+ *
+ * Scope: component-scoped (NOT `providedIn: 'root'`) — it injects the
+ * component-scoped `IngestionService` from `ProcessComponent.providers`.
+ */
+@Injectable()
+export class TokenUsageSelector {
+  private readonly ingestion: IngestionService = inject(IngestionService);
+
+  readonly teamTotals$: Observable<TeamTokenTotals> =
+    this.ingestion.tokenUsage.all$.pipe(
+      map(sumTotals),
+      distinctUntilChanged(totalsEqual),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+
+  perAgent$(agentId: string): Observable<AgentTokenUsage | undefined> {
+    return this.ingestion.tokenUsage.forAgent(agentId);
+  }
+}

--- a/src/app/protocol/message.types.spec.ts
+++ b/src/app/protocol/message.types.spec.ts
@@ -1,6 +1,9 @@
 import {
   ActorAddress,
   BaseMessage,
+  isLlmMessageEvent,
+  isLlmSystemPromptEvent,
+  isLlmUsageEvent,
   isWelcomeAnnouncement,
   isWelcomeMessage,
   SentMessage,
@@ -112,5 +115,71 @@ describe('isWelcomeAnnouncement', () => {
     const msg = makeSent(makeWelcome());
     (msg as { message?: BaseMessage }).message = undefined;
     expect(isWelcomeAnnouncement(msg)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLlmUsageEvent — inner-event check (ADR-022 §Decision 1)
+// ---------------------------------------------------------------------------
+
+describe('isLlmUsageEvent', () => {
+  it('returns true for an inner event whose __model__ includes "LlmUsageEvent"', () => {
+    expect(
+      isLlmUsageEvent({ __model__: 'akgentic.llm.event.LlmUsageEvent' }),
+    ).toBe(true);
+  });
+
+  it('returns false for null / undefined / missing __model__', () => {
+    expect(isLlmUsageEvent(null)).toBe(false);
+    expect(isLlmUsageEvent(undefined)).toBe(false);
+    expect(isLlmUsageEvent({})).toBe(false);
+  });
+
+  it('returns false for a different inner event', () => {
+    expect(
+      isLlmUsageEvent({ __model__: 'akgentic.llm.event.LlmSystemPromptEvent' }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #3 — the three Llm*Event guards are mutually exclusive.
+// For any one inner event, AT MOST ONE of (usage / system-prompt) guards fires,
+// and the message-event check never co-fires with either. The discriminators
+// must never overlap for the same event.
+// ---------------------------------------------------------------------------
+
+describe('Llm*Event guard mutual exclusion (AC #3)', () => {
+  const usage = { __model__: 'akgentic.llm.event.LlmUsageEvent' };
+  const systemPrompt = { __model__: 'akgentic.llm.event.LlmSystemPromptEvent' };
+  const message = { __model__: 'akgentic.llm.event.LlmMessageEvent' };
+
+  it('for an LlmUsageEvent, only isLlmUsageEvent fires', () => {
+    expect(isLlmUsageEvent(usage)).toBe(true);
+    expect(isLlmSystemPromptEvent(usage)).toBe(false);
+    expect(isLlmMessageEvent(usage)).toBe(false);
+  });
+
+  it('for an LlmSystemPromptEvent, only isLlmSystemPromptEvent fires', () => {
+    expect(isLlmSystemPromptEvent(systemPrompt)).toBe(true);
+    expect(isLlmUsageEvent(systemPrompt)).toBe(false);
+    expect(isLlmMessageEvent(systemPrompt)).toBe(false);
+  });
+
+  it('for an LlmMessageEvent, neither usage nor system-prompt guard fires', () => {
+    expect(isLlmMessageEvent(message)).toBe(true);
+    expect(isLlmUsageEvent(message)).toBe(false);
+    expect(isLlmSystemPromptEvent(message)).toBe(false);
+  });
+
+  it('the three guards never co-fire for the same event', () => {
+    for (const evt of [usage, systemPrompt, message]) {
+      const fired = [
+        isLlmUsageEvent(evt),
+        isLlmSystemPromptEvent(evt),
+        isLlmMessageEvent(evt),
+      ].filter(Boolean);
+      expect(fired.length).toBe(1);
+    }
   });
 });

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -203,6 +203,30 @@ export interface LlmSystemPromptEvent {
   parts: SystemPromptPartSnapshot[];
 }
 
+/**
+ * Inner event payload announcing per-`ModelResponse` token usage for one run,
+ * mirroring the akgentic-llm `LlmUsageEvent` frozen dataclass (ADR-022 §Decision
+ * 1). It rides the standard `EventMessage` envelope (outer `sender.agent_id`
+ * identifies the agent that ran the model) and is discriminated frontend-side by
+ * the inner `__model__` — exactly like `LlmSystemPromptEvent` / `LlmMessageEvent`
+ * / `CommandsAnnouncedEvent`. The serializer tags the dataclass with the
+ * fully-qualified `__model__` and preserves integer token counts (no
+ * stringification). Terminology (ADR-022 §Decision 4): `input_tokens` is "sent",
+ * `output_tokens` is "received". `cache_*` and `requests` ride the wire but are
+ * excluded from the v1 headline figures.
+ */
+export interface LlmUsageEvent {
+  __model__: string; // contains 'LlmUsageEvent'
+  run_id: string;
+  model_name: string;
+  provider_name: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  requests: number;
+}
+
 // Union type for all possible messages
 export type AkgenticMessage =
   | SentMessage
@@ -305,6 +329,33 @@ export function isLlmSystemPromptEvent(
   event: { __model__?: string } | null | undefined,
 ): event is LlmSystemPromptEvent {
   return !!event?.__model__?.includes('LlmSystemPromptEvent');
+}
+
+/**
+ * Inner-event check (ADR-022 §Decision 1): true when the inner event carried by
+ * an `EventMessage` is a `LlmUsageEvent`. Matches on the inner `__model__`, the
+ * same discrimination used for `LlmSystemPromptEvent` / `LlmMessageEvent` /
+ * `CommandsAnnouncedEvent`. `event` is the `EventMessage.event` payload (loosely
+ * typed on the wire); the guard narrows it to `LlmUsageEvent`.
+ */
+export function isLlmUsageEvent(
+  event: { __model__?: string } | null | undefined,
+): event is LlmUsageEvent {
+  return !!event?.__model__?.includes('LlmUsageEvent');
+}
+
+/**
+ * Inner-event check: true when the inner event carried by an `EventMessage` is a
+ * `LlmMessageEvent`. Named here for symmetry with `isLlmUsageEvent` /
+ * `isLlmSystemPromptEvent` (ADR-022 §Decision 1, Open Question 1) so the
+ * mutual-exclusion regression reads cleanly across the three `Llm*Event` guards.
+ * The `per-agent-specs.ts` fold helpers keep their existing inline
+ * `__model__.includes('LlmMessageEvent')` checks; this guard is additive.
+ */
+export function isLlmMessageEvent(
+  event: { __model__?: string } | null | undefined,
+): boolean {
+  return !!event?.__model__?.includes('LlmMessageEvent');
 }
 
 /**

--- a/src/app/shared/pipes/token-count.pipe.spec.ts
+++ b/src/app/shared/pipes/token-count.pipe.spec.ts
@@ -1,0 +1,38 @@
+import { TokenCountPipe } from './token-count.pipe';
+
+describe('TokenCountPipe (Epic 26 / ADR-022)', () => {
+  let pipe: TokenCountPipe;
+
+  beforeEach(() => {
+    pipe = new TokenCountPipe();
+  });
+
+  it('renders sub-1000 values verbatim (passthrough)', () => {
+    expect(pipe.transform(412)).toBe('412');
+    expect(pipe.transform(0)).toBe('0');
+    expect(pipe.transform(999)).toBe('999');
+  });
+
+  it('renders the k threshold with one decimal', () => {
+    expect(pipe.transform(1000)).toBe('1.0k');
+    expect(pipe.transform(12_031)).toBe('12.0k');
+    expect(pipe.transform(1500)).toBe('1.5k');
+  });
+
+  it('renders the M threshold with one decimal', () => {
+    expect(pipe.transform(1_000_000)).toBe('1.0M');
+    expect(pipe.transform(1_200_000)).toBe('1.2M');
+  });
+
+  it('crosses k → M exactly at 1_000_000', () => {
+    expect(pipe.transform(999_999)).toBe('1000.0k');
+    expect(pipe.transform(1_000_000)).toBe('1.0M');
+  });
+
+  it('renders null / undefined / non-finite as "0"', () => {
+    expect(pipe.transform(null)).toBe('0');
+    expect(pipe.transform(undefined)).toBe('0');
+    expect(pipe.transform(NaN)).toBe('0');
+    expect(pipe.transform(Infinity)).toBe('0');
+  });
+});

--- a/src/app/shared/pipes/token-count.pipe.ts
+++ b/src/app/shared/pipes/token-count.pipe.ts
@@ -1,0 +1,32 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Compact integer formatter for token counts (Epic 26 / ADR-022). Renders large
+ * counts with a one-decimal k / M suffix and small counts (`< 1000`) verbatim:
+ *   - `412      → "412"`
+ *   - `12_031   → "12.0k"`
+ *   - `1_200_000 → "1.2M"`
+ *
+ * Null / undefined / non-finite inputs render as `"0"`. Negative values are not
+ * expected on the wire (token counts are non-negative) and are passed through
+ * the same magnitude logic for robustness.
+ */
+@Pipe({
+  name: 'tokenCount',
+  standalone: true,
+})
+export class TokenCountPipe implements PipeTransform {
+  transform(value: number | null | undefined): string {
+    if (value === null || value === undefined || !Number.isFinite(value)) {
+      return '0';
+    }
+    const abs = Math.abs(value);
+    if (abs >= 1_000_000) {
+      return (value / 1_000_000).toFixed(1) + 'M';
+    }
+    if (abs >= 1_000) {
+      return (value / 1_000).toFixed(1) + 'k';
+    }
+    return String(value);
+  }
+}


### PR DESCRIPTION
## Epic 26 — LLM Token-Usage Selector + Chat / Team Displays

Surface LLM token spend in the UI from data **already on the wire** (`EventMessage(LlmUsageEvent)`) — frontend-only, no backend or protocol change. This umbrella PR tracks all three stories of Epic 26; it lands story-by-story on the shared epic branch.

### Stories

- [x] **26-1-token-usage-data-layer** — token-usage data layer: protocol type + guards, incremental per-agent `tokenUsageSpec` reducer, `IngestionService` registration, `TokenUsageSelector` (`perAgent$` + pure `teamTotals$`), and a compact `tokenCount` pipe (Relates to #193)
- [x] **26-2-member-chat-usage-pill** — member-chat usage pill in `AkgentChatComponent`: a compact, non-interactive `ctx <ctx> · ↑<sent> ↓<received>` pill left of Submit, bound to `TokenUsageSelector.perAgent$(agentId) | async`; neutral `ctx — · ↑0 ↓0` for never-run agents; native `title` tooltip spelling out the words + model; re-points on agent switch (Relates to #195)
- [x] **26-3-team-tree-footer-total** — team-tree footer total in `TreeComponent`: a slim, non-interactive `.team-total-footer` strip BETWEEN `.tree-container` and `<app-human-request>`, bound to `TokenUsageSelector.teamTotals$ | async` → `Team total ↑<sent> ↓<received>` (each via `tokenCount`); empty team → `Team total ↑0 ↓0`; flex-column container pins the footer beneath the tree; resolves the SHARED `ProcessComponent`-scoped selector via a bare `inject` (no self-provider) (Relates to #196)

### Review status

- **26-1 review: PASS** — adversarial review by Rex.
  - AC #1 wire-shape gate independently re-verified against backend source: `LlmUsageEvent` is a frozen dataclass with integer token fields (`akgentic-llm/.../event.py`); the core serializer's dataclass branch (`akgentic-core/.../serializer.py`) recurses each field (integers preserved) and stamps the fully-qualified `__model__`, the identical mechanism that already serializes `LlmSystemPromptEvent`. The frontend consumes the structured inner event one level deep (`m.event.__model__`), NOT the AngularV1 stringified `tool_update` wrapper. Gate correctly cleared — no `akgentic-infra` story needed.
  - AC #3 mutual-exclusion regression test is real and exhaustive (all three `Llm*Event` guards across all three event types + a "never co-fire" invariant).
  - `tokenUsageSpec` reducer is incremental & pure (`lastContextWindow` = newest `input_tokens`; `totalSent` = Σ input; `totalReceived` = Σ output; default `sender.agent_id` key; resets on log-shrink via the registry; fresh object per change for OnPush).
  - `teamTotals$` is a pure Σ over `tokenUsage.all$` with a structural `distinctUntilChanged` + `shareReplay({ bufferSize: 1, refCount: true })` — never a separately stored aggregate.
  - No HIGH/MEDIUM findings; no review fixup commit required.
  - Local gate green: Karma **1076 specs SUCCESS**, `lint` clean, production `build` succeeds (only the pre-existing lodash CommonJS warning), coverage ≥80% maintained.

- **26-2 review: PASS** — adversarial review by Rex. No HIGH/MEDIUM findings; no review fixup commit required.
  - All 8 ACs verified against the implementation. The pill is the FIRST child of `.input-row-buttons`, a non-interactive `<span>` (no click / no `routerLink`), bound to `usage$ = tokenUsageSelector.perAgent$(agentId)` through the `async` pipe — re-pointed via `bindUsage()` from both `ngOnInit` and `ngOnChanges` (mirrors `bindSystemPrompt()`), so it follows member switches.
  - Format contract enforced (`ctx 12.3k · ↑45.0k ↓12.1k`): every numeric via the `tokenCount` pipe; `ctx` binds to `lastContextWindow` (newest `input_tokens`, overwrite semantics) — the live-update test drives a SMALLER newest ctx and asserts `8.0k`. Never-run (`undefined`) renders the neutral `ctx — · ↑0 ↓0` empty-state; the VIEW owns the empty-state (no fabricated object in the class). Tooltip spells out the words + model, degrading to `No usage yet`.
  - OnPush correctly NOT enabled — the `async` pipe handles change detection, consistent with the existing `systemPrompt$ | async` head block under the component's default strategy.
  - OQ2 provider fix confirmed correct: `TokenUsageSelector` registered on `ProcessComponent.providers` (component-scoped, after `IngestionService`, NOT `providedIn: 'root'`) — it was genuinely absent (26-1 created it `@Injectable` but never provided it), so this single in-submodule wiring line is legitimate and required.
  - Golden Rule #8 clean — spec asserts on rendered DOM / binding behavior only; no `ADR-NNN` string assertions. Scope-compliant: all 5 files under `packages/akgentic-frontend/`.
  - Local gate green: Karma **1081 specs SUCCESS** (+6 over 26-1's 1075 baseline), `lint` clean, production `build` succeeds (only the pre-existing lodash CommonJS warning), coverage ≥80% maintained (80.26% stmts / 80.62% lines).

- **26-3 review: PASS** — adversarial review by Rex. No HIGH/MEDIUM findings; no review fixup commit required.
  - All 8 ACs verified against `tree.component.{ts,html,scss}` + the new `tree.component.spec.ts`. The footer is a `<div class="team-total-footer">` placed AFTER `.tree-container` and BEFORE `<app-human-request>` inside `.tree-component-container`; non-interactive (`cursor: default`, no click / no `routerLink`), bound to `teamTotals$ | async` → `Team total ↑{{ totalSent | tokenCount }} ↓{{ totalReceived | tokenCount }}`. Order is sent (↑) then received (↓) per ADR-022 §Decision 4.
  - **CRITICAL DI risk cleared:** `TreeComponent` uses a BARE `inject(TokenUsageSelector)` with NO `providers:` entry; `TeamTabsComponent` (the intermediate component) likewise declares no `providers`. The element-injector walk `TreeComponent → TeamTabsComponent → ProcessComponent` resolves the SINGLE shared instance from `ProcessComponent.providers`, so the footer reads THIS team's scoped totals — not a second empty registry's zeros. Verified directly in source. This was the #1 correctness risk for the story and is handled correctly.
  - Empty-team fallback is correct by construction: `teamTotals$` is a pure Σ over `tokenUsage.all$` that yields `{ totalSent: 0, totalReceived: 0 }` (never `undefined`) for an empty map, and the `tokenCount` pipe maps `0 → "0"`, so the footer renders `Team total ↑0 ↓0` from first paint. The `*ngIf … as` binds the value and never hides the footer.
  - Live update via the `async` pipe (no imperative refresh, no stored aggregate). `ChangeDetectionStrategy.OnPush` correctly NOT introduced — `async` handles CD by construction; the imperative `graphDataService` tree-building subscriptions are left untouched (AC #7).
  - SCSS is non-regressive: `.tree-component-container` gains `display: flex; flex-direction: column`, `.tree-container` keeps its existing `width/margin` and gains `flex: 1`, and the new muted `.team-total-footer` (border-top separator, `tabular-nums`) is added — `.human-node` / `.highlight-node` / the highlight animation / `.error-label` are unchanged.
  - The new spec is real: a driveable fake `TokenUsageSelector` (BehaviorSubject `teamTotals$`) drives populated render + DOM-order placement (a), live update (b), empty-team `↑0 ↓0` (c), and the shared-instance / no-self-provider contract plus node-click → `SelectionService.handleSelection` (d). Golden Rule #8 clean — ADR appears only in a docstring, no `ADR-NNN` string assertions.
  - Scope-compliant: all 4 files under `packages/akgentic-frontend/src/app/components/process/components/team-tabs/tree/`.
  - Local gate green: Karma **1085 specs SUCCESS** (+4 over 26-2's 1081 baseline), `lint` clean, production `build` succeeds (only the pre-existing lodash CommonJS warning), coverage ≥80% maintained (82.45% stmts / 82.99% lines).

### Scope guard

All changes stay inside `packages/akgentic-frontend/` (CLAUDE.md Golden Rule #4). No `akgentic-core` / `akgentic-llm` / `akgentic-infra` edit. 26-1's 9 files, 26-2's 5 files, and 26-3's 4 files are all under `src/app/` (protocol, process event/selectors, shared pipes, the chat component + its `ProcessComponent.providers` wiring line, and the team-tree footer).

## Epic 26 slice complete

All three stories of Epic 26 have landed on the shared epic branch and passed adversarial review:

| Story | Issue | What shipped |
|---|---|---|
| 26-1-token-usage-data-layer | #193 | `LlmUsageEvent` protocol type + `isLlmUsageEvent` guard, incremental per-agent `tokenUsageSpec` reducer, `IngestionService` registration, component-scoped `TokenUsageSelector` (`perAgent$` + pure `teamTotals$`), and the compact `tokenCount` pipe (`412 → 412`, `12_031 → 12.0k`, `1_200_000 → 1.2M`). |
| 26-2-member-chat-usage-pill | #195 | Member-chat usage pill in `AkgentChatComponent` (`ctx <ctx> · ↑<sent> ↓<received>`), bound to `perAgent$(agentId) \| async`, neutral empty-state, model tooltip, re-points on member switch; `TokenUsageSelector` wired onto `ProcessComponent.providers`. |
| 26-3-team-tree-footer-total | #196 | Team-tree footer total in `TreeComponent` (`Team total ↑<sent> ↓<received>`), bound to the SHARED `teamTotals$ \| async`, empty team → `↑0 ↓0`, flex-column footer pinned beneath the tree. |

**Wire-shape gate passed (no infra change).** The entire epic consumes a structured `EventMessage(LlmUsageEvent)` already on the wire — the inner event is read one level deep (`m.event.__model__`), serialized by the same core dataclass branch that already ships `LlmSystemPromptEvent`. No `akgentic-llm` / `akgentic-core` / `akgentic-infra` story was required; every change is frontend-only.

**Documented deferrals (ADR-022 §Decision 7, out of scope for v1):**
- **USD cost** — not on the wire (no per-model pricing in the event); not computed.
- **Per-run / per-call history** — only running team/agent aggregates and the latest context-window proxy are kept; there is no persisted per-run breakdown.
- **Cache occupancy** — the cache / `requests` fields ride the wire but are excluded from the v1 displays.

### Context

- ADR-022 — `_bmad-output/akgentic-frontend/decisions/adr-022-llm-token-usage-selector-and-displays.md`
- Epic 26 — `_bmad-output/akgentic-frontend/epics/epic-26-llm-token-usage-selector-and-displays.md`

Relates to #193
Relates to #195
Relates to #196
