### PR TITLE
feat(akgentic-frontend): epic 28 — classic paginated team list (28-1 → 28-4)

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -76,21 +76,33 @@
     <br />
     <br />
 
+    <!--
+      Classic numbered paginator (Epic 28, ADR-032 §Decision 3). [lazy] +
+      (onLazyLoad) drive a server-paged fetch (250/page); [totalRecords] from
+      the 28.1 totalCount feeds the "X–Y of N" report. The client cross-page
+      sort (former [sortField]/[sortOrder] + pSortableColumn/p-sortIcon) is
+      removed — the server returns each page already ordered created_at desc.
+      No [scrollable]/[virtualScroll]/@angular/cdk (classic, not virtual).
+    -->
     <p-table
       [value]="(contextService.teams$ | async) || []"
       selectionMode="single"
       (onRowSelect)="onRowSelect($event)"
       [tableStyle]="{ 'min-width': '50rem' }"
-      [sortField]="'created_at'"
-      [sortOrder]="-1"
+      [lazy]="true"
+      (onLazyLoad)="loadPage($event)"
+      [paginator]="true"
+      [rows]="rows"
+      [first]="first"
+      [totalRecords]="contextService.totalCount"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="{first}–{last} of {totalRecords}"
+      paginatorPosition="bottom"
     >
       <ng-template #header>
         <tr>
           <th>Name</th>
-          <th pSortableColumn="created_at">
-            Creation Date
-            <p-sortIcon field="created_at"></p-sortIcon>
-          </th>
+          <th>Creation Date</th>
           <th>Status</th>
           <th>Team ID</th>
           <th></th>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,6 +1,13 @@
 <section class="content">
   <br />
   <div class="main-container">
+    <!--
+      Controls row (dropdown + Create/Configuration/Refresh + "Show all" toggle).
+      Wrapped so it stays a normal-flow block (its master inline layout) and is
+      NOT a stretched/stacked flex child of .main-container — the table area
+      below is the only flex/scroll region (Story 28.3).
+    -->
+    <div class="home-controls">
     <p-select
       size="small"
       [options]="(namespaces$ | async) || []"
@@ -75,20 +82,35 @@
     ></button>
     <br />
     <br />
+    </div>
 
+    <!--
+      Table area — the single flex/scroll region (Story 28.3). Grows to fill the
+      bounded .main-container so the [scrollable] table's body scrolls within it
+      and the bottom paginator pins; the controls above stay in normal flow.
+    -->
+    <div class="home-table">
     <!--
       Classic numbered paginator (Epic 28, ADR-032 §Decision 3). [lazy] +
       (onLazyLoad) drive a server-paged fetch (250/page); [totalRecords] from
       the 28.1 totalCount feeds the "X–Y of N" report. The client cross-page
       sort (former [sortField]/[sortOrder] + pSortableColumn/p-sortIcon) is
       removed — the server returns each page already ordered created_at desc.
-      No [scrollable]/[virtualScroll]/@angular/cdk (classic, not virtual).
+
+      [scrollable]="true" + scrollHeight="flex" (Epic 28, Story 28.3) make the
+      body scroll within the height-constrained flex parent (.main-container)
+      so the sticky header and the bottom paginator stay pinned — the pager is
+      reachable without scrolling past 250 rows. This is plain PrimeNG table
+      scrolling, NOT virtual scroll: no [virtualScroll]/@angular/cdk (forbidden
+      by ADR-032 §"What we will not do"; [scrollable] is explicitly allowed).
     -->
     <p-table
       [value]="(contextService.teams$ | async) || []"
       selectionMode="single"
       (onRowSelect)="onRowSelect($event)"
       [tableStyle]="{ 'min-width': '50rem' }"
+      [scrollable]="true"
+      scrollHeight="flex"
       [lazy]="true"
       (onLazyLoad)="loadPage($event)"
       [paginator]="true"
@@ -227,6 +249,7 @@
         </tr>
       </ng-template>
     </p-table>
+    </div>
   </div>
 </section>
 

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -62,6 +62,22 @@
     }
 }
 
+// Story 28.4 — opaque sticky header. 28.3's [scrollable] gave the table a
+// sticky thead for free, but the app theme sets the datatable header-cell
+// background to `transparent` (app.theme.ts), so scrolling rows bleed through
+// behind the pinned "Name / Creation Date / Status / Team ID" labels. Paint
+// the home table's sticky thead (and its cells) white — matching the row
+// surface — so rows are masked as they scroll under it. PrimeNG renders the
+// datatable header INSIDE this component's view (unlike the teleported dialog
+// header below), so `::ng-deep` is needed to pierce encapsulation; `:host`
+// keeps the rule scoped here and off every other datatable (the global
+// `transparent` preset is intentionally untouched). PrimeNG's sticky thead
+// already wins the stacking, so no z-index is needed.
+:host ::ng-deep .p-datatable-thead,
+:host ::ng-deep .p-datatable-thead > tr > th {
+    background: #fff;
+}
+
 .show-all-namespaces {
     display: inline-flex;
     align-items: center;

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -1,7 +1,65 @@
+// Story 28.3 — height-constrained flex column so the classic paginated table
+// fills the area below the app header and defines a bounded scroll region. The
+// table's [scrollable]/scrollHeight="flex" then scrolls the BODY while the
+// header (sticky for free with scrollable) and the bottom paginator stay
+// pinned. Component-local (no shell change): no `position: fixed` (overlap risk
+// with the menubar). The header height is a CSS variable with a fallback rather
+// than a brittle magic pixel — `calc(100vh - var(--app-header-height))` bounds
+// :host so the flex chain has a real height to distribute. `min-height: 0` on
+// each flex child is the unlock that lets the table shrink below its content
+// and form the inner scroll region (without it the page, not the body, scrolls).
+:host {
+    --app-header-height: 4.5rem;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--app-header-height));
+    min-height: 0;
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
 .main-container {
     background-color: #F2F7F9;
     border-radius: 6px;
     padding: 1rem;
+
+    // Flex column with exactly two children: the controls block (.home-controls,
+    // natural height, normal flow) and the table area (.home-table) which grows
+    // to bound the scroll region. The flex is scoped to these two wrappers so it
+    // never reaches the individual controls (which would stretch/stack them).
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+// Controls row stays normal block flow — its dropdown / buttons / toggle keep
+// the master inline layout (NOT stretched or stacked). `flex: 0 0 auto` so it
+// takes only its natural height and never grows.
+.home-controls {
+    flex: 0 0 auto;
+}
+
+// The lazy paginated team list area grows to fill the column and bounds the
+// table's scrollHeight="flex" body. `min-height: 0` is the unlock that lets it
+// shrink below content so the inner scroll region forms (else the page scrolls).
+.home-table {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+
+    p-table {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+    }
 }
 
 .show-all-namespaces {

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
+import { Table } from 'primeng/table';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { ApiService } from '../../core/http/api.service';
@@ -1002,6 +1004,35 @@ describe('HomeComponent', () => {
   function paginatorEl(): HTMLElement | null {
     return fixture.nativeElement.querySelector('p-paginator, .p-paginator');
   }
+
+  // Reads the rendered PrimeNG Table instance to assert the scroll-contract
+  // inputs (28.3 AC #6a). The scroll body's p-scroller rows may not
+  // materialise deterministically in a detached fixture, so we assert the
+  // binding/configuration, not scraped viewport geometry.
+  function tableInstance(): Table {
+    return fixture.debugElement.query(By.directive(Table)).componentInstance;
+  }
+
+  it('(28.3 AC2/AC6a) table is configured scrollable with a flex scroll height and the paginator is present', async () => {
+    contextSpy.totalCount = 1000;
+    totalCount$.next(1000);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const table = tableInstance();
+    // The body scrolls within the bounded flex parent (sticky header + bottom
+    // paginator follow); the pager is always reachable without scrolling rows.
+    expect(table.scrollable).toBeTrue();
+    expect(table.scrollHeight).toBe('flex');
+    expect(paginatorEl()).withContext('paginator must render below the scroll body').not.toBeNull();
+  });
+
+  it('(28.3 AC4) table does NOT enable virtual scroll', () => {
+    fixture.detectChanges();
+    const table = tableInstance();
+    expect(table.virtualScroll).toBeFalsy();
+  });
 
   it('(28.2 AC8a) table renders with a paginator and totalRecords driven by totalCount', async () => {
     contextSpy.totalCount = 1000;

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -30,9 +30,12 @@ describe('HomeComponent', () => {
   let fixture: ComponentFixture<HomeComponent>;
   let component: HomeComponent;
   let teams$: BehaviorSubject<TeamContext[]>;
+  let totalCount$: BehaviorSubject<number>;
   let apiSpy: jasmine.SpyObj<ApiService>;
   let contextSpy: jasmine.SpyObj<ContextService> & {
     teams$: BehaviorSubject<TeamContext[]>;
+    totalCount$: BehaviorSubject<number>;
+    totalCount: number;
   };
   let authSpy: jasmine.SpyObj<AuthService> & {
     currentUser$: BehaviorSubject<any>;
@@ -45,6 +48,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     teams$ = new BehaviorSubject<TeamContext[]>([]);
+    totalCount$ = new BehaviorSubject<number>(0);
 
     apiSpy = jasmine.createSpyObj('ApiService', [
       'getNamespaces',
@@ -63,12 +67,42 @@ describe('HomeComponent', () => {
 
     contextSpy = jasmine.createSpyObj<ContextService>(
       'ContextService',
-      ['getTeams', 'deleteTeam', 'createTeamAndNavigate', 'stopTeamAndAwait']
+      [
+        'getTeams',
+        'loadTeamsPage',
+        'resetTeams',
+        'deleteTeam',
+        'createTeamAndNavigate',
+        'stopTeamAndAwait',
+      ],
     ) as jasmine.SpyObj<ContextService> & {
       teams$: BehaviorSubject<TeamContext[]>;
+      totalCount$: BehaviorSubject<number>;
+      totalCount: number;
     };
     contextSpy.teams$ = teams$;
+    contextSpy.totalCount$ = totalCount$;
+    // Plain settable property mirroring the 28.1 totalCount getter so the
+    // template's [totalRecords]="contextService.totalCount" has a value.
+    contextSpy.totalCount = 0;
     contextSpy.getTeams.and.callFake(async () => teams$.value);
+    // loadTeamsPage REPLACES teams$ with the page (one page in the DOM) and
+    // updates totalCount — mirrors the 28.1 data-layer behavior so REPLACE
+    // semantics and the page swap are observable in tests. The fake returns a
+    // single-row page keyed by the requested page so a jump-to-page renders
+    // distinct rows.
+    contextSpy.loadTeamsPage.and.callFake(
+      async (page: number = 1, _size?: number) => {
+        const pageTeams = [
+          makeTeam({ team_id: `team-page-${page}`, name: `Page ${page}` }),
+        ];
+        teams$.next(pageTeams);
+        contextSpy.totalCount = 1000;
+        totalCount$.next(1000);
+        return { teams: pageTeams, total_count: 1000 };
+      },
+    );
+    contextSpy.resetTeams.and.stub();
     contextSpy.deleteTeam.and.returnValue(Promise.resolve());
     contextSpy.createTeamAndNavigate.and.returnValue(Promise.resolve());
     contextSpy.stopTeamAndAwait.and.returnValue(Promise.resolve());
@@ -114,6 +148,10 @@ describe('HomeComponent', () => {
   });
 
   it('(AC6) template renders one row per team emitted on teams$', async () => {
+    // Render first so the lazy table's initial (onLazyLoad) seed fires; then
+    // push the page into teams$ (mirrors a real page arrival — REPLACE).
+    fixture.detectChanges();
+    await fixture.whenStable();
     teams$.next([
       makeTeam({ team_id: 't-1', name: 'Alpha' }),
       makeTeam({ team_id: 't-2', name: 'Beta' }),
@@ -137,6 +175,8 @@ describe('HomeComponent', () => {
   });
 
   it('(AC6, AC9) pushing a new list into teams$ triggers a re-render', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
     teams$.next([makeTeam({ team_id: 't-1' })]);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -159,9 +199,12 @@ describe('HomeComponent', () => {
     expect(apiSpy.deleteTeam).not.toHaveBeenCalled();
   });
 
-  it('(AC7) refreshContext() calls contextService.getTeams once without touching a local field', async () => {
+  it('(28.2 AC4) refreshContext() reloads the current page via loadTeamsPage (REPLACE), not getTeams', async () => {
+    component.currentPage = 2;
     await component.refreshContext();
-    expect(contextSpy.getTeams).toHaveBeenCalledTimes(1);
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(2, 250);
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+    expect(contextSpy.resetTeams).not.toHaveBeenCalled();
     expect((component as any).context).toBeUndefined();
   });
 
@@ -952,5 +995,224 @@ describe('HomeComponent', () => {
 
     // Still-present selection left untouched (reference-equal).
     expect(component.selectedNamespace$.value).toBe(original);
+  });
+
+  // --- Epic 28: classic lazy paginated table (view layer) ---
+
+  function paginatorEl(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('p-paginator, .p-paginator');
+  }
+
+  it('(28.2 AC8a) table renders with a paginator and totalRecords driven by totalCount', async () => {
+    contextSpy.totalCount = 1000;
+    totalCount$.next(1000);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // The lazy table seeds page 1 on init (loadPage → loadTeamsPage).
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalled();
+    // Paginator chrome present; totalRecords reflects the 28.1 totalCount.
+    expect(paginatorEl()).withContext('paginator must render').not.toBeNull();
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('1000');
+  });
+
+  it('(28.2 AC8b) loadPage computes page = first / rows + 1 and delegates to loadTeamsPage', async () => {
+    await component.loadPage({ first: 500, rows: 250 });
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(3, 250);
+    expect(component.currentPage).toBe(3);
+    expect(component.first).toBe(500);
+  });
+
+  it('(28.2 AC8b) loadPage falls back to PAGE_SIZE when event.rows is absent', async () => {
+    await component.loadPage({ first: 0 });
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(1, 250);
+  });
+
+  it('(28.2 AC8c) opening the home page triggers exactly ONE initial page-1 loadTeamsPage (no double-seed)', async () => {
+    // The lazy table fires its initial (onLazyLoad) once on render.
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledTimes(1);
+    expect(contextSpy.loadTeamsPage.calls.first().args[0]).toBe(1);
+    // ngOnInit must NOT itself fetch the list (no double seed).
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+  });
+
+  it('(28.2 AC8c) ngOnInit (hideHome off) does NOT fetch the list itself', async () => {
+    // Called directly without rendering — no table, so the only list fetch
+    // would be an (illegal) ngOnInit fetch. Assert there is none.
+    await component.ngOnInit();
+    expect(contextSpy.getTeams).not.toHaveBeenCalled();
+    expect(contextSpy.loadTeamsPage).not.toHaveBeenCalled();
+  });
+
+  it('(28.2 AC8d) a jump-to-page fetches that page and REPLACES (not appends) the rendered rows', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    // Initial seed rendered page 1.
+    expect((fixture.nativeElement.textContent as string)).toContain('team-page-1');
+
+    // Jump to page 3 (first = 500, rows = 250).
+    await component.loadPage({ first: 500, rows: 250 });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledWith(3, 250);
+    const text = fixture.nativeElement.textContent as string;
+    // New page rendered; prior page REPLACED (not accumulated).
+    expect(text).toContain('team-page-3');
+    expect(text).not.toContain('team-page-1');
+  });
+
+  it('(28.2 AC8e) createTeam resets to page 1, reloads page 1, and does not blank the list', async () => {
+    component.selectedNamespace$.next({
+      namespace: 'agent-team-v1',
+      name: 'Agent Team',
+      description: 'd',
+    });
+    component.currentPage = 4;
+    component.first = 750;
+    contextSpy.loadTeamsPage.calls.reset();
+
+    await component.createTeam();
+
+    expect(apiSpy.createTeam).toHaveBeenCalledOnceWith('agent-team-v1');
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(1, 250);
+    expect(component.currentPage).toBe(1);
+    expect(component.first).toBe(0);
+    // No empty flash — never reset before reload.
+    expect(contextSpy.resetTeams).not.toHaveBeenCalled();
+  });
+
+  it('(28.2 AC8e) restoreTeam reloads the CURRENT page with no empty emission', async () => {
+    component.currentPage = 2;
+    contextSpy.loadTeamsPage.calls.reset();
+    const emissions: TeamContext[][] = [];
+    const sub = teams$.subscribe((v) => emissions.push(v));
+
+    await component.restoreTeam('team-X');
+
+    expect(apiSpy.restoreTeam).toHaveBeenCalledOnceWith('team-X');
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(2, 250);
+    expect(contextSpy.resetTeams).not.toHaveBeenCalled();
+    // No empty [] emission slipped in before the reloaded page.
+    expect(emissions.some((e) => e.length === 0 && e !== emissions[0])).toBeFalse();
+    sub.unsubscribe();
+  });
+
+  it('(28.2 AC8e) refreshContext reloads the CURRENT page with no empty emission', async () => {
+    component.currentPage = 3;
+    contextSpy.loadTeamsPage.calls.reset();
+
+    await component.refreshContext();
+
+    expect(contextSpy.loadTeamsPage).toHaveBeenCalledOnceWith(3, 250);
+    expect(contextSpy.resetTeams).not.toHaveBeenCalled();
+  });
+
+  it('(28.2 AC8f) cell templates work on a paged row: select navigates, status tag, action handlers, inline edit', async () => {
+    spyOn(component, 'stopTeam').and.callThrough();
+    spyOn(component, 'deleteTeam').and.callThrough();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // Render a known running row (REPLACE the seed page).
+    teams$.next([
+      makeTeam({ team_id: 'row-1', name: 'Row One', status: 'running' }),
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('row-1');
+    // Status tag reflects running state.
+    expect(text).toContain('Running');
+
+    // Row select → navigate to /process/{team_id}.
+    component.onRowSelect({ data: { team_id: 'row-1' } });
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/process', 'row-1']);
+
+    // Action handlers invoke the right delegations on a paged row.
+    await component.deleteTeam('row-1');
+    expect(contextSpy.deleteTeam).toHaveBeenCalledWith('row-1');
+    await component.stopTeam('row-1');
+    expect(contextSpy.stopTeamAndAwait).toHaveBeenCalledWith('row-1');
+
+    // Inline description edit: open / save / cancel.
+    component.startEditDescription('row-1', 'old');
+    expect(component.editingDescriptionFor).toBe('row-1');
+    expect(component.descriptionDrafts.get('row-1')).toBe('old');
+    await component.saveDescription('row-1');
+    expect(apiSpy.updateTeamDescription).toHaveBeenCalled();
+    expect(component.editingDescriptionFor).toBeNull();
+    component.startEditDescription('row-1', 'again');
+    component.cancelEditDescription();
+    expect(component.editingDescriptionFor).toBeNull();
+  });
+
+  describe('hideHome reactive read (28.2 AC3)', () => {
+    beforeEach(async () => {
+      // Re-configure with hideHome ON so the auto-route branch runs.
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [HomeComponent, CommonModule, NoopAnimationsModule],
+        providers: [
+          { provide: ApiService, useValue: apiSpy },
+          { provide: ContextService, useValue: contextSpy },
+          { provide: AuthService, useValue: authSpy },
+          { provide: ConfigService, useValue: { hideHome: true } },
+          { provide: Router, useValue: routerSpy },
+        ],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      }).compileComponents();
+      fixture = TestBed.createComponent(HomeComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('navigates to the first team after the seed lands (reactive read, single fetch)', async () => {
+      // ngOnInit awaits the seed; drive the table seed via loadPage, which the
+      // fake resolves with a one-row page.
+      const init = component.ngOnInit();
+      await component.loadPage({ first: 0, rows: 250 });
+      await init;
+
+      // Exactly one page-1 fetch (the seed) — no extra ngOnInit fetch.
+      expect(contextSpy.loadTeamsPage).toHaveBeenCalledTimes(1);
+      expect(contextSpy.getTeams).not.toHaveBeenCalled();
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/process', 'team-page-1']);
+    });
+
+    it('creates a team when the seeded page is empty', async () => {
+      // loadNamespaces must keep the selection present (else reconciliation
+      // clears it to null and the create branch has no namespace to use).
+      apiSpy.getNamespaces.and.returnValue(
+        Promise.resolve([
+          { namespace: 'agent-team-v1', name: 'Agent Team', description: 'd' },
+        ]),
+      );
+      component.selectedNamespace$.next({
+        namespace: 'agent-team-v1',
+        name: 'Agent Team',
+        description: 'd',
+      });
+      // Seed an EMPTY page so the create branch runs.
+      contextSpy.loadTeamsPage.and.callFake(async () => {
+        teams$.next([]);
+        return { teams: [], total_count: 0 };
+      });
+
+      const init = component.ngOnInit();
+      await component.loadPage({ first: 0, rows: 250 });
+      await init;
+
+      expect(contextSpy.createTeamAndNavigate).toHaveBeenCalledOnceWith('agent-team-v1');
+    });
   });
 });

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -10,7 +10,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map, take } from 'rxjs/operators';
 
 import { ApiService } from '../../core/http/api.service';
 import { TeamContext, isRunning } from '../../core/context/team.interface';
@@ -19,7 +19,7 @@ import { NamespaceSummary } from '../../protocol/catalog.interface';
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
-import { TableModule } from 'primeng/table';
+import { TableModule, TableLazyLoadEvent } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
@@ -35,6 +35,11 @@ import { ContextService } from '../../core/context/context.service';
 // loaded only on first opening of the namespace-editor dialog — the initial
 // home-page bundle stays Monaco-free.
 import { NamespacePanelComponent } from '../catalog/namespace-panel/namespace-panel.component';
+
+// Classic team-list page size (Epic 28, ADR-032 §Decision 3). Bound to the
+// paginator's [rows] and used as the loadTeamsPage size fallback so no magic
+// 250 literal is duplicated. Server clamps size to [1, 500].
+const PAGE_SIZE = 250;
 
 @Component({
   selector: 'app-home',
@@ -69,6 +74,19 @@ export class HomeComponent {
   restoringTeams = new Set<string>();
   editingDescriptionFor: string | null = null;
   descriptionDrafts = new Map<string, string>();
+
+  // Classic paginator state (Epic 28). `rows` feeds [rows]; `first` is the
+  // row offset the paginator is parked on; `currentPage` (1-based) is tracked
+  // so create/restore/refresh reload the right page. The table's first
+  // (onLazyLoad) seeds page 1 — ngOnInit no longer fetches the list (AC #3).
+  readonly rows = PAGE_SIZE;
+  first = 0;
+  currentPage = 1;
+
+  // Flips true after the table's first (onLazyLoad) page-1 load resolves. The
+  // hideHome branch awaits this then reads teams$ reactively — so exactly one
+  // page-1 fetch happens (the seed), never a second ngOnInit fetch (AC #3).
+  private firstPageLoaded$ = new BehaviorSubject<boolean>(false);
 
   // Controls the Namespace Panel dialog visibility. The panel component is
   // mounted lazily via @defer in home.component.html so its Monaco-editor
@@ -116,25 +134,48 @@ export class HomeComponent {
   async ngOnInit() {
     await this.loadNamespaces();
 
-    // Populate _context$; return value reused for the hideHome branch.
-    const teams = await this.contextService.getTeams();
-
+    // The list is seeded by the table's first (onLazyLoad) (page 1) — NOT a
+    // fetch here, which would double-seed (AC #3). The hideHome branch reads
+    // the seeded list reactively below.
     if (this.config.hideHome) {
-      // If no team exists, create one using the first namespace.
-      if (!teams || teams.length === 0) {
-        const selected = this.selectedNamespace$.value;
-        if (selected) {
-          await this.contextService.createTeamAndNavigate(selected.namespace);
-        }
-      }
-      // If a team exists, navigate to its process page.
-      if (teams && teams.length > 0) {
-        const teamId = teams[0].team_id;
-        this.router.navigate(['/process', teamId]);
-      }
+      await this.handleHideHome();
     }
 
     this.authService.checkAuth().subscribe();
+  }
+
+  /**
+   * Classic lazy paginator load (Epic 28, ADR-032 §Decision 3). PrimeNG fires
+   * (onLazyLoad) once on init (first: 0) and on every page change. Computes the
+   * 1-based page from the row offset and delegates to the 28.1 data layer,
+   * which REPLACES teams$ with the fetched page (one page in the DOM) and sets
+   * totalCount. Tracks first/currentPage so create/restore/refresh reload the
+   * right page.
+   */
+  async loadPage(event: TableLazyLoadEvent): Promise<void> {
+    const size = event.rows ?? PAGE_SIZE;
+    this.first = event.first ?? 0;
+    this.currentPage = Math.floor(this.first / size) + 1;
+    await this.contextService.loadTeamsPage(this.currentPage, size);
+    this.firstPageLoaded$.next(true);
+  }
+
+  /**
+   * hideHome auto-route: once the table's first page-1 seed lands, read the
+   * current page reactively from teams$ (no extra fetch) and either create a
+   * team (empty) or navigate to the first one. Preserves the master behavior.
+   */
+  private async handleHideHome(): Promise<void> {
+    await firstValueFrom(this.firstPageLoaded$.pipe(filter((done) => done), take(1)));
+    const teams = await firstValueFrom(this.contextService.teams$.pipe(take(1)));
+    if (!teams || teams.length === 0) {
+      const selected = this.selectedNamespace$.value;
+      if (selected) {
+        await this.contextService.createTeamAndNavigate(selected.namespace);
+      }
+      return;
+    }
+    this.router.navigate(['/process', teams[0].team_id]);
   }
 
   /**
@@ -182,7 +223,11 @@ export class HomeComponent {
         return;
       }
       await this.apiService.createTeam(selected.namespace);
-      await this.contextService.getTeams();
+      // New team is newest under created_at desc → it belongs on page 1.
+      // Move the paginator to page 1 and reload (REPLACE — no empty flash).
+      this.first = 0;
+      this.currentPage = 1;
+      await this.contextService.loadTeamsPage(1, PAGE_SIZE);
     } catch (error) {
       console.error('Failed to create team:', error);
     } finally {
@@ -207,7 +252,8 @@ export class HomeComponent {
     this.restoringTeams.add(teamId);
     try {
       await this.apiService.restoreTeam(teamId);
-      await this.contextService.getTeams();
+      // Reload the current page (REPLACE — no empty flash); no page jump.
+      await this.contextService.loadTeamsPage(this.currentPage, PAGE_SIZE);
     } finally {
       this.restoringTeams.delete(teamId);
     }
@@ -235,7 +281,8 @@ export class HomeComponent {
   async refreshContext() {
     this.isRefreshing = true;
     try {
-      await this.contextService.getTeams();
+      // Reload the current page (REPLACE — no empty flash); no page jump.
+      await this.contextService.loadTeamsPage(this.currentPage, PAGE_SIZE);
     } finally {
       this.isRefreshing = false;
     }

--- a/src/app/core/context/context.service.spec.ts
+++ b/src/app/core/context/context.service.spec.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from 'rxjs';
 
 import { ApiService } from '../http/api.service';
 import { ContextService } from './context.service';
-import { TeamContext, TeamResponse } from './team.interface';
+import { TeamContext, TeamPage, TeamResponse } from './team.interface';
 
 function makeTeam(
   teamId: string,
@@ -41,6 +41,7 @@ describe('ContextService', () => {
   beforeEach(() => {
     apiSpy = jasmine.createSpyObj('ApiService', [
       'getTeams',
+      'getTeamsPage',
       'getTeam',
       'createTeam',
       'deleteTeam',
@@ -899,4 +900,75 @@ describe('ContextService', () => {
     // Unchanged slot preserves reference identity (immutable filter on same refs).
     expect(next[0]).toBe(prevB);
   }));
+
+  // =======================================================================
+  // Story 28.1 — classic page load (REPLACE) + totalCount slice
+  // =======================================================================
+
+  function makePage(teams: TeamContext[], total: number): TeamPage {
+    return { teams, total_count: total };
+  }
+
+  it('(AC5f) loadTeamsPage REPLACES teams$ with the fetched page (does NOT append)', async () => {
+    // Seed a prior page so a buggy append would leave 3 teams, not 2.
+    apiSpy.getTeamsPage.and.returnValue(
+      Promise.resolve(makePage([makeTeam('a')], 1)),
+    );
+    await service.loadTeamsPage(1, 250);
+
+    const page2 = [makeTeam('b'), makeTeam('c')];
+    apiSpy.getTeamsPage.and.returnValue(Promise.resolve(makePage(page2, 2)));
+
+    const returned = await service.loadTeamsPage(2, 250);
+
+    const teams = await firstValueFrom(service.teams$);
+    expect(teams).toEqual(page2);
+    expect(teams.map((t) => t.team_id)).toEqual(['b', 'c']);
+    expect(returned.teams).toEqual(page2);
+  });
+
+  it('(AC5g) loadTeamsPage updates totalCount from the response total_count', async () => {
+    apiSpy.getTeamsPage.and.returnValue(
+      Promise.resolve(makePage([makeTeam('a')], 137)),
+    );
+
+    const emissions: number[] = [];
+    const sub = service.totalCount$.subscribe((v) => emissions.push(v));
+
+    await service.loadTeamsPage(1, 250);
+
+    expect(service.totalCount).toBe(137);
+    // Initial 0 emission + the updated total.
+    expect(emissions[emissions.length - 1]).toBe(137);
+
+    sub.unsubscribe();
+  });
+
+  it('(AC5g) loadTeamsPage calls apiService.getTeamsPage with the given page/size', async () => {
+    apiSpy.getTeamsPage.and.returnValue(Promise.resolve(makePage([], 0)));
+
+    await service.loadTeamsPage(3, 250);
+
+    expect(apiSpy.getTeamsPage).toHaveBeenCalledOnceWith(3, 250);
+  });
+
+  it('(AC5h) resetTeams clears totalCount back to 0 and teams$ to []', async () => {
+    apiSpy.getTeamsPage.and.returnValue(
+      Promise.resolve(makePage([makeTeam('a'), makeTeam('b')], 2)),
+    );
+    await service.loadTeamsPage(1, 250);
+
+    expect((await firstValueFrom(service.teams$)).length).toBe(2);
+    expect(service.totalCount).toBe(2);
+
+    service.resetTeams();
+
+    expect(await firstValueFrom(service.teams$)).toEqual([]);
+    expect(service.totalCount).toBe(0);
+  });
+
+  it('(28.1) totalCount$ emits 0 synchronously on construction', async () => {
+    const value = await firstValueFrom(service.totalCount$);
+    expect(value).toBe(0);
+  });
 });

--- a/src/app/core/context/context.service.ts
+++ b/src/app/core/context/context.service.ts
@@ -19,7 +19,7 @@ import {
   timeout,
 } from 'rxjs/operators';
 import { ApiService } from '../http/api.service';
-import { isRunning, TeamContext, toTeamContext } from './team.interface';
+import { isRunning, TeamContext, TeamPage, toTeamContext } from './team.interface';
 
 @Injectable({
   providedIn: 'root',
@@ -37,6 +37,15 @@ export class ContextService {
   // will push updates via _context$.next(applyPatch(_context$.value, patch)).
   private _context$ = new BehaviorSubject<TeamContext[]>([]);
   public teams$: Observable<TeamContext[]> = this._context$.asObservable();
+
+  // Total teams across all pages (classic offset+total pagination, Epic 28).
+  // Single write path, same discipline as `_context$`; reset with the team
+  // list so a stale total never bleeds across teams.
+  private _totalCount$ = new BehaviorSubject<number>(0);
+  public totalCount$: Observable<number> = this._totalCount$.asObservable();
+  public get totalCount(): number {
+    return this._totalCount$.value;
+  }
 
   /** Derived selector: the team whose id matches `currentProcessId$`, or
    *  `null` if none matches (including the empty-string initial id). The
@@ -68,6 +77,26 @@ export class ContextService {
     const teams = await this.apiService.getTeams();
     this._context$.next(teams);
     return teams;
+  }
+
+  /**
+   * Classic page load (Epic 28): fetch one page via `apiService.getTeamsPage`
+   * and REPLACE the team list with it (one page in the DOM at a time — NOT
+   * append) while recording `total_count`. Returns the page for awaiting
+   * callers. Story 28.2 wires this to the paginator's `(onLazyLoad)`.
+   */
+  async loadTeamsPage(page?: number, size?: number): Promise<TeamPage> {
+    const result = await this.apiService.getTeamsPage(page, size);
+    this._context$.next(result.teams);
+    this._totalCount$.next(result.total_count);
+    return result;
+  }
+
+  /** Clear team-list state on team-switch / context reset so a stale page or
+   *  total never bleeds across teams. */
+  resetTeams(): void {
+    this._context$.next([]);
+    this._totalCount$.next(0);
   }
 
   async getCurrentTeam(

--- a/src/app/core/context/team.interface.ts
+++ b/src/app/core/context/team.interface.ts
@@ -13,9 +13,12 @@ export interface TeamResponse {
   updated_at: string;
 }
 
-// Maps to Python TeamListResponse
+// Maps to Python TeamListResponse (classic offset+total pagination, Epic 28).
+// `total_count` is the total teams the user owns across ALL pages; `teams` is
+// the current page. No `next_cursor` (the parked cursor approach, ADR-031).
 export interface TeamListResponse {
   teams: TeamResponse[];
+  total_count: number;
 }
 
 // Maps to Python EventResponse
@@ -75,6 +78,16 @@ export interface TeamContext {
   updated_at: string;
   config_name: string;
   description?: string | null;
+}
+
+/**
+ * Frontend-facing page of teams (classic offset+total pagination, Epic 28).
+ * `teams` is already mapped to the `TeamContext` view model; `total_count`
+ * is carried through verbatim from `TeamListResponse`.
+ */
+export interface TeamPage {
+  teams: TeamContext[];
+  total_count: number;
 }
 
 /** Check if a team is currently running. */

--- a/src/app/core/http/api.service.spec.ts
+++ b/src/app/core/http/api.service.spec.ts
@@ -272,6 +272,88 @@ describe('ApiService', () => {
     });
   });
 
+  describe('getTeamsPage (Story 28.1)', () => {
+    const makeResponse = () => ({
+      teams: [
+        {
+          team_id: 't1',
+          name: 'Alpha',
+          status: 'running',
+          user_id: 'u1',
+          created_at: '2026-06-20T10:00:00Z',
+          updated_at: '2026-06-20T10:00:00Z',
+        },
+      ],
+      total_count: 42,
+    });
+
+    it('(AC5a) issues the bare /teams URL (no query) when both args omitted', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(makeResponse()));
+
+      await service.getTeamsPage();
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/teams$/);
+      expect(callArgs.url).not.toContain('?');
+    });
+
+    it('(AC5b) appends page= when only page is provided', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(makeResponse()));
+
+      await service.getTeamsPage(2);
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toMatch(/\/teams\?/);
+      expect(callArgs.url).toContain('page=2');
+      expect(callArgs.url).not.toContain('size=');
+    });
+
+    it('(AC5c) appends both page= and size= when both provided', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(makeResponse()));
+
+      await service.getTeamsPage(2, 250);
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toContain('page=2');
+      expect(callArgs.url).toContain('size=250');
+    });
+
+    it('(AC5c) sends size even when only size is provided', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(makeResponse()));
+
+      await service.getTeamsPage(undefined, 250);
+
+      const callArgs = fetchServiceSpy.fetch.calls.first().args[0];
+      expect(callArgs.url).toContain('size=250');
+      expect(callArgs.url).not.toContain('page=');
+    });
+
+    it('(AC5d) returns a TeamPage with total_count and teams mapped via toTeamContext', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(makeResponse()));
+
+      const result = await service.getTeamsPage(1, 250);
+
+      expect(result.total_count).toBe(42);
+      expect(result.teams.length).toBe(1);
+      // toTeamContext slims TeamResponse → TeamContext (drops user_id, adds
+      // config_name/description); assert the mapped view-model shape.
+      const team = result.teams[0];
+      expect(team.team_id).toBe('t1');
+      expect(team.config_name).toBe('Alpha');
+      expect(team.description).toBeNull();
+      expect((team as unknown as Record<string, unknown>)['user_id']).toBeUndefined();
+    });
+
+    it('(AC5e) defaults to teams:[] and total_count:0 on a missing/empty body', async () => {
+      fetchServiceSpy.fetch.and.returnValue(Promise.resolve(undefined));
+
+      const result = await service.getTeamsPage();
+
+      expect(result.teams).toEqual([]);
+      expect(result.total_count).toBe(0);
+    });
+  });
+
   describe('sendMessage (existing)', () => {
     it('should broadcast when no agentName provided', async () => {
       await service.sendMessage('team-1', 'broadcast msg');

--- a/src/app/core/http/api.service.ts
+++ b/src/app/core/http/api.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '../config/config.service';
 import { FetchService } from './fetch.service';
 import {
   TeamContext,
+  TeamPage,
   TeamResponse,
   TeamListResponse,
   EventResponse,
@@ -38,6 +39,29 @@ export class ApiService {
     });
     const teams = response?.teams ?? [];
     return teams.map(toTeamContext);
+  }
+
+  /**
+   * Classic offset+total page of teams (Epic 28). Issues `GET /teams?page&size`
+   * — bare `/teams` when both args are omitted (server applies its defaults:
+   * page 1 / size 250). A provided arg is appended even if it equals the
+   * server default. Maps `teams` via `toTeamContext` and carries `total_count`
+   * through; a missing/empty body yields `teams: []`, `total_count: 0`.
+   */
+  async getTeamsPage(page?: number, size?: number): Promise<TeamPage> {
+    const params = new URLSearchParams();
+    if (page !== undefined) {
+      params.set('page', String(page));
+    }
+    if (size !== undefined) {
+      params.set('size', String(size));
+    }
+    const query = params.toString();
+    const url = query ? `${this.apiUrl}/teams?${query}` : `${this.apiUrl}/teams`;
+
+    const response: TeamListResponse = await this.fetchService.fetch({ url });
+    const teams = (response?.teams ?? []).map(toTeamContext);
+    return { teams, total_count: response?.total_count ?? 0 };
   }
 
   async getTeam(teamId: string): Promise<TeamContext> {


### PR DESCRIPTION
## Epic 28 — Classic Paginated Team List on the Home Page

Converts the home-page team list from the original non-paginated table to a **classic numbered
PrimeNG paginated table** (250 rows/page, "X–Y of N", jump-to-page). This is the **classic-pagination
pivot** (ADR-032) and **supersedes the parked virtual-scroll / cursor approach** (ADR-031 / Epic 27,
PR #198) — that work is abandoned, not extended. There is no `next_cursor`, no cursor, no append-load,
and no virtual scroll in this epic.

The frontend consumes infra Epic 37's `total_count` contract: `GET /teams?page&size` →
`{ teams, total_count }` (page 1-based, server-side size default 250). This is a **deploy-time
dependency** only — the Karma specs mock HTTP, so the frontend is self-contained for dev/CI.

### Stories

- [x] `28-1-get-teams-page-size-and-total-count-interface` — classic data layer (Relates to #201)
- [x] `28-2-home-page-classic-paginated-table` — classic paginated table (Relates to #203)
- [x] `28-3-pin-paginator-footer-scroll-body` — pinned paginator footer + scrolling body (Relates to #204)
- [x] `28-4-opaque-sticky-table-header` — opaque sticky header (Relates to #205)

### Review status

- **28-1 — APPROVED (done).** `ApiService.getTeamsPage(page?, size?)` issues `GET /teams?page&size`
  (bare `/teams` when omitted) and returns a typed `TeamPage`; `TeamListResponse` gains
  `total_count: number`. `ContextService.loadTeamsPage` REPLACES `teams$` per page (not append) and
  tracks a `totalCount` getter + `totalCount$`; `resetTeams()` clears both. Additive only — the legacy
  `getTeams()` on both services is unchanged and `home.component.*` is untouched (the `<p-table>`
  paginator wiring is Story 28.2). Zero review fixes needed.
- 28-2 review: **PASS — APPROVED (done), zero review fixes.** The home `<p-table>` is a classic lazy
  paginator (`[lazy]`/`[paginator]`/`[rows]=250`/`[totalRecords]=totalCount`/`(onLazyLoad)`), with the
  "X–Y of N" report and NO `[scrollable]`/`[virtualScroll]`/`@angular/cdk`. `loadPage` computes
  `page = first/rows + 1` and delegates to `loadTeamsPage` (REPLACE per page; PAGE_SIZE const, no magic
  literal). **TRAP 1 (single init fetch):** `ngOnInit` no longer fetches; the lazy table's single initial
  `(onLazyLoad)` is the sole page-1 seeder; `hideHome` awaits a `firstPageLoaded$` latch then reads
  `teams$` once reactively — specs assert exactly one page-1 `loadTeamsPage` and `getTeams` never called.
  **TRAP 2 (no empty flash):** create (page 1 + `first=0`) / restore / refresh call ONLY `loadTeamsPage`
  (load-then-swap); a spec asserts no interstitial `[]` emission and `resetTeams` never called. Client
  cross-page sort removed (`[sortField]`/`[sortOrder]`/`pSortableColumn`/`p-sortIcon` gone — server owns
  `created_at desc`). Cell templates (selection→navigate, status tag, Stop/Restore/Delete, inline
  description edit) preserved verbatim.
- 28-3 review: **PASS — APPROVED (done), zero review fixes.** Layout/CSS polish only — adds
  `[scrollable]="true"` + `scrollHeight="flex"` to the home `<p-table>` and a component-local
  height-constrained flex chain (`:host { height: calc(100vh - var(--app-header-height)); display:flex;
  flex-direction:column; min-height:0 }` → `.content`/`.main-container` `flex:1; min-height:0`). The
  flex/scroll is scoped to the **table only**: the controls (dropdown / Create / Configuration / Refresh /
  "Show all" toggle) are wrapped in `.home-controls` (`flex:0 0 auto`, normal block flow — **NOT** a flex
  container, so its inner controls keep master's single-row natural-width inline layout, never
  stretched/stacked); the table lives in `.home-table` (the sole `flex:1; min-height:0` scroll child).
  **No `position: fixed`** (no menubar-overlap risk); **no shell change** (`app.component.*` untouched →
  zero blast radius on `/process`). **No `[virtualScroll]`/`[virtualScrollItemSize]`/
  `cdk-virtual-scroll-viewport`/`@angular/cdk`** — plain PrimeNG `[scrollable]` (allowed by ADR-032
  §"What we will not do"); a spec asserts `table.virtualScroll` is falsy. **All of 28.2 is preserved
  verbatim** — `home.component.ts` is untouched (single-init-fetch, `loadPage` page math, no-flash
  create→page1 / restore+refresh→current-page callers, no `resetTeams`); the `<p-table>` change ADDS
  only the two scroll attributes; the paginator bindings and every cell template are byte-for-byte
  unchanged; all 28.2 specs pass unchanged. New specs assert the scroll contract (`scrollable === true`,
  `scrollHeight === 'flex'`, paginator present below the body) — the binding/config, not scraped
  `p-scroller` geometry. No `ADR-NNN` string assertion.
- 28-4 review: **PASS — APPROVED (done), zero review fixes.** Pure CSS bugfix follow-up to 28.3
  (`home.component.scss` only, +16 lines; `home.component.{html,ts,spec.ts}` byte-for-byte unchanged).
  Root cause: `app.theme.ts` sets the datatable `headerCellBackground: 'transparent'` globally, so 28.3's
  `[scrollable]` sticky thead let scrolling rows bleed through behind "Name / Creation Date / Status /
  Team ID". Fix paints the home table's sticky header opaque white via
  `:host ::ng-deep .p-datatable-thead, :host ::ng-deep .p-datatable-thead > tr > th { background: #fff; }`
  — covering both the `thead` and its `> tr > th` cells (the full sticky-header mask). **Scoped to the
  home table only:** the `:host` prefix anchors the otherwise-global `::ng-deep` to `<app-home>`, so other
  datatables and the global `transparent` preset are untouched (the existing bare `::ng-deep`
  namespace-panel rule is the only deliberately-global pierce; the new rule is `:host`-scoped). White
  matches the row/table surface (no visual mismatch — header `th` cells compute `rgb(255,255,255)` over
  the same white rows). No `z-index` added — PrimeNG's sticky thead (`position: sticky; z-index: 2`)
  already wins stacking; verified visually no row paints over the header. **28.2/28.3 not regressed:** the
  `<p-table>` `[scrollable]`/`scrollHeight="flex"`, paginator bindings, lazy/onLazyLoad,
  `[rows]`/`[first]`/`[totalRecords]`/`[value]`, the "X–Y of N" report, the flex chain, and every cell
  template are unchanged (CSS-only commit). No `@angular/cdk`/`[virtualScroll]`. No `ADR-NNN` string
  assertion (no test/code change at all). Header opacity verified visually (running app); the 28.2/28.3
  contract specs stay green.

### Scope guard

All changes stay inside `packages/akgentic-frontend/`. 28-1 touched `src/app/core/` (3 source files +
2 specs); 28-2 touched only `src/app/components/home/home.component.{ts,html,spec.ts}`; 28-3 touched only
`src/app/components/home/home.component.{html,scss,spec.ts}` (`.ts` untouched); 28-4 touched only
`src/app/components/home/home.component.scss` (`.ts`/`.html`/`.spec.ts` untouched). No files outside
`akgentic-frontend` are touched.

### Local gate (28-1)

Karma headless 1096 SUCCESS (12 new specs); ESLint clean; production build OK (only the pre-existing
lodash CommonJS warning in untouched `util.ts`); coverage Statements 82.56% / Lines 83.11% (≥80%).

## Epic 28 slice complete

Commit chain on `feat/201-epic-28-classic-paginated-team-list`:

- `7005f1d` — 28-1 `getTeams(page,size)` + `total_count` data layer
- `eff5a67` — 28-2 home-page classic paginated team table
- `30567c5` — 28-3 pin paginator footer + scroll table body (height-constrained flex column; controls
  in non-flex `.home-controls`, table in `.home-table`)
- `126a347` — 28-4 opaque sticky table header (home-scoped `:host ::ng-deep` paints the sticky thead
  white; global `transparent` preset and other datatables untouched)

Local gate (28-4, the full epic tip): **Karma headless 1110/1110 SUCCESS**; ESLint clean; production
build OK (same pre-existing lodash CommonJS warning only); coverage Statements 83.68% / Lines 84.26%
(≥80%, not regressed across the epic). No review fixes were needed on any of the four stories.

Relates to #201
Relates to #203
Relates to #204
Relates to #205
