### PR TITLE
feat(akgentic-frontend): epic 29 — render context-compaction & clear markers (29-1)

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -18,10 +18,15 @@ import {
   systemPromptReduce,
 } from '../../../selectors/system-prompt.selector';
 import { TokenUsageSelector } from '../../../selectors/token-usage.selector';
-import { AgentTokenUsage } from '../../../event/per-agent-specs';
+import {
+  AgentTokenUsage,
+  CONVERSATION_SUMMARY_PREFIX,
+  foldContextCompaction,
+} from '../../../event/per-agent-specs';
 import {
   AkgenticMessage,
   CommandDescriptor,
+  LlmContextCompactedEvent,
 } from '../../../../../protocol/message.types';
 
 /**
@@ -1235,5 +1240,136 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     component.userInput = 'hello';
     fixture.detectChanges();
     expect(submit.disabled).toBeFalse();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 29-2 (Epic 29 / ADR-010 §4) — the per-agent `context` store folds a
+// compaction by dropping the replaced prefix and inserting a synthetic summary
+// entry (prefixed CONVERSATION_SUMMARY_PREFIX). The member trace must render the
+// summary as a clearly-labelled row and NOT show the replaced prefix. Driven by
+// pushing the SAME folded array the store produces (foldContextCompaction) into
+// context$ and asserting the rendered conversation rows.
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — folded compaction summary (Story 29-2)', () => {
+  const AGENT = 'a-mgr';
+
+  function setup(): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    component: AkgentChatComponent;
+  } {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
+        provideNoopAnimations(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, component };
+  }
+
+  /** Conversation-table card headers (excludes the head system block), whitespace
+   *  normalised. */
+  function convHeaders(fixture: ComponentFixture<AkgentChatComponent>): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.collapsible-container .card-header'),
+    ).map((n) => (n.textContent ?? '').replace(/\s+/g, ' ').trim());
+  }
+
+  /** Conversation-table content bodies. */
+  function convBodies(fixture: ComponentFixture<AkgentChatComponent>): string[] {
+    const el: HTMLElement = fixture.nativeElement;
+    return Array.from(
+      el.querySelectorAll('.collapsible-container .text-container'),
+    ).map((n) => (n.textContent ?? '').trim());
+  }
+
+  function userEntry(text: string): unknown {
+    return { kind: 'request', parts: [{ part_kind: 'user-prompt', content: text }] };
+  }
+  function systemEntry(text: string): unknown {
+    return {
+      kind: 'request',
+      parts: [{ part_kind: 'system-prompt', dynamic_ref: null, content: text }],
+    };
+  }
+
+  it('AC4 renders the inserted summary row (clearly labelled, prefix stripped) and NOT the replaced prefix', () => {
+    const { fixture, component } = setup();
+
+    // Pre-compaction history, then fold it with the SAME helper the store uses.
+    const preFold = [
+      systemEntry('SYSTEM'),
+      userEntry('dropped earlier turn one'),
+      userEntry('dropped earlier turn two'),
+      userEntry('kept latest turn'),
+    ];
+    const folded = foldContextCompaction(preFold, {
+      __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+      run_id: null,
+      strategy_id: 'sliding-window',
+      summary: 'the running recap',
+      replaced_message_count: 2,
+      summarizer_prompt_version: 'v1',
+      tokens_before: null,
+      tokens_after: 1234,
+    } as LlmContextCompactedEvent);
+
+    component.context$.next(folded as any[]);
+    fixture.detectChanges();
+
+    // The summary row renders, clearly labelled, with the prefix stripped.
+    expect(convHeaders(fixture)).toContain('Human : Summary');
+    expect(convBodies(fixture)).toContain('the running recap');
+    // The kept turn still renders as a normal user row.
+    expect(convHeaders(fixture)).toContain('Human : User');
+    expect(convBodies(fixture)).toContain('kept latest turn');
+
+    // The replaced prefix is GONE — neither dropped turn appears anywhere, and the
+    // raw summary marker is not shown to the user (stripped by the render touch).
+    const allText = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(allText).not.toContain('dropped earlier turn one');
+    expect(allText).not.toContain('dropped earlier turn two');
+    expect(allText).not.toContain(CONVERSATION_SUMMARY_PREFIX);
   });
 });

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -38,7 +38,10 @@ import {
   systemPromptLabel,
 } from '../../../selectors/system-prompt.selector';
 import { TokenUsageSelector } from '../../../selectors/token-usage.selector';
-import { AgentTokenUsage } from '../../../event/per-agent-specs';
+import {
+  AgentTokenUsage,
+  CONVERSATION_SUMMARY_PREFIX,
+} from '../../../event/per-agent-specs';
 import { CommandDescriptor } from '../../../../../protocol/message.types';
 
 import { CopyButtonComponent } from '../../../../../shared/components/copy-button/copy-button.component';
@@ -323,10 +326,20 @@ export class AkgentChatComponent implements OnInit, OnChanges {
           // the run-1 double-carry renders once. Only `user-prompt` is handled
           // here now; the system label/`dynamic_ref` logic moved to the selector.
           if (part.part_kind === 'user-prompt') {
+            // Epic 29 (ADR-010 §4): the per-agent `context` store folds a
+            // compaction by inserting a synthetic user-prompt prefixed
+            // `CONVERSATION_SUMMARY_PREFIX`. Surface it as a clearly-labelled
+            // "Summary" row (prefix stripped); every other user-prompt renders
+            // unchanged.
+            const isSummary =
+              typeof part.content === 'string' &&
+              part.content.startsWith(CONVERSATION_SUMMARY_PREFIX);
             msg.push({
               type: 'human',
-              name: 'User',
-              content: part.content,
+              name: isSummary ? 'Summary' : 'User',
+              content: isSummary
+                ? part.content.slice(CONVERSATION_SUMMARY_PREFIX.length)
+                : part.content,
               timestamp: part.timestamp,
             });
           } else if (part.part_kind === 'tool-call') {

--- a/src/app/components/process/components/chat/chat-message.component.html
+++ b/src/app/components/process/components/chat/chat-message.component.html
@@ -26,9 +26,37 @@
   }}</span>
 </div>
 
+<!-- Context-management markers (Epic 29 / ADR-010): rule 6 = collapsible
+     "Summarized N" compaction fold; rule 7 = inert "Conversation cleared" line.
+     No sender/recipient, no left/right alignment — not a chat bubble. -->
+<div *ngIf="isMarker()" class="system-marker">
+  <div
+    class="system-marker-line"
+    [class.expandable]="message().rule === 6"
+    (click)="onToggleMarker()"
+  >
+    <i class="pi system-marker-icon" [ngClass]="markerIcon()"></i>
+    <span class="system-marker-label">{{ message().label }}</span>
+    <i
+      *ngIf="message().rule === 6"
+      class="pi system-marker-caret"
+      [ngClass]="message().collapsed ? 'pi-chevron-right' : 'pi-chevron-down'"
+    ></i>
+    <span class="system-marker-timestamp">{{
+      message().timestamp | date : "HH:mm"
+    }}</span>
+  </div>
+  <div
+    *ngIf="message().rule === 6 && !message().collapsed"
+    class="system-marker-summary"
+  >
+    <markdown [data]="message().content"></markdown>
+  </div>
+</div>
+
 <!-- Expanded bubble (Rules 1/2, or Rule 3/4 expanded) -->
 <div
-  *ngIf="(message().rule !== 3 && message().rule !== 4) || !message().collapsed"
+  *ngIf="!isMarker() && ((message().rule !== 3 && message().rule !== 4) || !message().collapsed)"
   class="message"
   [class.right]="message().alignment === 'right'"
   [class.left]="message().alignment === 'left'"

--- a/src/app/components/process/components/chat/chat-message.component.scss
+++ b/src/app/components/process/components/chat/chat-message.component.scss
@@ -145,3 +145,68 @@
 .markdown-content {
   margin-top: 4px;
 }
+
+/* Context-management markers (Epic 29 / ADR-010) — inert, centered system rows.
+   Visually distinct from chat bubbles: muted, full-width, no alignment. */
+.system-marker {
+  width: 100%;
+}
+
+.system-marker-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 4px 10px;
+  color: #64748b;
+  font-size: 0.85rem;
+  font-style: italic;
+  border-radius: 6px;
+  border: 1px dashed rgba(100, 116, 139, 0.4);
+  background-color: rgba(100, 116, 139, 0.04);
+
+  &.expandable {
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgba(100, 116, 139, 0.08);
+    }
+  }
+}
+
+.system-marker-icon {
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.system-marker-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.system-marker-caret {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+.system-marker-timestamp {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* The expanded compaction summary can be long (~2k tokens) — bound the height
+   and scroll rather than letting it blow the trace height (story Open Q). */
+.system-marker-summary {
+  margin-top: 4px;
+  padding: 8px 12px;
+  max-height: 240px;
+  overflow-y: auto;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #334155;
+  border-left: 2px solid rgba(100, 116, 139, 0.3);
+  background-color: rgba(100, 116, 139, 0.03);
+}

--- a/src/app/components/process/components/chat/chat-message.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-message.component.spec.ts
@@ -801,4 +801,105 @@ describe('ChatMessageComponent', () => {
       expect(header.lastElementChild.classList.contains('bubble-timestamp')).toBe(true);
     });
   });
+
+  describe('Rule 6/7 context-management markers (Epic 29 / ADR-010)', () => {
+    function makeCompactionMarker(collapsed = true): ChatMessage {
+      return makeChatMessage({
+        id: 'evt-1',
+        rule: 6,
+        alignment: 'left',
+        color: '',
+        collapsed,
+        label: 'Summarized 8 messages',
+        content: 'the summary text body',
+      });
+    }
+
+    function makeClearMarker(): ChatMessage {
+      return makeChatMessage({
+        id: 'evt-2',
+        rule: 7,
+        alignment: 'left',
+        color: '',
+        collapsed: false,
+        label: 'Conversation cleared (5 messages)',
+        content: '',
+      });
+    }
+
+    it('compaction marker renders a .system-marker row with the count label + icon, not a bubble', () => {
+      fixture.componentRef.setInput('message', makeCompactionMarker());
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.system-marker')).toBeTruthy();
+      expect(el.querySelector('.system-marker-icon')).toBeTruthy();
+      expect(el.querySelector('.system-marker-label').textContent).toContain(
+        'Summarized 8 messages',
+      );
+      // A marker is NOT a chat bubble or a Rule 3/4 collapsed line.
+      expect(el.querySelector('.message-bubble')).toBeNull();
+      expect(el.querySelector('.collapsed-line')).toBeNull();
+    });
+
+    it('collapsed compaction marker hides the summary body but shows a caret', () => {
+      fixture.componentRef.setInput('message', makeCompactionMarker(true));
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.system-marker-summary')).toBeNull();
+      expect(el.querySelector('.system-marker-caret')).toBeTruthy();
+    });
+
+    it('expanded compaction marker reveals the summary body (markdown)', () => {
+      fixture.componentRef.setInput('message', makeCompactionMarker(false));
+      fixture.detectChanges();
+
+      const summary = fixture.nativeElement.querySelector('.system-marker-summary');
+      expect(summary).toBeTruthy();
+      expect(summary.querySelector('markdown')).toBeTruthy();
+    });
+
+    it('clicking the compaction line emits toggleCollapse', () => {
+      const msg = makeCompactionMarker(true);
+      fixture.componentRef.setInput('message', msg);
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      fixture.nativeElement.querySelector('.system-marker-line').click();
+      expect(component.toggleCollapse.emit).toHaveBeenCalledWith(msg);
+    });
+
+    it('clear marker renders the cleared line — no caret, no summary, no bubble', () => {
+      fixture.componentRef.setInput('message', makeClearMarker());
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.system-marker')).toBeTruthy();
+      expect(el.querySelector('.system-marker-label').textContent).toContain(
+        'Conversation cleared (5 messages)',
+      );
+      expect(el.querySelector('.system-marker-caret')).toBeNull();
+      expect(el.querySelector('.system-marker-summary')).toBeNull();
+      expect(el.querySelector('.message-bubble')).toBeNull();
+    });
+
+    it('clicking the clear marker line is inert — does NOT emit toggleCollapse', () => {
+      fixture.componentRef.setInput('message', makeClearMarker());
+      fixture.detectChanges();
+
+      spyOn(component.toggleCollapse, 'emit');
+      fixture.nativeElement.querySelector('.system-marker-line').click();
+      expect(component.toggleCollapse.emit).not.toHaveBeenCalled();
+    });
+
+    it('markers render no label-pill and no Reply button', () => {
+      fixture.componentRef.setInput('message', makeCompactionMarker());
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement;
+      expect(el.querySelector('.label-pill')).toBeNull();
+      expect(el.querySelector('.open-button')).toBeNull();
+    });
+  });
 });

--- a/src/app/components/process/components/chat/chat-message.component.ts
+++ b/src/app/components/process/components/chat/chat-message.component.ts
@@ -22,6 +22,27 @@ export class ChatMessageComponent {
 
   readonly preview = computed(() => buildPreview(this.message().content));
 
+  /** True for the synthetic context-management markers (Epic 29 / ADR-010):
+   *  rule 6 = compaction fold, rule 7 = clear line. */
+  readonly isMarker = computed(
+    () => this.message().rule === 6 || this.message().rule === 7,
+  );
+
+  /** Leading glyph for a marker row — stacked bars for a compaction fold, a
+   *  trash glyph for a conversation clear. */
+  readonly markerIcon = computed(() =>
+    this.message().rule === 6 ? 'pi-bars' : 'pi-trash',
+  );
+
+  /** Toggle the compaction summary fold. Only rule 6 collapses; the clear
+   *  marker (rule 7) is inert. Reuses the panel's `toggleCollapse` channel so
+   *  the expand state persists across the pure fold's re-emissions. */
+  onToggleMarker(): void {
+    if (this.message().rule === 6) {
+      this.toggleCollapse.emit(this.message());
+    }
+  }
+
   onToggleCollapse(): void {
     const msg = this.message();
     // Rule 5 (welcome) is behaviourally inert (ADR-011 Decision 3).

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -867,6 +867,54 @@ describe('ChatPanelComponent', () => {
     expect(component.chatMessages[0].collapsed).toBe(false);
   });
 
+  describe('Rule 6/7 marker collapse (Epic 29 / ADR-010)', () => {
+    function makeMarker(overrides: Partial<ChatMessage>): ChatMessage {
+      return {
+        id: 'evt-1',
+        message_id: 'evt-1',
+        parent_id: null,
+        content: 'summary body',
+        sender: makeAddress({ name: '@Researcher', role: 'Worker' }),
+        recipient: makeAddress({ name: '@Researcher', role: 'Worker' }),
+        timestamp: new Date('2026-06-28T10:00:00Z'),
+        rule: 6,
+        alignment: 'left',
+        color: '',
+        collapsed: true,
+        label: 'Summarized 8 messages',
+        ...overrides,
+      };
+    }
+
+    it('onToggleCollapse expands a Rule 6 marker and persists it across re-emission', () => {
+      const marker = makeMarker({});
+      component.onToggleCollapse(marker);
+      expect(marker.collapsed).toBe(false);
+
+      // The pure fold rebuilds the marker collapsed-by-default; onMessages must
+      // re-apply the expanded override (same expandedMessageIds mechanism as
+      // Rule 3/4).
+      const rebuilt = makeMarker({ collapsed: true });
+      (component as unknown as {
+        onMessages: (c: ChatMessage[], t: ThinkingState[]) => void;
+      }).onMessages([rebuilt], []);
+      expect(rebuilt.collapsed).toBe(false);
+    });
+
+    it('onToggleCollapse ignores the Rule 7 clear marker (inert — no flip)', () => {
+      const clear = makeMarker({
+        id: 'evt-2',
+        message_id: 'evt-2',
+        rule: 7,
+        collapsed: true,
+        content: '',
+        label: 'Conversation cleared (5 messages)',
+      });
+      component.onToggleCollapse(clear);
+      expect(clear.collapsed).toBe(true);
+    });
+  });
+
   describe('displayItems merge (Story 4-8)', () => {
     function getThinkingSubj(): BehaviorSubject<ThinkingState[]> {
       const svc = TestBed.inject(ChatService) as any;

--- a/src/app/components/process/components/chat/chat-panel.component.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.ts
@@ -203,10 +203,12 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
     const grew = classified.length > this.prevCount;
     this.prevCount = classified.length;
 
-    // Preserve per-user expand state across re-emissions (Rule 3 / Rule 4).
+    // Preserve per-user expand state across re-emissions (Rule 3 / Rule 4, plus
+    // the Rule 6 compaction marker — Epic 29). The pure fold rebuilds each
+    // ChatMessage collapsed-by-default, so the toggled-open set is re-applied.
     for (const chatMsg of classified) {
       if (
-        (chatMsg.rule === 3 || chatMsg.rule === 4) &&
+        (chatMsg.rule === 3 || chatMsg.rule === 4 || chatMsg.rule === 6) &&
         this.expandedMessageIds.has(chatMsg.id)
       ) {
         chatMsg.collapsed = false;
@@ -447,7 +449,8 @@ export class ChatPanelComponent implements OnInit, OnDestroy, AfterViewChecked {
   // ---------------------------------------------------------------------------
 
   onToggleCollapse(chatMsg: ChatMessage): void {
-    if (chatMsg.rule !== 3 && chatMsg.rule !== 4) return;
+    // Rule 6 = the compaction marker fold (Epic 29); rules 3/4 = chat bubbles.
+    if (chatMsg.rule !== 3 && chatMsg.rule !== 4 && chatMsg.rule !== 6) return;
     chatMsg.collapsed = !chatMsg.collapsed;
     if (chatMsg.collapsed) {
       this.expandedMessageIds.delete(chatMsg.id);

--- a/src/app/components/process/event/per-agent-specs.spec.ts
+++ b/src/app/components/process/event/per-agent-specs.spec.ts
@@ -1,13 +1,20 @@
 import { TestBed } from '@angular/core/testing';
 import { MessageService } from 'primeng/api';
 
-import { AkgenticMessage } from '../../../protocol/message.types';
+import {
+  AkgenticMessage,
+  LlmContextCompactedEvent,
+} from '../../../protocol/message.types';
 import { ApiService } from '../../../core/http/api.service';
 import { IngestionService } from './ingestion.service';
 import { MessageLogService } from './message-log.service';
 import { PerAgentStore, PerAgentStoreRegistry } from './per-agent-store';
 import {
   AgentTokenUsage,
+  contextMatch,
+  contextReduce,
+  CONVERSATION_SUMMARY_PREFIX,
+  foldContextCompaction,
   tokenUsageReduce,
   tokenUsageSpec,
 } from './per-agent-specs';
@@ -79,6 +86,99 @@ function makeUnrelatedEnvelope(id: string): AkgenticMessage {
     content: null,
     __model__: 'akgentic.core.messages.orchestrator.EventMessage',
     event: { __model__: 'akgentic.llm.event.LlmSystemPromptEvent' },
+  } as unknown as AkgenticMessage;
+}
+
+// ---------------------------------------------------------------------
+// Fixtures — context-store fold (Epic 29 / ADR-010 §4/§8): LlmMessageEvent
+// (append source), LlmContextCompactedEvent (fold), LlmContextClearedEvent
+// (reset), plus the ModelMessage-shaped entries the fold operates on.
+// ---------------------------------------------------------------------
+
+/** A non-system ModelRequest-shaped context entry (one user-prompt part). */
+function userEntry(text: string): unknown {
+  return { kind: 'request', parts: [{ part_kind: 'user-prompt', content: text }] };
+}
+
+/** A system ModelRequest-shaped context entry (one system-prompt part) — the
+ *  fold exempts these (mirrors backend `_is_system_message`). */
+function systemEntry(text: string): unknown {
+  return {
+    kind: 'request',
+    parts: [{ part_kind: 'system-prompt', dynamic_ref: null, content: text }],
+  };
+}
+
+/** EventMessage envelope carrying an LlmMessageEvent whose inner `message` is
+ *  the given ModelMessage-shaped entry (appended verbatim to the context store). */
+function makeMessageEnvelope(agentId: string, message: unknown): AkgenticMessage {
+  return {
+    id: 'msg-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: { __model__: 'akgentic.llm.event.LlmMessageEvent', message },
+  } as unknown as AkgenticMessage;
+}
+
+interface CompactionFields {
+  summary: string;
+  replaced_message_count: number;
+  tokens_after?: number | null;
+}
+
+/** The inner LlmContextCompactedEvent payload (ADR-010 §3 wire JSON). */
+function compactionEvent(f: CompactionFields): LlmContextCompactedEvent {
+  return {
+    __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+    run_id: null,
+    strategy_id: 'sliding-window',
+    summary: f.summary,
+    replaced_message_count: f.replaced_message_count,
+    summarizer_prompt_version: 'v1',
+    tokens_before: null,
+    tokens_after: f.tokens_after ?? null,
+  };
+}
+
+/** EventMessage envelope carrying an LlmContextCompactedEvent for `agentId`. */
+function makeCompactionEnvelope(
+  agentId: string,
+  f: CompactionFields,
+): AkgenticMessage {
+  return {
+    id: 'compact-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: compactionEvent(f),
+  } as unknown as AkgenticMessage;
+}
+
+/** EventMessage envelope carrying an LlmContextClearedEvent for `agentId`. */
+function makeClearEnvelope(agentId: string, clearedCount = 0): AkgenticMessage {
+  return {
+    id: 'clear-' + agentId + '-' + envCounter++,
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: new Date().toISOString(),
+    sender: sender(agentId),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: {
+      __model__: 'akgentic.llm.event.LlmContextClearedEvent',
+      run_id: null,
+      cleared_message_count: clearedCount,
+    },
   } as unknown as AkgenticMessage;
 }
 
@@ -288,6 +388,300 @@ describe('tokenUsageReduce (pure reducer)', () => {
         lastContextWindow: 0,
         totalSent: 0,
         totalReceived: 0,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Epic 29 (ADR-010 §4/§8) — context store: fold compaction/clear.
+// ---------------------------------------------------------------------
+
+describe('contextMatch (Epic 29 / ADR-010 §4/§8)', () => {
+  it('AC #1 admits LlmMessageEvent, LlmContextCompactedEvent, and LlmContextClearedEvent', () => {
+    expect(contextMatch(makeMessageEnvelope('A', userEntry('u')))).toBeTrue();
+    expect(
+      contextMatch(
+        makeCompactionEnvelope('A', { summary: 's', replaced_message_count: 1 }),
+      ),
+    ).toBeTrue();
+    expect(contextMatch(makeClearEnvelope('A', 2))).toBeTrue();
+  });
+
+  it('AC #1 rejects unrelated inner events (LlmUsageEvent / LlmSystemPromptEvent)', () => {
+    expect(
+      contextMatch(makeUsageEnvelope('A', { input_tokens: 1, output_tokens: 1 })),
+    ).toBeFalse();
+    expect(contextMatch(makeUnrelatedEnvelope('u1'))).toBeFalse();
+  });
+});
+
+describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)', () => {
+  function ctx(service: IngestionService, agentId: string): unknown[] | undefined {
+    return service.context.snapshot(agentId);
+  }
+
+  it('AC #2 append parity: a pure LlmMessageEvent sequence appends inner messages in order', () => {
+    const { log, service } = configureBed();
+    const m1 = userEntry('one');
+    const m2 = userEntry('two');
+    log.appendAll([makeMessageEnvelope('A', m1), makeMessageEnvelope('A', m2)]);
+    expect(ctx(service, 'A')).toEqual([m1, m2]);
+  });
+
+  it('AC #2 returns a FRESH array reference on each append (OnPush safety)', () => {
+    const { log, service } = configureBed();
+    log.append(makeMessageEnvelope('A', userEntry('u1')));
+    const first = ctx(service, 'A');
+    log.append(makeMessageEnvelope('A', userEntry('u2')));
+    expect(first).not.toBe(ctx(service, 'A'));
+  });
+
+  it('AC #3 compaction drops the first replaced_message_count NON-system entries and inserts ONE summary at the fold point', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeMessageEnvelope('A', systemEntry('SYS')),
+      makeMessageEnvelope('A', userEntry('u1')),
+      makeMessageEnvelope('A', userEntry('u2')),
+      makeMessageEnvelope('A', userEntry('u3')),
+      makeCompactionEnvelope('A', { summary: 'recap', replaced_message_count: 2 }),
+    ]);
+    const result = ctx(service, 'A') as any[];
+    // Leading system entry exempt; u1 + u2 replaced by exactly one summary; u3 kept.
+    expect(result.length).toBe(3);
+    expect(result[0]).toEqual(systemEntry('SYS'));
+    expect(result[1].parts[0].part_kind).toBe('user-prompt');
+    expect(result[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'recap');
+    expect(result[2]).toEqual(userEntry('u3'));
+  });
+
+  it('AC #3 a system entry interleaved in the dropped prefix is preserved (never counted/folded)', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeMessageEnvelope('A', userEntry('u1')),
+      makeMessageEnvelope('A', systemEntry('SYS')),
+      makeMessageEnvelope('A', userEntry('u2')),
+      makeMessageEnvelope('A', userEntry('u3')),
+      makeCompactionEnvelope('A', { summary: 's', replaced_message_count: 2 }),
+    ]);
+    const result = ctx(service, 'A') as any[];
+    // u1 dropped (summary inserted at the head), SYS exempt, u2 dropped, u3 kept.
+    expect(result.length).toBe(3);
+    expect(result[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 's');
+    expect(result[1]).toEqual(systemEntry('SYS'));
+    expect(result[2]).toEqual(userEntry('u3'));
+  });
+
+  it('AC #5 clear empties the per-agent array; subsequent messages rebuild it', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeMessageEnvelope('A', userEntry('u1')),
+      makeMessageEnvelope('A', userEntry('u2')),
+      makeClearEnvelope('A', 2),
+    ]);
+    expect(ctx(service, 'A')).toEqual([]);
+    log.append(makeMessageEnvelope('A', userEntry('fresh')));
+    expect(ctx(service, 'A')).toEqual([userEntry('fresh')]);
+  });
+
+  it('AC #6 two sequential compactions compose (the first summary is itself foldable); no double-apply', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeMessageEnvelope('A', userEntry('u1')),
+      makeMessageEnvelope('A', userEntry('u2')),
+      makeMessageEnvelope('A', userEntry('u3')),
+      makeCompactionEnvelope('A', { summary: 'first', replaced_message_count: 2 }),
+      // After fold 1: [summary(first), u3]. Fold 2 (count 2) replaces BOTH.
+      makeCompactionEnvelope('A', { summary: 'second', replaced_message_count: 2 }),
+    ]);
+    const result = ctx(service, 'A') as any[];
+    expect(result.length).toBe(1);
+    expect(result[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'second');
+  });
+
+  it('AC #6 ordered-fold parity: batch appendAll equals per-message append', () => {
+    const events = (): AkgenticMessage[] => [
+      makeMessageEnvelope('A', systemEntry('SYS')),
+      makeMessageEnvelope('A', userEntry('u1')),
+      makeMessageEnvelope('A', userEntry('u2')),
+      makeCompactionEnvelope('A', { summary: 'r', replaced_message_count: 1 }),
+      makeMessageEnvelope('A', userEntry('u3')),
+    ];
+    const batch = configureBed();
+    batch.log.appendAll(events());
+    const batchResult = ctx(batch.service, 'A');
+
+    const ws = configureBed();
+    for (const e of events()) ws.log.append(e);
+    expect(ctx(ws.service, 'A')).toEqual(batchResult);
+  });
+});
+
+describe('foldContextCompaction (pure)', () => {
+  it('replaced_message_count <= 0 is a no-op (returns the SAME input array)', () => {
+    const msgs = [userEntry('a'), userEntry('b')];
+    expect(
+      foldContextCompaction(
+        msgs,
+        compactionEvent({ summary: 's', replaced_message_count: 0 }),
+      ),
+    ).toBe(msgs);
+  });
+
+  it('returns a FRESH array on a real fold; the summary carries the prefixed content', () => {
+    const msgs = [userEntry('a'), userEntry('b')];
+    const out = foldContextCompaction(
+      msgs,
+      compactionEvent({ summary: 'recap', replaced_message_count: 1 }),
+    ) as any[];
+    expect(out).not.toBe(msgs);
+    expect(out.length).toBe(2); // summary + b
+    expect(out[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'recap');
+    expect(out[1]).toEqual(userEntry('b'));
+  });
+
+  it('contextReduce passes a non-event message through unchanged (defensive)', () => {
+    const prev = [userEntry('keep')];
+    expect(contextReduce(prev, makeUnrelatedEnvelope('x'))).toBe(prev);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Epic 29 (ADR-010 §4/§8) — tokenUsage store: re-point the context window
+// on compaction/clear while leaving cumulative totals + labels untouched.
+// ---------------------------------------------------------------------
+
+describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)', () => {
+  const PREV: AgentTokenUsage = {
+    lastContextWindow: 30_000,
+    lastRunId: 'run-9',
+    lastModelName: 'claude-opus',
+    totalSent: 50_000,
+    totalReceived: 12_000,
+  };
+
+  it('AC #7 compaction sets lastContextWindow = tokens_after, leaving totals + labels untouched', () => {
+    const next = tokenUsageReduce(
+      PREV,
+      makeCompactionEnvelope('A', {
+        summary: 's',
+        replaced_message_count: 3,
+        tokens_after: 8_000,
+      }),
+    );
+    expect(next).toEqual({
+      lastContextWindow: 8_000,
+      lastRunId: 'run-9',
+      lastModelName: 'claude-opus',
+      totalSent: 50_000,
+      totalReceived: 12_000,
+    });
+  });
+
+  it('AC #7 compaction with null/absent tokens_after leaves the window unchanged (prev passthrough, no NaN)', () => {
+    const next = tokenUsageReduce(
+      PREV,
+      makeCompactionEnvelope('A', { summary: 's', replaced_message_count: 3 }),
+    );
+    expect(next).toBe(PREV);
+  });
+
+  it('AC #7 compaction before any usage seeds from zero (window only, totals stay 0)', () => {
+    const next = tokenUsageReduce(
+      undefined,
+      makeCompactionEnvelope('A', {
+        summary: 's',
+        replaced_message_count: 1,
+        tokens_after: 1_234,
+      }),
+    );
+    expect(next).toEqual({
+      lastContextWindow: 1_234,
+      lastRunId: '',
+      lastModelName: '',
+      totalSent: 0,
+      totalReceived: 0,
+    });
+  });
+
+  it('AC #8 clear resets lastContextWindow to 0, keeping totals + labels', () => {
+    const next = tokenUsageReduce(PREV, makeClearEnvelope('A', 5));
+    expect(next).toEqual({
+      lastContextWindow: 0,
+      lastRunId: 'run-9',
+      lastModelName: 'claude-opus',
+      totalSent: 50_000,
+      totalReceived: 12_000,
+    });
+  });
+});
+
+describe('tokenUsageSpec — context events via the real registry (Epic 29)', () => {
+  it('AC #9 the next LlmUsageEvent after a compaction overrides the estimate with the real provider count', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', {
+        run_id: 'r1',
+        input_tokens: 30_000,
+        output_tokens: 9_000,
+      }),
+      makeCompactionEnvelope('A', {
+        summary: 's',
+        replaced_message_count: 2,
+        tokens_after: 6_000,
+      }),
+    ]);
+    // Compaction re-points the window; totals + labels unchanged (not a run).
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 6_000,
+      lastRunId: 'r1',
+      lastModelName: 'claude-sonnet',
+      totalSent: 30_000,
+      totalReceived: 9_000,
+    });
+    // The next real usage overrides the window AND accumulates totals.
+    log.append(
+      makeUsageEnvelope('A', {
+        run_id: 'r2',
+        input_tokens: 6_500,
+        output_tokens: 800,
+      }),
+    );
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 6_500,
+      lastRunId: 'r2',
+      lastModelName: 'claude-sonnet',
+      totalSent: 36_500,
+      totalReceived: 9_800,
+    });
+  });
+
+  it('AC #8 clear via the real registry zeroes the window and keeps the cumulative totals', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', { input_tokens: 12_000, output_tokens: 3_000 }),
+      makeClearEnvelope('A', 4),
+    ]);
+    expect(usage(service.tokenUsage, 'A')).toEqual(
+      jasmine.objectContaining({
+        lastContextWindow: 0,
+        totalSent: 12_000,
+        totalReceived: 3_000,
+      }),
+    );
+  });
+
+  it('AC #7 compaction with null tokens_after does NOT disturb the existing window via the registry', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', { input_tokens: 20_000, output_tokens: 4_000 }),
+      makeCompactionEnvelope('A', { summary: 's', replaced_message_count: 1 }),
+    ]);
+    expect(usage(service.tokenUsage, 'A')).toEqual(
+      jasmine.objectContaining({
+        lastContextWindow: 20_000, // unchanged — defensive no-op
+        totalSent: 20_000,
+        totalReceived: 4_000,
       }),
     );
   });

--- a/src/app/components/process/event/per-agent-specs.ts
+++ b/src/app/components/process/event/per-agent-specs.ts
@@ -5,15 +5,17 @@ import {
   EventMessage,
   isCommandsAnnouncedEvent,
   isEventMessage,
+  isLlmContextClearedEvent,
+  isLlmContextCompactedEvent,
   isLlmSystemPromptEvent,
   isLlmUsageEvent,
   isStateChangedMessage,
+  LlmContextCompactedEvent,
   LlmUsageEvent,
   StateChangedMessage,
   SystemPromptPartSnapshot,
 } from '../../../protocol/message.types';
 import {
-  appendWith,
   PerAgentSpec,
   replaceWith,
 } from './per-agent-store';
@@ -260,16 +262,145 @@ export const stateSpec: PerAgentSpec<AgentStateValue> = {
 };
 
 /**
- * Epic 17 (ADR-014 §5): per-agent ordered conversation array derived by
- * appending each `LlmMessageEvent` envelope's inner `message`. Replaces the
- * bespoke `contextDict$`. Default key `sender.agent_id`; the append is
- * O(Δ)/frame (the registry walks only `log.slice(processedCount)` and
- * `appendWith` concats once per new message). Read via `context.forAgent(id)`.
+ * Marker prefix the backend's synthetic compaction summary carries on its single
+ * `UserPromptPart` (`ContextManager.fold_compaction`, ADR-010 §4). The member
+ * trace prepends the same prefix so `AkgentChatComponent` can label the
+ * folded-in row as a summary rather than a plain user turn.
+ */
+export const CONVERSATION_SUMMARY_PREFIX = '[Conversation summary] ';
+
+/**
+ * True when a context entry is a "system" message — one whose `parts` include a
+ * `part_kind === 'system-prompt'` part. Mirrors the backend `_is_system_message`
+ * exemption (and `llmMessageSystemParts` above): system entries are NEVER folded
+ * by a compaction, exactly like the sliding window. Defensive: a missing or
+ * non-array `parts` is treated as non-system.
+ */
+function isContextSystemEntry(entry: unknown): boolean {
+  const parts = (entry as { parts?: unknown } | null | undefined)?.parts;
+  return (
+    Array.isArray(parts) &&
+    parts.some(
+      (p) => (p as { part_kind?: string } | null)?.part_kind === 'system-prompt',
+    )
+  );
+}
+
+/**
+ * Build the synthetic summary entry inserted at a compaction's fold point: a
+ * `ModelRequest`-shaped object with one `user-prompt` part prefixed
+ * `CONVERSATION_SUMMARY_PREFIX`, mirroring the backend synthetic `ModelRequest` /
+ * `UserPromptPart`. The shape matches what `AkgentChatComponent.updateContext`
+ * already renders for a user-prompt part.
+ */
+function buildSummaryEntry(summary: string): unknown {
+  return {
+    kind: 'request',
+    parts: [
+      {
+        part_kind: 'user-prompt',
+        content: `${CONVERSATION_SUMMARY_PREFIX}${summary}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Fold `messages` per a compaction event, mirroring `ContextManager.fold_compaction`
+ * (ADR-010 §4): drop the first `replaced_message_count` NON-system entries and
+ * insert ONE synthetic summary entry at the fold point; system entries are never
+ * dropped. Returns a FRESH array on a real fold (OnPush); a non-positive
+ * `replaced_message_count` is a no-op (returns the input unchanged). The backend's
+ * trailing `_drop_orphan_tool_results` (an OpenAI role=tool adjacency guard for
+ * the NEXT provider request) is intentionally not mirrored — it does not affect
+ * what the member trace displays.
+ */
+export function foldContextCompaction(
+  messages: unknown[],
+  event: LlmContextCompactedEvent,
+): unknown[] {
+  if (event.replaced_message_count <= 0) return messages;
+  const summary = buildSummaryEntry(event.summary ?? '');
+  const folded: unknown[] = [];
+  let remaining = event.replaced_message_count;
+  let inserted = false;
+  for (const entry of messages) {
+    if (isContextSystemEntry(entry)) {
+      folded.push(entry);
+      continue;
+    }
+    if (remaining > 0) {
+      remaining -= 1;
+      if (!inserted) {
+        folded.push(summary);
+        inserted = true;
+      }
+      continue;
+    }
+    folded.push(entry);
+  }
+  return folded;
+}
+
+/**
+ * `match` for the `context` spec: admit an `EventMessage` whose inner is a
+ * `LlmMessageEvent` (the append source) OR a `LlmContextCompactedEvent` (fold)
+ * OR a `LlmContextClearedEvent` (reset). The reducer — not `match` — decides
+ * which transition applies; anything else passes through.
+ */
+export function contextMatch(msg: AkgenticMessage): boolean {
+  if (!isEventMessage(msg)) return false;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string }
+    | undefined;
+  return (
+    innerLlmMessage(msg) !== undefined ||
+    isLlmContextCompactedEvent(inner) ||
+    isLlmContextClearedEvent(inner)
+  );
+}
+
+/**
+ * Incremental per-message reducer for the `context` store — the client-side
+ * ordered fold of the same event log the backend folds (`ContextManager`):
+ *   - `LlmMessageEvent`          → append the inner `message` (fresh array).
+ *   - `LlmContextCompactedEvent` → `foldContextCompaction` (drop prefix + insert
+ *                                  summary), mirroring `compact` (ADR-010 §4).
+ *   - `LlmContextClearedEvent`   → reset to `[]`, mirroring `clear_context` (§8).
+ *   - anything else              → passthrough `prev`.
+ * The synthetic summary is derivable from the event (the backend emits no
+ * `LlmMessageEvent` for it), so folding the event never double-applies (§4).
+ */
+export function contextReduce(
+  prev: unknown[] | undefined,
+  msg: AkgenticMessage,
+): unknown[] | undefined {
+  if (!isEventMessage(msg)) return prev;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string }
+    | undefined;
+  if (isLlmContextClearedEvent(inner)) return [];
+  if (isLlmContextCompactedEvent(inner)) {
+    return foldContextCompaction(prev ?? [], inner);
+  }
+  const message = innerLlmMessage(msg);
+  if (message !== undefined) return [...(prev ?? []), message];
+  return prev;
+}
+
+/**
+ * Epic 17 (ADR-014 §5) + Epic 29 (ADR-010 §4/§8): per-agent ordered conversation
+ * array. Appends each `LlmMessageEvent`'s inner `message`, FOLDS on
+ * `LlmContextCompactedEvent`, and RESETS on `LlmContextClearedEvent` — so the
+ * Member trace reflects the agent's actual post-compaction state, not the stale
+ * pre-compaction history. Custom `contextMatch`/`contextReduce` (no stock factory
+ * fits the three-way fold). Default key `sender.agent_id`; O(Δ)/frame; fresh
+ * value on real change. Read via `context.forAgent(id)`.
  */
 export const contextSpec: PerAgentSpec<unknown[]> = {
   name: 'context',
-  match: (m) => isEventMessage(m) && innerLlmMessage(m) !== undefined,
-  reduce: appendWith((m) => innerLlmMessage(m)),
+  match: contextMatch,
+  reduce: contextReduce,
 };
 
 /**
@@ -346,43 +477,92 @@ function innerLlmUsage(msg: AkgenticMessage): LlmUsageEvent | undefined {
   return isLlmUsageEvent(inner) ? inner : undefined;
 }
 
+/** Zero seed for an agent's token-usage value, used when a compaction/clear
+ *  event re-points the context window before any `LlmUsageEvent` has been folded
+ *  (ADR-022 §Decision 2). Only ever spread, never mutated — a shared constant is
+ *  safe. */
+const ZERO_TOKEN_USAGE: AgentTokenUsage = {
+  lastContextWindow: 0,
+  lastRunId: '',
+  lastModelName: '',
+  totalSent: 0,
+  totalReceived: 0,
+};
+
 /**
  * Incremental per-message reducer (the store's `(prev, msg) => next` contract,
- * ADR-022 §Decision 2). NOT a stock factory: it BOTH accumulates (sums
- * sent/received) AND overwrites (context window + labels) per event. The first
- * event seeds from `prev ?? zero`; every event returns a FRESH object (OnPush
- * safety). A non-usage message passes `prev` through unchanged (the spec's
- * `match` already gates these out, but the reducer stays defensive). Numeric
- * reads coalesce a missing/malformed field to `0` so a partial event never
- * yields `NaN` totals.
+ * ADR-022 §Decision 2). NOT a stock factory:
+ *   - `LlmUsageEvent` → accumulate (sum sent/received) AND overwrite (context
+ *     window + labels); numeric reads coalesce a missing field to `0` (no NaN).
+ *   - `LlmContextCompactedEvent` (Epic 29 / ADR-010 §4) → re-point
+ *     `lastContextWindow` to `event.tokens_after` when it is a number; leave it
+ *     unchanged when `tokens_after` is null/absent (defensive — no NaN, no reset).
+ *   - `LlmContextClearedEvent` (§8) → reset `lastContextWindow` to `0`.
+ * The two context events leave the cumulative I/O totals and run labels untouched
+ * (neither is a model run) and seed from `prev ?? zero`. Every change returns a
+ * FRESH object (OnPush safety); any other message passes `prev` through.
  */
 export function tokenUsageReduce(
   prev: AgentTokenUsage | undefined,
   msg: AkgenticMessage,
 ): AgentTokenUsage | undefined {
   const ev = innerLlmUsage(msg);
-  if (ev === undefined) return prev;
-  const input = ev.input_tokens ?? 0;
-  const output = ev.output_tokens ?? 0;
-  return {
-    lastContextWindow: input,
-    lastRunId: ev.run_id,
-    lastModelName: ev.model_name,
-    totalSent: (prev?.totalSent ?? 0) + input,
-    totalReceived: (prev?.totalReceived ?? 0) + output,
-  };
+  if (ev !== undefined) {
+    const input = ev.input_tokens ?? 0;
+    const output = ev.output_tokens ?? 0;
+    return {
+      lastContextWindow: input,
+      lastRunId: ev.run_id,
+      lastModelName: ev.model_name,
+      totalSent: (prev?.totalSent ?? 0) + input,
+      totalReceived: (prev?.totalReceived ?? 0) + output,
+    };
+  }
+  if (!isEventMessage(msg)) return prev;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string }
+    | undefined;
+  if (isLlmContextCompactedEvent(inner)) {
+    return typeof inner.tokens_after === 'number'
+      ? { ...(prev ?? ZERO_TOKEN_USAGE), lastContextWindow: inner.tokens_after }
+      : prev;
+  }
+  if (isLlmContextClearedEvent(inner)) {
+    return { ...(prev ?? ZERO_TOKEN_USAGE), lastContextWindow: 0 };
+  }
+  return prev;
 }
 
 /**
- * Epic 26 (ADR-022 §Decision 2): per-agent token-usage store derived from
- * `LlmUsageEvent` riding the `EventMessage` passthrough. Default key
- * `sender.agent_id` (the agent that ran the model). The custom
- * `tokenUsageReduce` both accumulates and overwrites, so no stock factory fits.
- * Read via `tokenUsage.forAgent(id)` / `tokenUsage.all$`; the team total is a
- * pure derivation over `all$` (TokenUsageSelector), never a separate aggregate.
+ * `match` for the `tokenUsage` spec: admit an `EventMessage` whose inner is a
+ * `LlmUsageEvent` (accumulate + overwrite) OR a `LlmContextCompactedEvent` /
+ * `LlmContextClearedEvent` (Epic 29 — re-point the live context-window estimate).
+ * The reducer decides the transition; any other message passes through.
+ */
+export function tokenUsageMatch(msg: AkgenticMessage): boolean {
+  if (!isEventMessage(msg)) return false;
+  const inner = (msg as EventMessage).event as
+    | { __model__?: string }
+    | undefined;
+  return (
+    isLlmUsageEvent(inner) ||
+    isLlmContextCompactedEvent(inner) ||
+    isLlmContextClearedEvent(inner)
+  );
+}
+
+/**
+ * Epic 26 (ADR-022 §Decision 2) + Epic 29 (ADR-010 §4/§8): per-agent token-usage
+ * store derived from `LlmUsageEvent` (accumulate + overwrite) plus the two
+ * context events (`tokenUsageMatch`), which re-point the live context-window
+ * estimate after a `/compact` or `/clear`. Default key `sender.agent_id` (the
+ * agent that ran the model). The custom `tokenUsageReduce` both accumulates and
+ * overwrites, so no stock factory fits. Read via `tokenUsage.forAgent(id)` /
+ * `tokenUsage.all$`; the team total is a pure derivation over `all$`
+ * (TokenUsageSelector), never a separate aggregate.
  */
 export const tokenUsageSpec: PerAgentSpec<AgentTokenUsage> = {
   name: 'tokenUsage',
-  match: (m) => isEventMessage(m) && isLlmUsageEvent((m as EventMessage).event),
+  match: tokenUsageMatch,
   reduce: tokenUsageReduce,
 };

--- a/src/app/components/process/selectors/chat-message.model.spec.ts
+++ b/src/app/components/process/selectors/chat-message.model.spec.ts
@@ -1,13 +1,24 @@
 import {
+  buildClearMarker,
+  buildCompactionMarker,
   buildPreview,
   classifyRule,
   buildLabel,
   classifyMessage,
+  CLEAR_MARKER_RULE,
+  COMPACTION_MARKER_RULE,
   ENTRY_POINT_NAME,
   ChatMessage,
   SYSTEM_MESSAGE_LABEL,
 } from './chat-message.model';
-import { ActorAddress, SentMessage, BaseMessage } from '../../../protocol/message.types';
+import {
+  ActorAddress,
+  BaseMessage,
+  EventMessage,
+  LlmContextClearedEvent,
+  LlmContextCompactedEvent,
+  SentMessage,
+} from '../../../protocol/message.types';
 
 function makeAddress(overrides: Partial<ActorAddress> = {}): ActorAddress {
   return {
@@ -478,5 +489,121 @@ describe('classifyMessage', () => {
       }),
     );
     expect(result.sender.name).toBe('@Manager');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Context-management marker builders (Epic 29 / ADR-010)
+// ---------------------------------------------------------------------------
+
+function makeEventMessage(inner: unknown): EventMessage {
+  return {
+    id: 'evt-1',
+    parent_id: null,
+    team_id: 'team-1',
+    timestamp: '2026-06-28T10:15:00Z',
+    sender: makeAddress({ name: '@Researcher', role: 'Worker', agent_id: 'agent-7' }),
+    display_type: 'other',
+    content: null,
+    __model__: 'akgentic.core.messages.orchestrator.EventMessage',
+    event: inner,
+  };
+}
+
+function makeCompacted(
+  overrides: Partial<LlmContextCompactedEvent> = {},
+): LlmContextCompactedEvent {
+  return {
+    __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+    run_id: 'run-1',
+    strategy_id: 'summarize',
+    summary: 'The team agreed on the API contract and split the work.',
+    replaced_message_count: 8,
+    summarizer_prompt_version: 'v1',
+    tokens_before: 12000,
+    tokens_after: 3000,
+    ...overrides,
+  };
+}
+
+function makeCleared(
+  overrides: Partial<LlmContextClearedEvent> = {},
+): LlmContextClearedEvent {
+  return {
+    __model__: 'akgentic.llm.event.LlmContextClearedEvent',
+    run_id: 'run-2',
+    cleared_message_count: 5,
+    ...overrides,
+  };
+}
+
+describe('buildCompactionMarker (Rule 6)', () => {
+  it('produces a collapsed marker carrying the count headline and summary body', () => {
+    const inner = makeCompacted();
+    const marker = buildCompactionMarker(makeEventMessage(inner), inner);
+
+    expect(marker.rule).toBe(COMPACTION_MARKER_RULE);
+    expect(marker.collapsed).toBe(true);
+    expect(marker.label).toBe('Summarized 8 messages');
+    // The expandable body holds the summary text.
+    expect(marker.content).toBe(inner.summary);
+    expect(marker.alignment).toBe('left');
+  });
+
+  it('pluralises the count: 1 → singular "message"', () => {
+    const inner = makeCompacted({ replaced_message_count: 1 });
+    const marker = buildCompactionMarker(makeEventMessage(inner), inner);
+    expect(marker.label).toBe('Summarized 1 message');
+  });
+
+  it('carries the event envelope id and timestamp (chronological identity)', () => {
+    const inner = makeCompacted();
+    const evt = makeEventMessage(inner);
+    const marker = buildCompactionMarker(evt, inner);
+    expect(marker.id).toBe('evt-1');
+    expect(marker.message_id).toBe('evt-1');
+    expect(marker.timestamp.getTime()).toBe(new Date(evt.timestamp).getTime());
+  });
+
+  it('is inert: parent_id null and sender/recipient are non-Human (no notification)', () => {
+    const inner = makeCompacted();
+    const marker = buildCompactionMarker(makeEventMessage(inner), inner);
+    expect(marker.parent_id).toBeNull();
+    expect(marker.recipient.role).not.toBe('Human');
+    expect(marker.sender.role).not.toBe('Human');
+  });
+
+  it('tolerates an empty summary string', () => {
+    const inner = makeCompacted({ summary: '' });
+    const marker = buildCompactionMarker(makeEventMessage(inner), inner);
+    expect(marker.content).toBe('');
+    expect(marker.label).toBe('Summarized 8 messages');
+  });
+});
+
+describe('buildClearMarker (Rule 7)', () => {
+  it('produces a non-collapsible marker with the cleared headline and no summary', () => {
+    const inner = makeCleared();
+    const marker = buildClearMarker(makeEventMessage(inner), inner);
+
+    expect(marker.rule).toBe(CLEAR_MARKER_RULE);
+    expect(marker.collapsed).toBe(false);
+    expect(marker.label).toBe('Conversation cleared (5 messages)');
+    expect(marker.content).toBe('');
+  });
+
+  it('pluralises the cleared count: 1 → singular "message"', () => {
+    const inner = makeCleared({ cleared_message_count: 1 });
+    const marker = buildClearMarker(makeEventMessage(inner), inner);
+    expect(marker.label).toBe('Conversation cleared (1 message)');
+  });
+
+  it('carries the event envelope id/timestamp and is inert (parent_id null)', () => {
+    const inner = makeCleared();
+    const evt = makeEventMessage(inner);
+    const marker = buildClearMarker(evt, inner);
+    expect(marker.id).toBe('evt-1');
+    expect(marker.parent_id).toBeNull();
+    expect(marker.timestamp.getTime()).toBe(new Date(evt.timestamp).getTime());
   });
 });

--- a/src/app/components/process/selectors/chat-message.model.ts
+++ b/src/app/components/process/selectors/chat-message.model.ts
@@ -1,6 +1,9 @@
 import {
   ActorAddress,
+  EventMessage,
   isWelcomeAnnouncement,
+  LlmContextClearedEvent,
+  LlmContextCompactedEvent,
   SentMessage,
 } from '../../../protocol/message.types';
 import { makeAgentNameUserFriendly } from '../../../shared/util/util';
@@ -12,7 +15,17 @@ export const ENTRY_POINT_NAME = '@Human';
  *  (ADR-011 Decision 3, AC6). */
 export const SYSTEM_MESSAGE_LABEL = 'System message';
 
-export type MessageRule = 1 | 2 | 3 | 4 | 5;
+/** Rules 1-5 are conversational chat bubbles classified from a `SentMessage`. */
+export type ChatBubbleRule = 1 | 2 | 3 | 4 | 5;
+/** Rules 6-7 are synthetic, inert context-management markers (Epic 29 /
+ *  ADR-010): 6 = compaction (a collapsible "Summarized N" fold), 7 = clear
+ *  (a non-collapsible "Conversation cleared" line). Markers carry no real
+ *  sender/recipient and are not aligned bubbles. */
+export type MarkerRule = 6 | 7;
+export type MessageRule = ChatBubbleRule | MarkerRule;
+
+export const COMPACTION_MARKER_RULE: MarkerRule = 6;
+export const CLEAR_MARKER_RULE: MarkerRule = 7;
 
 export interface ChatMessage {
   /** Outer `SentMessage` envelope id — used to route human replies back to
@@ -48,7 +61,7 @@ export interface ChatMessage {
  * `recipient` is `@Human`, so without the first-match it would classify as
  * Rule 2 and expose the `@ActorSystem` transport envelope.
  */
-export function classifyRule(msg: SentMessage): MessageRule {
+export function classifyRule(msg: SentMessage): ChatBubbleRule {
   if (isWelcomeAnnouncement(msg)) return 5;
   if (msg.sender.name === ENTRY_POINT_NAME) return 1;
   if (msg.recipient.name === ENTRY_POINT_NAME) return 2;
@@ -64,7 +77,7 @@ export function classifyRule(msg: SentMessage): MessageRule {
  *   Rule 4: "@{sender} ⇒ @{recipient}"
  *   Rule 5: fixed `SYSTEM_MESSAGE_LABEL` (ADR-011 Decision 3) — not conversational
  */
-export function buildLabel(msg: SentMessage, rule: MessageRule): string {
+export function buildLabel(msg: SentMessage, rule: ChatBubbleRule): string {
   const senderName = makeAgentNameUserFriendly(msg.sender.name);
   const recipientName = makeAgentNameUserFriendly(msg.recipient.name);
 
@@ -81,7 +94,7 @@ export function buildLabel(msg: SentMessage, rule: MessageRule): string {
   }
 }
 
-const RULE_COLORS: Record<MessageRule, string> = {
+const RULE_COLORS: Record<ChatBubbleRule, string> = {
   1: '#efeeee',
   2: '#9ebbcb',
   3: '#9ebbcb',
@@ -165,5 +178,69 @@ export function classifyMessage(msg: SentMessage): ChatMessage {
     color: RULE_COLORS[rule],
     collapsed: rule === 3 || rule === 4,
     label: buildLabel(msg, rule),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Context-management markers (Epic 29 / ADR-010). Synthetic, inert ChatMessages
+// folded from native EventMessage payloads — no real sender/recipient bubble.
+// ---------------------------------------------------------------------------
+
+/** "N message" / "N messages" fragment for marker labels (1 is singular). */
+function messageCountLabel(n: number): string {
+  return `${n} message${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * Build the compaction marker `ChatMessage` (Rule 6) from a native
+ * `EventMessage(LlmContextCompactedEvent)` (ADR-010 §3). Collapsed by default;
+ * `content` holds the summary revealed on expand, `label` the "Summarized N
+ * message(s)" headline. `sender`/`recipient` are set to the emitting agent only
+ * to satisfy the type — the marker render reads neither (no alignment, no pill).
+ */
+export function buildCompactionMarker(
+  evt: EventMessage,
+  inner: LlmContextCompactedEvent,
+): ChatMessage {
+  const agent = evt.sender;
+  return {
+    id: evt.id,
+    message_id: evt.id,
+    parent_id: null,
+    content: inner.summary ?? '',
+    sender: agent,
+    recipient: agent,
+    timestamp: new Date(evt.timestamp),
+    rule: COMPACTION_MARKER_RULE,
+    alignment: 'left',
+    color: '',
+    collapsed: true,
+    label: `Summarized ${messageCountLabel(inner.replaced_message_count)}`,
+  };
+}
+
+/**
+ * Build the clear marker `ChatMessage` (Rule 7) from a native
+ * `EventMessage(LlmContextClearedEvent)` (ADR-010 §8). Non-collapsible (no
+ * summary); the label is the "Conversation cleared (N message(s))" line.
+ */
+export function buildClearMarker(
+  evt: EventMessage,
+  inner: LlmContextClearedEvent,
+): ChatMessage {
+  const agent = evt.sender;
+  return {
+    id: evt.id,
+    message_id: evt.id,
+    parent_id: null,
+    content: '',
+    sender: agent,
+    recipient: agent,
+    timestamp: new Date(evt.timestamp),
+    rule: CLEAR_MARKER_RULE,
+    alignment: 'left',
+    color: '',
+    collapsed: false,
+    label: `Conversation cleared (${messageCountLabel(inner.cleared_message_count)})`,
   };
 }

--- a/src/app/components/process/selectors/chat.selector.spec.ts
+++ b/src/app/components/process/selectors/chat.selector.spec.ts
@@ -443,6 +443,102 @@ describe('chatFold / chatStep (pure)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// chatStep — context-management markers (Epic 29 / ADR-010 §3/§8)
+// ---------------------------------------------------------------------------
+
+describe('chatStep — context-management markers (Epic 29 / ADR-010)', () => {
+  function makeCompactionEvent(
+    overrides: Record<string, unknown> = {},
+    msgOverrides: Partial<EventMessage> = {},
+  ): EventMessage {
+    return makeEvent(
+      {
+        __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+        run_id: 'run-1',
+        strategy_id: 'summarize',
+        summary: 'condensed earlier history',
+        replaced_message_count: 6,
+        summarizer_prompt_version: 'v1',
+        tokens_before: 9000,
+        tokens_after: 1200,
+        ...overrides,
+      },
+      msgOverrides,
+    );
+  }
+
+  function makeClearEvent(
+    overrides: Record<string, unknown> = {},
+    msgOverrides: Partial<EventMessage> = {},
+  ): EventMessage {
+    return makeEvent(
+      {
+        __model__: 'akgentic.llm.event.LlmContextClearedEvent',
+        run_id: 'run-2',
+        cleared_message_count: 3,
+        ...overrides,
+      },
+      msgOverrides,
+    );
+  }
+
+  it('compaction EventMessage → a Rule 6 marker carrying count + expandable summary', () => {
+    const state = chatFold([makeCompactionEvent()]);
+    expect(state.messages.length).toBe(1);
+    expect(state.messages[0].rule).toBe(6);
+    expect(state.messages[0].label).toBe('Summarized 6 messages');
+    expect(state.messages[0].content).toBe('condensed earlier history');
+    expect(state.messages[0].collapsed).toBe(true);
+  });
+
+  it('clear EventMessage → a Rule 7 marker (non-collapsible, no summary)', () => {
+    const state = chatFold([makeClearEvent()]);
+    expect(state.messages.length).toBe(1);
+    expect(state.messages[0].rule).toBe(7);
+    expect(state.messages[0].label).toBe('Conversation cleared (3 messages)');
+    expect(state.messages[0].collapsed).toBe(false);
+  });
+
+  it('marker sits CHRONOLOGICALLY at the event log index, between surrounding messages', () => {
+    const before = makeSent({
+      id: 'before-1',
+      sender: makeAddress({ name: '@Worker', role: 'Worker', agent_id: 'w-1' }),
+      message: makeInnerBase({ content: 'first' }),
+    });
+    const after = makeSent({
+      id: 'after-1',
+      sender: makeAddress({ name: '@Worker', role: 'Worker', agent_id: 'w-1' }),
+      message: makeInnerBase({ content: 'second' }),
+    });
+    const state = chatFold([before, makeCompactionEvent(), after]);
+    expect(state.messages.map((m) => m.id)).toEqual(['before-1', 'evt-1', 'after-1']);
+    expect(state.messages[1].rule).toBe(6);
+  });
+
+  it('two sequential context events emit two markers in order (guard exclusivity)', () => {
+    const state = chatFold([
+      makeCompactionEvent(),
+      makeClearEvent({}, { id: 'evt-2' }),
+    ]);
+    expect(state.messages.map((m) => m.rule)).toEqual([6, 7]);
+    expect(state.messages.map((m) => m.id)).toEqual(['evt-1', 'evt-2']);
+  });
+
+  it('a marker does NOT spawn or finalise a thinking bubble', () => {
+    const rcv = makeReceived();
+    const state = chatFold([rcv, makeCompactionEvent()]);
+    expect(state.thinkingAgents.length).toBe(1);
+    expect(state.thinkingAgents[0].final).toBe(false);
+  });
+
+  it('(AC5) markers are pure/incremental — a log shrink yields no stale marker', () => {
+    expect(chatFold([makeCompactionEvent()]).messages.length).toBe(1);
+    // Fold-from-scratch over a shorter log (the event gone) → no marker.
+    expect(chatFold([]).messages.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ChatService (selector over MessageLogService.log$)
 // ---------------------------------------------------------------------------
 
@@ -555,6 +651,25 @@ describe('ChatService (selector over log$)', () => {
     const msgs = await firstValueFrom(service.messages$);
     expect(msgs.length).toBe(1);
     expect(msgs[0].rule).toBe(5);
+  });
+
+  it('(Epic 29) a compaction EventMessage reaches messages$ as a Rule 6 marker', async () => {
+    log.append(
+      makeEvent({
+        __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+        run_id: 'run-1',
+        strategy_id: 'summarize',
+        summary: 'condensed',
+        replaced_message_count: 4,
+        summarizer_prompt_version: 'v1',
+        tokens_before: 8000,
+        tokens_after: 1000,
+      }),
+    );
+    const msgs = await firstValueFrom(service.messages$);
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].rule).toBe(6);
+    expect(msgs[0].label).toBe('Summarized 4 messages');
   });
 
   it('pendingNotifications$ reacts to Rule 3 messages via the derived messages$', async () => {

--- a/src/app/components/process/selectors/chat.selector.ts
+++ b/src/app/components/process/selectors/chat.selector.ts
@@ -8,6 +8,8 @@ import {
 } from 'rxjs';
 
 import {
+  buildClearMarker,
+  buildCompactionMarker,
   buildPreview,
   ChatMessage,
   classifyMessage,
@@ -17,6 +19,8 @@ import {
   AkgenticMessage,
   EventMessage,
   isEventMessage,
+  isLlmContextClearedEvent,
+  isLlmContextCompactedEvent,
   isProcessedMessage,
   isReceivedMessage,
   isSentMessage,
@@ -270,6 +274,12 @@ function applyMessageFromSent(state: ChatState, msg: SentMessage): ChatState {
   return { ...state, messages: [...state.messages, chatMsg] };
 }
 
+/** Append a synthetic context-management marker (Epic 29 / ADR-010) at the
+ *  event's log position. A passthrough branch only — no new state service. */
+function applyMarker(state: ChatState, marker: ChatMessage): ChatState {
+  return { ...state, messages: [...state.messages, marker] };
+}
+
 /** Pure per-message transition (Task 3.4). Returns `state` unchanged for
  *  unhandled discriminants (FR11 passthrough — AC6). */
 export function chatStep(state: ChatState, msg: AkgenticMessage): ChatState {
@@ -286,6 +296,15 @@ export function chatStep(state: ChatState, msg: AkgenticMessage): ChatState {
   }
   if (isEventMessage(msg)) {
     const inner = (msg as EventMessage).event;
+    // Epic 29 / ADR-010: fold context-management events into synthetic markers,
+    // positioned chronologically at the event's log index. Guards are mutually
+    // exclusive, so the order relative to the tool branches below is immaterial.
+    if (isLlmContextCompactedEvent(inner)) {
+      return applyMarker(state, buildCompactionMarker(msg as EventMessage, inner));
+    }
+    if (isLlmContextClearedEvent(inner)) {
+      return applyMarker(state, buildClearMarker(msg as EventMessage, inner));
+    }
     const kind: string | undefined = inner?.__model__;
     if (kind?.includes('ToolCallEvent')) {
       return applyToolCallToThinking(state, msg as EventMessage);

--- a/src/app/protocol/message.types.spec.ts
+++ b/src/app/protocol/message.types.spec.ts
@@ -1,6 +1,8 @@
 import {
   ActorAddress,
   BaseMessage,
+  isLlmContextClearedEvent,
+  isLlmContextCompactedEvent,
   isLlmMessageEvent,
   isLlmSystemPromptEvent,
   isLlmUsageEvent,
@@ -179,6 +181,110 @@ describe('Llm*Event guard mutual exclusion (AC #3)', () => {
         isLlmSystemPromptEvent(evt),
         isLlmMessageEvent(evt),
       ].filter(Boolean);
+      expect(fired.length).toBe(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLlmContextCompactedEvent — inner-event check (ADR-010 §3, AC #2)
+// ---------------------------------------------------------------------------
+
+describe('isLlmContextCompactedEvent', () => {
+  it('returns true for an inner event whose __model__ includes "LlmContextCompactedEvent"', () => {
+    expect(
+      isLlmContextCompactedEvent({
+        __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for null / undefined / missing __model__', () => {
+    expect(isLlmContextCompactedEvent(null)).toBe(false);
+    expect(isLlmContextCompactedEvent(undefined)).toBe(false);
+    expect(isLlmContextCompactedEvent({})).toBe(false);
+  });
+
+  it('returns false for the sibling clear event (no substring collision)', () => {
+    expect(
+      isLlmContextCompactedEvent({
+        __model__: 'akgentic.llm.event.LlmContextClearedEvent',
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isLlmContextClearedEvent — inner-event check (ADR-010 §8, AC #2)
+// ---------------------------------------------------------------------------
+
+describe('isLlmContextClearedEvent', () => {
+  it('returns true for an inner event whose __model__ includes "LlmContextClearedEvent"', () => {
+    expect(
+      isLlmContextClearedEvent({
+        __model__: 'akgentic.llm.event.LlmContextClearedEvent',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for null / undefined / missing __model__', () => {
+    expect(isLlmContextClearedEvent(null)).toBe(false);
+    expect(isLlmContextClearedEvent(undefined)).toBe(false);
+    expect(isLlmContextClearedEvent({})).toBe(false);
+  });
+
+  it('returns false for the sibling compaction event (no substring collision)', () => {
+    expect(
+      isLlmContextClearedEvent({
+        __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
+      }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC #2 — the FIVE Llm*Event / context guards are mutually exclusive.
+// For any single inner event exactly ONE of the five guards fires. Crucially
+// this protects the two new substrings against collision IN EITHER DIRECTION:
+// 'LlmContextCompactedEvent' vs 'LlmContextClearedEvent' (shared 'LlmContext'
+// prefix) and against 'LlmMessageEvent' / 'LlmUsageEvent' /
+// 'LlmSystemPromptEvent'.
+// ---------------------------------------------------------------------------
+
+describe('Llm*Event five-guard mutual exclusion (AC #2)', () => {
+  const compacted = { __model__: 'akgentic.llm.event.LlmContextCompactedEvent' };
+  const cleared = { __model__: 'akgentic.llm.event.LlmContextClearedEvent' };
+  const usage = { __model__: 'akgentic.llm.event.LlmUsageEvent' };
+  const systemPrompt = { __model__: 'akgentic.llm.event.LlmSystemPromptEvent' };
+  const message = { __model__: 'akgentic.llm.event.LlmMessageEvent' };
+
+  const guards = [
+    isLlmContextCompactedEvent,
+    isLlmContextClearedEvent,
+    isLlmUsageEvent,
+    isLlmSystemPromptEvent,
+    isLlmMessageEvent,
+  ] as const;
+
+  it('for a compaction event, ONLY isLlmContextCompactedEvent fires', () => {
+    expect(isLlmContextCompactedEvent(compacted)).toBe(true);
+    expect(isLlmContextClearedEvent(compacted)).toBe(false);
+    expect(isLlmUsageEvent(compacted)).toBe(false);
+    expect(isLlmSystemPromptEvent(compacted)).toBe(false);
+    expect(isLlmMessageEvent(compacted)).toBe(false);
+  });
+
+  it('for a clear event, ONLY isLlmContextClearedEvent fires', () => {
+    expect(isLlmContextClearedEvent(cleared)).toBe(true);
+    expect(isLlmContextCompactedEvent(cleared)).toBe(false);
+    expect(isLlmUsageEvent(cleared)).toBe(false);
+    expect(isLlmSystemPromptEvent(cleared)).toBe(false);
+    expect(isLlmMessageEvent(cleared)).toBe(false);
+  });
+
+  it('the five guards never co-fire for the same event', () => {
+    for (const evt of [compacted, cleared, usage, systemPrompt, message]) {
+      const fired = guards.map((g) => g(evt)).filter(Boolean);
       expect(fired.length).toBe(1);
     }
   });

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -227,6 +227,43 @@ export interface LlmUsageEvent {
   requests: number;
 }
 
+/**
+ * Inner event payload announcing that a summary replaced a leading prefix of an
+ * agent's conversation, mirroring the akgentic-llm `LlmContextCompactedEvent`
+ * frozen dataclass (ADR-010 §3). It rides the standard `EventMessage` envelope
+ * (outer `sender.agent_id` identifies the agent that compacted) and is
+ * discriminated frontend-side by the inner `__model__` — exactly like
+ * `LlmUsageEvent` / `LlmSystemPromptEvent`. The serializer tags the dataclass
+ * with the fully-qualified `__model__` and preserves the primitive field values
+ * (integer counts, string summary — no `repr` stringification). `run_id` is
+ * `null` for a manual `/compact` between runs; `tokens_before` / `tokens_after`
+ * are observability-only and may be `null`.
+ */
+export interface LlmContextCompactedEvent {
+  __model__: string; // contains 'LlmContextCompactedEvent'
+  run_id: string | null;
+  strategy_id: string;
+  summary: string;
+  replaced_message_count: number;
+  summarizer_prompt_version: string;
+  tokens_before: number | null;
+  tokens_after: number | null;
+}
+
+/**
+ * Inner event payload announcing that an agent's conversation was wiped to empty
+ * (system prompt re-injects on the next run), mirroring the akgentic-llm
+ * `LlmContextClearedEvent` frozen dataclass (ADR-010 §8). Same native
+ * `EventMessage` passthrough + inner `__model__` discrimination as
+ * `LlmContextCompactedEvent`. `run_id` is `null` for a manual `/clear` between
+ * runs; `cleared_message_count` is the number of messages removed.
+ */
+export interface LlmContextClearedEvent {
+  __model__: string; // contains 'LlmContextClearedEvent'
+  run_id: string | null;
+  cleared_message_count: number;
+}
+
 // Union type for all possible messages
 export type AkgenticMessage =
   | SentMessage
@@ -342,6 +379,33 @@ export function isLlmUsageEvent(
   event: { __model__?: string } | null | undefined,
 ): event is LlmUsageEvent {
   return !!event?.__model__?.includes('LlmUsageEvent');
+}
+
+/**
+ * Inner-event check (ADR-010 §3): true when the inner event carried by an
+ * `EventMessage` is a `LlmContextCompactedEvent`. Matches on the inner
+ * `__model__`, the same discrimination used for `LlmUsageEvent` /
+ * `LlmSystemPromptEvent`. Mutually exclusive with every other `Llm*Event` guard:
+ * `'LlmContextCompactedEvent'` neither contains nor is contained by
+ * `'LlmContextClearedEvent'`, `'LlmUsageEvent'`, `'LlmSystemPromptEvent'`, or
+ * `'LlmMessageEvent'` (no substring collision in either direction).
+ */
+export function isLlmContextCompactedEvent(
+  event: { __model__?: string } | null | undefined,
+): event is LlmContextCompactedEvent {
+  return !!event?.__model__?.includes('LlmContextCompactedEvent');
+}
+
+/**
+ * Inner-event check (ADR-010 §8): true when the inner event carried by an
+ * `EventMessage` is a `LlmContextClearedEvent`. Matches on the inner
+ * `__model__`; mutually exclusive with `isLlmContextCompactedEvent` and the
+ * other `Llm*Event` guards (no substring collision in either direction).
+ */
+export function isLlmContextClearedEvent(
+  event: { __model__?: string } | null | undefined,
+): event is LlmContextClearedEvent {
+  return !!event?.__model__?.includes('LlmContextClearedEvent');
 }
 
 /**


### PR DESCRIPTION
## Epic 29 — Render context-compaction & clear markers in the chat trace

Renders the two new `akgentic-llm` context-management events (ADR-010) as native
chat-trace markers, consumed off the raw `EventMessage` by inner `__model__` — exactly
like `LlmUsageEvent` (Epic 26) / `LlmSystemPromptEvent` (Epic 16). No `angular_v1`
adapter, no `akgentic-infra` change.

### Stories

- [x] 29-1 — render compaction & clear markers in the **main chat** (Relates to #206)
- [x] 29-2 — fold compaction/clear in the **per-agent `context` + `tokenUsage` stores** (Member tab) (Relates to #208)

### What changed (frontend-only)

**29-1 — main chat markers**

- **protocol** — `LlmContextCompactedEvent` / `LlmContextClearedEvent` interfaces +
  `isLlmContextCompactedEvent` / `isLlmContextClearedEvent` guards. Mutually exclusive
  with the other `Llm*Event` guards (no substring collision in either direction); a
  five-guard regression test asserts exactly one fires per event.
- **model** — `MessageRule` extended to `6` (compaction) / `7` (clear);
  `buildCompactionMarker` + `buildClearMarker` produce synthetic, inert `ChatMessage`s.
  Bubble-rule logic narrowed to `ChatBubbleRule` (1-5) so `buildLabel`/`RULE_COLORS`
  stay exhaustive and untouched.
- **selector** — `chatStep()` passthrough branch emits the marker at the event's log
  index (chronological). Pure / incremental — no new state service; log-shrink and
  team-switch yield no stale markers.
- **render** — `.system-marker` block: a collapsible "Summarized N message(s)" fold
  revealing the summary (markdown, height-bounded 240px + scroll) and an inert
  "Conversation cleared (N message(s))" line. Rule 6 expand persists via the panel's
  existing `expandedMessageIds` path.

**29-2 — per-agent stores fold (Member tab)**

- **`context` store** — replaced the stock append-only spec with custom
  `contextMatch`/`contextReduce`: append on `LlmMessageEvent`, FOLD on
  `LlmContextCompactedEvent` (`foldContextCompaction` drops the first
  `replaced_message_count` non-system entries and inserts ONE synthetic
  `[Conversation summary] …` entry at the fold point; system entries exempt, mirroring
  backend `_is_system_message`), RESET to `[]` on `LlmContextClearedEvent`. Sequential
  compactions compose; no double-apply. Faithful mirror of `akgentic-llm`
  `ContextManager.fold_compaction` / `compact` / `clear_context`.
- **`tokenUsage` store** — `tokenUsageMatch` admits the two context events;
  `tokenUsageReduce` re-points `lastContextWindow ← tokens_after` on compaction (only
  when numeric; null/absent is a defensive no-op) and to `0` on clear, leaving cumulative
  totals + run labels untouched. The next `LlmUsageEvent` overrides the estimate.
- **render touch** — `AkgentChatComponent.updateContext` labels the folded-in summary
  entry as a "Summary" row (prefix stripped) so it reads clearly.

## Review status

**Rex (adversarial code review): both stories APPROVED → done.**

### 29-1 — verified against commit `40eea59`

| AC | Verdict | Evidence |
| --- | --- | --- |
| #1 wire-shape gate | PASS (reasoned) | guards discriminate inner `__model__`; native `EventMessage` path. Gate reasoned from the serializer + `LlmUsageEvent` precedent (live frame unavailable until akgentic-llm Epic 12 merges) — disclosed; specs mock the structured frame. |
| #2 typed guards, mutually exclusive | PASS | two guards + five-guard mutual-exclusion spec (both substring directions). |
| #3 compaction collapsible fold | PASS | Rule 6, collapsed-by-default, chevron-expandable summary, chronological, inert. |
| #4 clear inline marker | PASS | Rule 7, "Conversation cleared (N message(s))", non-collapsible, chronological, inert. |
| #5 pure incremental folds | PASS | `chatStep()` passthrough branch, no new state service; `chatFold([])` proves no stale marker. |
| #6 quality gates | PASS | Karma green, lint clean, build OK, coverage thresholds enforced. |

### 29-2 — verified against commit `2e4a7df`

| AC | Verdict | Evidence |
| --- | --- | --- |
| #1 `match` admits all three events | PASS | `contextMatch` reuses `innerLlmMessage` + the two context guards; admit-3 / reject usage+unrelated tests. |
| #2 `LlmMessageEvent` → append (byte-identical) | PASS | pure-append parity test + fresh-reference (OnPush) test. |
| #3 compaction fold (drop N non-system, insert one summary; system exempt) | PASS | `foldContextCompaction` mirrors backend line-for-line; leading + interleaved system-exempt tests. |
| #4 summary visible in Member trace | PASS | render touch labels the prefixed entry "Summary"; DOM test asserts the row + replaced prefix gone. |
| #5 clear → reset `[]` | PASS | empties then rebuilds. |
| #6 ordered-fold parity / re-compaction / no double-apply | PASS | two-sequential-compaction composition + batch==per-message parity. |
| #7 compaction re-points `lastContextWindow` (numeric only) | PASS | `typeof tokens_after === 'number'` guard; numeric / null-passthrough / seed-from-zero tests; totals + labels untouched. |
| #8 clear → window `0`, totals/labels kept | PASS | pure + registry tests. |
| #9 `LlmUsageEvent` unchanged + next-usage override | PASS | usage branch unchanged; registry override test. |
| #10 quality gates | PASS | **Karma 1163/1163 SUCCESS** (33 new specs), lint clean, build OK, ≥80% coverage on the new reducers. |

No HIGH/MEDIUM findings on either story → no fixup commit. 29-2 LOW notes (non-blocking):
backend `_drop_orphan_tool_results` intentionally not mirrored (observability-only edge
case, documented); `isContextSystemEntry` is `kind`-agnostic vs backend's `ModelRequest`
check (harmless); summary detected by the shared prefix convention; micro-redundant inner
reads matching the module idiom.

## Scope guard

All changed files are under `packages/akgentic-frontend/src/app/`. No `akgentic-infra`
change, no `angular_v1` adapter path (Golden Rule #4). ADR discipline (Golden Rule #8):
`ADR-010` appears only in `describe`/`it` labels and comments — no test asserts on an ADR
string. Default per-agent key remains `sender.agent_id`.

## Epic 29 slice complete

29-1 (main chat) and 29-2 (per-agent Member-tab stores) are both merged into this branch
and reviewed. The chat trace and the Member tab now both render the agent's actual
post-compaction / post-clear state, mirroring the proven message-log → guard →
selector/store → OnPush render pattern. `epic-29`, `29-1`, and `29-2` are marked `done`
in `sprint-status.yaml`.

Closes #206
Closes #208
