### PR TITLE
feat(akgentic-frontend): 29-3 full-fold + part-level compaction in Member context store

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1244,14 +1244,14 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Story 29-2 (Epic 29 / ADR-010 §4) — the per-agent `context` store folds a
-// compaction by dropping the replaced prefix and inserting a synthetic summary
-// entry (prefixed CONVERSATION_SUMMARY_PREFIX). The member trace must render the
-// summary as a clearly-labelled row and NOT show the replaced prefix. Driven by
-// pushing the SAME folded array the store produces (foldContextCompaction) into
-// context$ and asserting the rendered conversation rows.
+// Story 29-3 (Epic 29 / ADR-010 §9) — the per-agent `context` store full-folds a
+// compaction to `[system-parts-only head] + [one summary]` (part-level system
+// exemption). The member trace must render the summary as a clearly-labelled row
+// and show NEITHER the fused `[Operator action] "/clear" …` user row NOR the
+// verbatim Q/A tail. Driven by pushing the SAME folded array the store produces
+// (foldContextCompaction) into context$ and asserting the rendered rows.
 // ---------------------------------------------------------------------------
-describe('AkgentChatComponent — folded compaction summary (Story 29-2)', () => {
+describe('AkgentChatComponent — folded compaction summary (Story 29-3)', () => {
   const AGENT = 'a-mgr';
 
   function setup(): {
@@ -1327,29 +1327,35 @@ describe('AkgentChatComponent — folded compaction summary (Story 29-2)', () =>
   function userEntry(text: string): unknown {
     return { kind: 'request', parts: [{ part_kind: 'user-prompt', content: text }] };
   }
-  function systemEntry(text: string): unknown {
+  function fusedSystemUserEntry(systemText: string, userText: string): unknown {
     return {
       kind: 'request',
-      parts: [{ part_kind: 'system-prompt', dynamic_ref: null, content: text }],
+      parts: [
+        { part_kind: 'system-prompt', dynamic_ref: null, content: systemText },
+        { part_kind: 'user-prompt', content: userText },
+      ],
     };
   }
 
-  it('AC4 renders the inserted summary row (clearly labelled, prefix stripped) and NOT the replaced prefix', () => {
+  it('AC8 renders the summary row and NEITHER the fused /clear head NOR the Q/A tail', () => {
     const { fixture, component } = setup();
 
-    // Pre-compaction history, then fold it with the SAME helper the store uses.
+    // The live scenario: fused first request (`/clear` + first prompt), Q/A turns,
+    // then a /compact. Fold it with the SAME helper the store uses.
     const preFold = [
-      systemEntry('SYSTEM'),
-      userEntry('dropped earlier turn one'),
-      userEntry('dropped earlier turn two'),
-      userEntry('kept latest turn'),
+      fusedSystemUserEntry(
+        'SYSTEM',
+        '[Operator action] "/clear" — first question after clear',
+      ),
+      userEntry('verbatim question two'),
+      userEntry('verbatim question three'),
     ];
     const folded = foldContextCompaction(preFold, {
       __model__: 'akgentic.llm.event.LlmContextCompactedEvent',
       run_id: null,
       strategy_id: 'sliding-window',
       summary: 'the running recap',
-      replaced_message_count: 2,
+      replaced_message_count: 99,
       summarizer_prompt_version: 'v1',
       tokens_before: null,
       tokens_after: 1234,
@@ -1361,15 +1367,14 @@ describe('AkgentChatComponent — folded compaction summary (Story 29-2)', () =>
     // The summary row renders, clearly labelled, with the prefix stripped.
     expect(convHeaders(fixture)).toContain('Human : Summary');
     expect(convBodies(fixture)).toContain('the running recap');
-    // The kept turn still renders as a normal user row.
-    expect(convHeaders(fixture)).toContain('Human : User');
-    expect(convBodies(fixture)).toContain('kept latest turn');
 
-    // The replaced prefix is GONE — neither dropped turn appears anywhere, and the
-    // raw summary marker is not shown to the user (stripped by the render touch).
+    // Full-fold: no fused `/clear` head row, no verbatim Q/A tail rows, and the
+    // raw summary marker is not shown (stripped by the render touch).
     const allText = (fixture.nativeElement as HTMLElement).textContent ?? '';
-    expect(allText).not.toContain('dropped earlier turn one');
-    expect(allText).not.toContain('dropped earlier turn two');
+    expect(allText).not.toContain('/clear');
+    expect(allText).not.toContain('first question after clear');
+    expect(allText).not.toContain('verbatim question two');
+    expect(allText).not.toContain('verbatim question three');
     expect(allText).not.toContain(CONVERSATION_SUMMARY_PREFIX);
   });
 });

--- a/src/app/components/process/event/per-agent-specs.spec.ts
+++ b/src/app/components/process/event/per-agent-specs.spec.ts
@@ -101,12 +101,31 @@ function userEntry(text: string): unknown {
 }
 
 /** A system ModelRequest-shaped context entry (one system-prompt part) — the
- *  fold exempts these (mirrors backend `_is_system_message`). */
+ *  part-level fold keeps these (rebuilt system-parts-only). */
 function systemEntry(text: string): unknown {
   return {
     kind: 'request',
     parts: [{ part_kind: 'system-prompt', dynamic_ref: null, content: text }],
   };
+}
+
+/** The "fused" first ModelRequest pydantic-ai builds as
+ *  `[SystemPromptPart, UserPromptPart]`. Post-12-7 the fold keeps ONLY the
+ *  system part; the fused user part (the `[Operator action] "/clear" …` block)
+ *  is dropped into the summary (AC1/AC3). */
+function fusedSystemUserEntry(systemText: string, userText: string): unknown {
+  return {
+    kind: 'request',
+    parts: [
+      { part_kind: 'system-prompt', dynamic_ref: null, content: systemText },
+      { part_kind: 'user-prompt', content: userText },
+    ],
+  };
+}
+
+/** A non-system ModelResponse-shaped context entry (one text part). */
+function responseEntry(text: string): unknown {
+  return { kind: 'response', parts: [{ part_kind: 'text', content: text }] };
 }
 
 /** EventMessage envelope carrying an LlmMessageEvent whose inner `message` is
@@ -416,12 +435,12 @@ describe('contextMatch (Epic 29 / ADR-010 §4/§8)', () => {
   });
 });
 
-describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)', () => {
+describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §9)', () => {
   function ctx(service: IngestionService, agentId: string): unknown[] | undefined {
     return service.context.snapshot(agentId);
   }
 
-  it('AC #2 append parity: a pure LlmMessageEvent sequence appends inner messages in order', () => {
+  it('AC2 append parity: a pure LlmMessageEvent sequence appends inner messages in order', () => {
     const { log, service } = configureBed();
     const m1 = userEntry('one');
     const m2 = userEntry('two');
@@ -429,7 +448,7 @@ describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)
     expect(ctx(service, 'A')).toEqual([m1, m2]);
   });
 
-  it('AC #2 returns a FRESH array reference on each append (OnPush safety)', () => {
+  it('AC6 returns a FRESH array reference on each append (OnPush safety)', () => {
     const { log, service } = configureBed();
     log.append(makeMessageEnvelope('A', userEntry('u1')));
     const first = ctx(service, 'A');
@@ -437,42 +456,34 @@ describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)
     expect(first).not.toBe(ctx(service, 'A'));
   });
 
-  it('AC #3 compaction drops the first replaced_message_count NON-system entries and inserts ONE summary at the fold point', () => {
+  it('AC2/AC3 full-fold: a /clear → turns → /compact history folds to [system-only head, one summary]', () => {
     const { log, service } = configureBed();
     log.appendAll([
-      makeMessageEnvelope('A', systemEntry('SYS')),
-      makeMessageEnvelope('A', userEntry('u1')),
-      makeMessageEnvelope('A', userEntry('u2')),
-      makeMessageEnvelope('A', userEntry('u3')),
-      makeCompactionEnvelope('A', { summary: 'recap', replaced_message_count: 2 }),
+      makeMessageEnvelope(
+        'A',
+        fusedSystemUserEntry('SYS', '[Operator action] "/clear" — please help'),
+      ),
+      makeMessageEnvelope('A', responseEntry('a1')),
+      makeMessageEnvelope('A', userEntry('q2')),
+      makeMessageEnvelope('A', responseEntry('a2')),
+      makeMessageEnvelope('A', userEntry('q3')),
+      makeMessageEnvelope('A', responseEntry('a3')),
+      makeCompactionEnvelope('A', { summary: 'recap', replaced_message_count: 99 }),
     ]);
     const result = ctx(service, 'A') as any[];
-    // Leading system entry exempt; u1 + u2 replaced by exactly one summary; u3 kept.
-    expect(result.length).toBe(3);
+    // Part-level head rebuild: only the system-prompt part survives; one summary.
+    expect(result.length).toBe(2);
     expect(result[0]).toEqual(systemEntry('SYS'));
     expect(result[1].parts[0].part_kind).toBe('user-prompt');
     expect(result[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'recap');
-    expect(result[2]).toEqual(userEntry('u3'));
+    // AC3 regression: no fused '/clear' head, no verbatim Q/A turn survives.
+    const dump = JSON.stringify(result);
+    expect(dump).not.toContain('/clear');
+    expect(dump).not.toContain('q2');
+    expect(dump).not.toContain('a2');
   });
 
-  it('AC #3 a system entry interleaved in the dropped prefix is preserved (never counted/folded)', () => {
-    const { log, service } = configureBed();
-    log.appendAll([
-      makeMessageEnvelope('A', userEntry('u1')),
-      makeMessageEnvelope('A', systemEntry('SYS')),
-      makeMessageEnvelope('A', userEntry('u2')),
-      makeMessageEnvelope('A', userEntry('u3')),
-      makeCompactionEnvelope('A', { summary: 's', replaced_message_count: 2 }),
-    ]);
-    const result = ctx(service, 'A') as any[];
-    // u1 dropped (summary inserted at the head), SYS exempt, u2 dropped, u3 kept.
-    expect(result.length).toBe(3);
-    expect(result[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 's');
-    expect(result[1]).toEqual(systemEntry('SYS'));
-    expect(result[2]).toEqual(userEntry('u3'));
-  });
-
-  it('AC #5 clear empties the per-agent array; subsequent messages rebuild it', () => {
+  it('AC5 clear empties the per-agent array; subsequent messages rebuild it', () => {
     const { log, service } = configureBed();
     log.appendAll([
       makeMessageEnvelope('A', userEntry('u1')),
@@ -484,22 +495,24 @@ describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)
     expect(ctx(service, 'A')).toEqual([userEntry('fresh')]);
   });
 
-  it('AC #6 two sequential compactions compose (the first summary is itself foldable); no double-apply', () => {
+  it('AC5 two sequential compactions compose to [system head, summary2] (summary1 folded away)', () => {
     const { log, service } = configureBed();
     log.appendAll([
+      makeMessageEnvelope('A', systemEntry('SYS')),
       makeMessageEnvelope('A', userEntry('u1')),
       makeMessageEnvelope('A', userEntry('u2')),
-      makeMessageEnvelope('A', userEntry('u3')),
       makeCompactionEnvelope('A', { summary: 'first', replaced_message_count: 2 }),
-      // After fold 1: [summary(first), u3]. Fold 2 (count 2) replaces BOTH.
-      makeCompactionEnvelope('A', { summary: 'second', replaced_message_count: 2 }),
+      // After fold 1: [SYS, summary(first)]. A new turn arrives, then a 2nd compact.
+      makeMessageEnvelope('A', userEntry('u3')),
+      makeCompactionEnvelope('A', { summary: 'second', replaced_message_count: 99 }),
     ]);
     const result = ctx(service, 'A') as any[];
-    expect(result.length).toBe(1);
-    expect(result[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'second');
+    expect(result.length).toBe(2);
+    expect(result[0]).toEqual(systemEntry('SYS'));
+    expect(result[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'second');
   });
 
-  it('AC #6 ordered-fold parity: batch appendAll equals per-message append', () => {
+  it('AC7 ordered-fold parity: batch appendAll equals per-message append', () => {
     const events = (): AkgenticMessage[] => [
       makeMessageEnvelope('A', systemEntry('SYS')),
       makeMessageEnvelope('A', userEntry('u1')),
@@ -517,27 +530,93 @@ describe('contextSpec fold — via the real registry (Epic 29 / ADR-010 §4/§8)
   });
 });
 
-describe('foldContextCompaction (pure)', () => {
-  it('replaced_message_count <= 0 is a no-op (returns the SAME input array)', () => {
-    const msgs = [userEntry('a'), userEntry('b')];
-    expect(
-      foldContextCompaction(
-        msgs,
-        compactionEvent({ summary: 's', replaced_message_count: 0 }),
-      ),
-    ).toBe(msgs);
-  });
-
-  it('returns a FRESH array on a real fold; the summary carries the prefixed content', () => {
-    const msgs = [userEntry('a'), userEntry('b')];
+describe('foldContextCompaction (pure, ADR-010 §9 full-fold + part-level)', () => {
+  it('AC1 part-level head rebuild: keeps only system-prompt parts, drops the fused user part', () => {
+    const msgs = [
+      fusedSystemUserEntry('SYS', '[Operator action] "/clear" hello'),
+      userEntry('q1'),
+      responseEntry('a1'),
+    ];
     const out = foldContextCompaction(
       msgs,
       compactionEvent({ summary: 'recap', replaced_message_count: 1 }),
     ) as any[];
-    expect(out).not.toBe(msgs);
-    expect(out.length).toBe(2); // summary + b
+    expect(out.length).toBe(2);
+    expect(out[0]).toEqual(systemEntry('SYS')); // user-prompt dropped from the head
+    expect(out[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'recap');
+    expect(JSON.stringify(out)).not.toContain('/clear');
+  });
+
+  it('AC2 full-fold: every non-system entry is gone, exactly one summary after the head', () => {
+    const msgs = [
+      systemEntry('SYS'),
+      userEntry('u1'),
+      responseEntry('r1'),
+      userEntry('u2'),
+    ];
+    const out = foldContextCompaction(
+      msgs,
+      compactionEvent({ summary: 's', replaced_message_count: 0 }),
+    ) as any[];
+    expect(out.length).toBe(2);
+    expect(out[0]).toEqual(systemEntry('SYS'));
+    expect(out[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 's');
+  });
+
+  it('AC2 no system head: folds to a single summary entry', () => {
+    const out = foldContextCompaction(
+      [userEntry('a'), userEntry('b')],
+      compactionEvent({ summary: 'recap', replaced_message_count: 5 }),
+    ) as any[];
+    expect(out.length).toBe(1);
     expect(out[0].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'recap');
-    expect(out[1]).toEqual(userEntry('b'));
+  });
+
+  it('AC2 returns a FRESH array on a real fold', () => {
+    const msgs = [userEntry('a')];
+    expect(
+      foldContextCompaction(
+        msgs,
+        compactionEvent({ summary: 's', replaced_message_count: 1 }),
+      ),
+    ).not.toBe(msgs);
+  });
+
+  it('AC4 no-op guard: empty summary AND no non-system content returns the SAME input array', () => {
+    const msgs = [systemEntry('SYS')];
+    expect(
+      foldContextCompaction(
+        msgs,
+        compactionEvent({ summary: '', replaced_message_count: 0 }),
+      ),
+    ).toBe(msgs);
+  });
+
+  it('AC4 empty summary but non-system content present still folds (count not consulted)', () => {
+    const msgs = [systemEntry('SYS'), userEntry('drop-me')];
+    const out = foldContextCompaction(
+      msgs,
+      compactionEvent({ summary: '', replaced_message_count: 0 }),
+    ) as any[];
+    expect(out.length).toBe(2);
+    expect(out[0]).toEqual(systemEntry('SYS'));
+    expect(out[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + '');
+    expect(JSON.stringify(out)).not.toContain('drop-me');
+  });
+
+  it('AC5 second compaction folds summary1 (a non-system entry) into summary2', () => {
+    const afterFirst = [
+      systemEntry('SYS'),
+      userEntry(CONVERSATION_SUMMARY_PREFIX + 'first'),
+      userEntry('m'),
+    ];
+    const out = foldContextCompaction(
+      afterFirst,
+      compactionEvent({ summary: 'second', replaced_message_count: 9 }),
+    ) as any[];
+    expect(out.length).toBe(2);
+    expect(out[0]).toEqual(systemEntry('SYS'));
+    expect(out[1].parts[0].content).toBe(CONVERSATION_SUMMARY_PREFIX + 'second');
   });
 
   it('contextReduce passes a non-event message through unchanged (defensive)', () => {

--- a/src/app/components/process/event/per-agent-specs.ts
+++ b/src/app/components/process/event/per-agent-specs.ts
@@ -270,20 +270,49 @@ export const stateSpec: PerAgentSpec<AgentStateValue> = {
 export const CONVERSATION_SUMMARY_PREFIX = '[Conversation summary] ';
 
 /**
- * True when a context entry is a "system" message — one whose `parts` include a
- * `part_kind === 'system-prompt'` part. Mirrors the backend `_is_system_message`
- * exemption (and `llmMessageSystemParts` above): system entries are NEVER folded
- * by a compaction, exactly like the sliding window. Defensive: a missing or
- * non-array `parts` is treated as non-system.
+ * Part-level system-split helpers (ADR-010 §9 — part-level system exemption).
+ * The post-12-7 backend rebuilds the first `ModelRequest` keeping ONLY its
+ * `SystemPromptPart`s and folds every non-system part — including the fused
+ * `[Operator action] "/clear" … <first request>` `UserPromptPart` — into the
+ * summary. The member fold mirrors that, so it needs three reads: does an entry
+ * carry any system part, rebuild it system-parts-only, and does it still carry
+ * non-system content. All reads are defensive: a missing or non-array `parts`
+ * is treated as no parts.
+ */
+function entryParts(entry: unknown): unknown[] {
+  const parts = (entry as { parts?: unknown } | null | undefined)?.parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
+/** True for a `part_kind === 'system-prompt'` part (defensive on null). */
+function isSystemPart(part: unknown): boolean {
+  return (part as { part_kind?: string } | null)?.part_kind === 'system-prompt';
+}
+
+/**
+ * True when an entry carries ≥1 `system-prompt` part. Part-level: an entry can
+ * be system-bearing AND still carry non-system parts (e.g. the fused first
+ * request), so this no longer means "never folded" — see `rebuildSystemOnly`.
  */
 function isContextSystemEntry(entry: unknown): boolean {
-  const parts = (entry as { parts?: unknown } | null | undefined)?.parts;
-  return (
-    Array.isArray(parts) &&
-    parts.some(
-      (p) => (p as { part_kind?: string } | null)?.part_kind === 'system-prompt',
-    )
-  );
+  return entryParts(entry).some(isSystemPart);
+}
+
+/** True when an entry carries ≥1 non-system part (folded into the summary). */
+function entryHasNonSystemPart(entry: unknown): boolean {
+  return entryParts(entry).some((p) => !isSystemPart(p));
+}
+
+/**
+ * Rebuild a fresh entry keeping ONLY its system-prompt parts, preserving the
+ * entry's `kind` (and any other top-level fields). Its non-system parts are
+ * dropped — they are represented solely by the folded summary.
+ */
+function rebuildSystemOnly(entry: unknown): unknown {
+  return {
+    ...(entry as object),
+    parts: entryParts(entry).filter(isSystemPart),
+  };
 }
 
 /**
@@ -306,39 +335,33 @@ function buildSummaryEntry(summary: string): unknown {
 }
 
 /**
- * Fold `messages` per a compaction event, mirroring `ContextManager.fold_compaction`
- * (ADR-010 §4): drop the first `replaced_message_count` NON-system entries and
- * insert ONE synthetic summary entry at the fold point; system entries are never
- * dropped. Returns a FRESH array on a real fold (OnPush); a non-positive
- * `replaced_message_count` is a no-op (returns the input unchanged). The backend's
- * trailing `_drop_orphan_tool_results` (an OpenAI role=tool adjacency guard for
- * the NEXT provider request) is intentionally not mirrored — it does not affect
- * what the member trace displays.
+ * Fold `messages` per a compaction event, mirroring the post-12-7 backend
+ * `summarize` (ADR-010 §9 — full-fold + part-level system exemption). The result
+ * is exactly `[…system-parts-only head entries…, ONE synthetic summary]`: every
+ * entry that carries a system part is rebuilt keeping only its system parts (its
+ * fused `UserPromptPart` is dropped), every entry with no system part is dropped
+ * entirely, and a single summary follows the system head. `replaced_message_count`
+ * is observability-only — the fold drops ALL non-system content regardless of the
+ * count. Returns a FRESH array on a real fold (OnPush); the no-op (empty `summary`
+ * AND nothing non-system to fold) returns the input unchanged (same reference) so
+ * the head is never reduced to nothing and an empty summary is never inserted. The
+ * backend's trailing `_drop_orphan_tool_results` adjacency guard is intentionally
+ * NOT mirrored — once nothing is orphaned it is inert (§9 "Frontend").
  */
 export function foldContextCompaction(
   messages: unknown[],
   event: LlmContextCompactedEvent,
 ): unknown[] {
-  if (event.replaced_message_count <= 0) return messages;
-  const summary = buildSummaryEntry(event.summary ?? '');
+  const summary = event.summary ?? '';
+  const hasNonSystemToFold = messages.some(
+    (entry) => !isContextSystemEntry(entry) || entryHasNonSystemPart(entry),
+  );
+  if (summary === '' && !hasNonSystemToFold) return messages;
   const folded: unknown[] = [];
-  let remaining = event.replaced_message_count;
-  let inserted = false;
   for (const entry of messages) {
-    if (isContextSystemEntry(entry)) {
-      folded.push(entry);
-      continue;
-    }
-    if (remaining > 0) {
-      remaining -= 1;
-      if (!inserted) {
-        folded.push(summary);
-        inserted = true;
-      }
-      continue;
-    }
-    folded.push(entry);
+    if (isContextSystemEntry(entry)) folded.push(rebuildSystemOnly(entry));
   }
+  folded.push(buildSummaryEntry(summary));
   return folded;
 }
 
@@ -364,8 +387,8 @@ export function contextMatch(msg: AkgenticMessage): boolean {
  * Incremental per-message reducer for the `context` store — the client-side
  * ordered fold of the same event log the backend folds (`ContextManager`):
  *   - `LlmMessageEvent`          → append the inner `message` (fresh array).
- *   - `LlmContextCompactedEvent` → `foldContextCompaction` (drop prefix + insert
- *                                  summary), mirroring `compact` (ADR-010 §4).
+ *   - `LlmContextCompactedEvent` → `foldContextCompaction` (full-fold to
+ *                                  `[system parts] + [summary]`, ADR-010 §9).
  *   - `LlmContextClearedEvent`   → reset to `[]`, mirroring `clear_context` (§8).
  *   - anything else              → passthrough `prev`.
  * The synthetic summary is derivable from the event (the backend emits no


### PR DESCRIPTION
## Story 29-3 — Mirror full-fold + part-level compaction in the Member context store

Reworks the per-agent Member `context` fold (`per-agent-specs.ts`) from the count-based / message-level shape Story 29-2 produced to the **post-12-7 backend** shape (akgentic-llm, ADR-010 §9): a `/compact` now full-folds the entire non-system conversation into one summary, so the Member trace shows `[system parts] + [one summary]` — no fused `[Operator action] "/clear" …` head and no verbatim Q/A tail.

### What changed
- **`foldContextCompaction`** rewritten to full-fold + part-level: every system-bearing entry is rebuilt keeping **only** its `system-prompt` parts (`rebuildSystemOnly`); every entry with no system part is dropped; exactly one synthetic summary is appended after the system head. `replaced_message_count` is observability-only.
- **Part-level helpers** replace the message-level `isContextSystemEntry`: `entryParts`, `isSystemPart`, `isContextSystemEntry`, `entryHasNonSystemPart`, `rebuildSystemOnly`. The fused `[Operator action] "/clear" …` `UserPromptPart` is folded away, not kept.
- **No-op guard**: empty `summary` **and** no non-system content to fold returns the same input reference (OnPush). Fresh array on every real fold.
- **Sequential composition** emerges from the new fold with no reducer change (`summary1` is an ordinary non-system entry, dropped by fold-2).
- `contextMatch` / `contextReduce` / clear / append and the `tokenUsage` store are **unchanged**.
- **Render**: no component change — `updateContext` already skips `system-prompt` parts and strips `CONVERSATION_SUMMARY_PREFIX` into a "Summary" row. The 29-2 render test was reworked into the 29-3 full-fold render regression.

### Quality gates (local — authoritative)
- Karma: 1167 SUCCESS (headless, ChromeHeadlessNoSandbox)
- `npm run lint`: clean
- Production build: OK (pre-existing lodash CommonJS warning only)

### Review
Reviewed by Rex (adversarial code review). Implementation is faithful to ADR-010 §9; all 10 ACs verified; OnPush semantics correct; no `ADR-NNN` test assertions; all changes scoped to `packages/akgentic-frontend/`. No HIGH/MEDIUM findings — no fixup commit required.

Closes #209
