### PR TITLE
feat(akgentic-frontend): epic 30 — Surface Prompt-Cache Tokens in the Token-Usage Model & Displays (30-1-cache-token-data-layer-and-true-context-window -> 30-2-usage-popovers-member-chat-and-team-tree)

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -140,30 +140,71 @@
       </ng-template>
       <div class="input-row-buttons">
         <!--
-          ADR-022 §Decision 5 — non-interactive token-usage pill, first child of
-          `.input-row-buttons` (left of Submit). Bound to
-          `tokenUsageSelector.perAgent$(agentId) | async`: a defined usage renders
-          `ctx <ctx> · ↑<sent> ↓<received>` (every number via `tokenCount`); a
-          never-run agent (`undefined`) renders the neutral `ctx — · ↑0 ↓0`
-          empty-state (the VIEW owns the empty-state, ADR-022 §OQ2). A native
-          `title` tooltip spells out the words + model, degrading to "No usage
-          yet" when never-run. Non-interactive `<span>` — no click, no routerLink.
+          ADR-024 §Decision 3 — interactive token-usage trigger, first child of
+          `.input-row-buttons` (left of Submit); supersedes ADR-022 §Decision 5's
+          non-interactive `[title]` pill. Bound to
+          `tokenUsageSelector.perAgent$(agentId) | async` ONCE via `*ngIf ... as
+          usage`: a defined usage renders a keyboard-focusable `<button>` —
+          `ctx <ctx> · ↑<sent> ↓<received>` (every number via `tokenCount`) plus a
+          `⚡` glyph when any cache tokens were used — that toggles
+          `<p-popover #usageOp>` with the full breakdown (model, true context
+          window with the fresh/cached split, sent/received, cache read/write, all
+          via the exact `| number` pipe). A never-run agent (`undefined`) renders
+          the neutral `ctx — · ↑0 ↓0` with the trigger DISABLED — inert, no
+          popover to open (the VIEW owns the empty-state, ADR-022 §OQ2).
         -->
-        <span
-          *ngIf="usage$ | async as usage; else emptyPill"
-          class="usage-pill"
-          [title]="
-            'Context window ' + (usage.lastContextWindow | number) +
-            ' · Sent ' + (usage.totalSent | number) +
-            ' · Received ' + (usage.totalReceived | number) +
-            ' · ' + usage.lastModelName
-          "
-        >
-          ctx {{ usage.lastContextWindow | tokenCount }} ·
-          ↑{{ usage.totalSent | tokenCount }} ↓{{ usage.totalReceived | tokenCount }}
-        </span>
+        <ng-container *ngIf="usage$ | async as usage; else emptyPill">
+          <button
+            type="button"
+            class="usage-pill"
+            [attr.aria-label]="
+              'Token usage: context window ' + (usage.lastContextWindow | number) +
+              ', sent ' + (usage.totalSent | number) +
+              ', received ' + (usage.totalReceived | number) +
+              ', model ' + usage.lastModelName
+            "
+            (click)="usageOp.toggle($event)"
+          >
+            ctx {{ usage.lastContextWindow | tokenCount }} ·
+            ↑{{ usage.totalSent | tokenCount }} ↓{{ usage.totalReceived | tokenCount }}
+            <span *ngIf="usage.totalCacheRead + usage.totalCacheWrite > 0">⚡</span>
+          </button>
+          <p-popover #usageOp>
+            <div class="usage-popover">
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Model</span>
+                <span>{{ usage.lastModelName }}</span>
+              </div>
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Context window</span>
+                <span>
+                  {{ usage.lastContextWindow | number }} of which
+                  {{ usage.lastCacheRead + usage.lastCacheWrite | number }} cached
+                </span>
+              </div>
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Sent</span>
+                <span>{{ usage.totalSent | number }}</span>
+              </div>
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Received</span>
+                <span>{{ usage.totalReceived | number }}</span>
+              </div>
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Cache read</span>
+                <span>{{ usage.lastCacheRead | number }} / {{ usage.totalCacheRead | number }}</span>
+              </div>
+              <div class="usage-popover-row">
+                <span class="usage-popover-label">Cache write</span>
+                <span>{{ usage.lastCacheWrite | number }} / {{ usage.totalCacheWrite | number }}</span>
+              </div>
+            </div>
+          </p-popover>
+        </ng-container>
         <ng-template #emptyPill>
-          <span class="usage-pill" title="No usage yet">ctx — · ↑0 ↓0</span>
+          <button type="button" class="usage-pill" aria-label="No token usage yet" disabled>
+            ctx — · ↑0 ↓0
+          </button>
         </ng-template>
         <button
           pButton

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -163,6 +163,8 @@
               ', received ' + (usage.totalReceived | number) +
               ', model ' + usage.lastModelName
             "
+            aria-haspopup="dialog"
+            [attr.aria-expanded]="usageOp.overlayVisible"
             (click)="usageOp.toggle($event)"
           >
             ctx {{ usage.lastContextWindow | tokenCount }} ·

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.scss
@@ -28,25 +28,55 @@
       font-size: 1rem;
     }
 
-    // ADR-022 §Decision 5 — token-usage pill: compact, muted, non-interactive.
-    // Visually subordinate to Submit (small, muted). `white-space: nowrap`
-    // keeps `ctx … · ↑… ↓…` on one line; `default` cursor signals it is not a
-    // control. Shrinks before Submit at narrow widths so it never pushes the
-    // button off the row.
+    // ADR-024 §Decision 3 — token-usage trigger: compact, muted, but now an
+    // interactive `<button>` (supersedes ADR-022 §Decision 5's non-interactive
+    // pill). `white-space: nowrap` keeps `ctx … · ↑… ↓…` on one line; the button
+    // reset (border/font/background) keeps the visual weight subordinate to
+    // Submit. Shrinks before Submit at narrow widths so it never pushes the
+    // button off the row. `:disabled` (never-run agent, AC 3) reverts to the
+    // `default` cursor — inert, nothing to open.
     .usage-pill {
       flex: 0 1 auto;
       min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      cursor: default;
+      border: none;
+      font: inherit;
+      cursor: pointer;
       color: #64748b;
       font-size: 0.75rem;
       font-variant-numeric: tabular-nums;
       padding: 0.15rem 0.5rem;
       border-radius: 999px;
       background-color: #f1f5f9;
+
+      &:disabled {
+        cursor: default;
+      }
     }
+  }
+}
+
+// ADR-024 §Decision 3 — the popover's key/value breakdown (member-chat pill and
+// team-tree footer share this layout). Exact counts via `| number`; the pill/
+// footer keep the compact `tokenCount` numbers.
+.usage-popover {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  min-width: 14rem;
+
+  .usage-popover-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .usage-popover-label {
+    color: #64748b;
+    font-weight: 600;
   }
 }
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1152,7 +1152,7 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     return (pill(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
 
-  it('(a) renders left of Submit inside `.input-row-buttons` with the populated `ctx … · ↑… ↓…` format', () => {
+  it('(a) renders left of Submit inside `.input-row-buttons` with the populated `ctx … · ↑… ↓…` format, as an interactive trigger', () => {
     const { fixture } = setup(
       usage({
         lastContextWindow: 12_300,
@@ -1169,19 +1169,21 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     // The pill is the FIRST child of the buttons row, and Submit comes after it.
     const row = buttonsRow(fixture);
     expect(row.firstElementChild?.classList.contains('usage-pill')).toBeTrue();
-    const children = Array.from(row.children);
-    const pillIdx = children.findIndex((c) => c.classList.contains('usage-pill'));
-    const submitIdx = children.findIndex((c) => c.tagName.toLowerCase() === 'button');
+    const buttons = Array.from(row.querySelectorAll('button'));
+    const pillIdx = buttons.findIndex((b) => b.classList.contains('usage-pill'));
+    const submitIdx = buttons.findIndex((b) => !b.classList.contains('usage-pill'));
     expect(pillIdx).toBeLessThan(submitIdx);
 
-    // Non-interactive: a <span>, not a <button>, no routerLink.
+    // ADR-024 §Decision 3 — interactive: a keyboard-focusable <button>, not a
+    // <span>, enabled (there is a popover to open).
     const p = pill(fixture)!;
-    expect(p.tagName.toLowerCase()).toBe('span');
-    expect(p.getAttribute('href')).toBeNull();
+    expect(p.tagName.toLowerCase()).toBe('button');
+    expect(p.hasAttribute('disabled')).toBeFalse();
 
-    // Tooltip spells out the words + model (full grouped numbers).
-    expect(p.getAttribute('title')).toBe(
-      'Context window 12,300 · Sent 45,000 · Received 12,100 · gpt-4o',
+    // aria-label spells out the words + model (full grouped numbers) — the
+    // trigger no longer relies on a non-interactive `title` tooltip.
+    expect(p.getAttribute('aria-label')).toBe(
+      'Token usage: context window 12,300, sent 45,000, received 12,100, model gpt-4o',
     );
   });
 
@@ -1202,15 +1204,16 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     expect(pillText(fixture)).toBe('ctx 8.0k · ↑38.0k ↓11.5k');
   });
 
-  it('(c) never-run agent (`perAgent$` emits undefined) renders the neutral `ctx — · ↑0 ↓0` empty-state', () => {
+  it('(c) never-run agent (`perAgent$` emits undefined) renders the neutral `ctx — · ↑0 ↓0` empty-state with an inert (disabled) trigger', () => {
     const { fixture } = setup(undefined);
     fixture.detectChanges();
 
     expect(pillText(fixture)).toBe('ctx — · ↑0 ↓0');
-    // Still non-interactive, and its tooltip must not render undefined/null.
+    // AC 3 — the trigger is a <button>, DISABLED: no popover to open.
     const p = pill(fixture)!;
-    expect(p.tagName.toLowerCase()).toBe('span');
-    expect(p.getAttribute('title')).toBe('No usage yet');
+    expect(p.tagName.toLowerCase()).toBe('button');
+    expect(p.hasAttribute('disabled')).toBeTrue();
+    expect(p.getAttribute('aria-label')).toBe('No token usage yet');
   });
 
   it('the pill follows an agent switch (perAgent$ re-bound in ngOnChanges)', () => {
@@ -1236,7 +1239,11 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     );
     fixture.detectChanges();
 
-    const submit = buttonsRow(fixture).querySelector('button') as HTMLButtonElement;
+    // The usage pill is ALSO a <button> now (ADR-024 §Decision 3) — exclude it
+    // to find Submit specifically.
+    const submit = buttonsRow(fixture).querySelector(
+      'button:not(.usage-pill)',
+    ) as HTMLButtonElement;
     // Empty input → Submit disabled (existing rule unchanged).
     expect(submit.disabled).toBeTrue();
 
@@ -1244,6 +1251,190 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     component.userInput = 'hello';
     fixture.detectChanges();
     expect(submit.disabled).toBeFalse();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 30-2 (ADR-024 §Decision 3) — the pill becomes an interactive trigger
+// for a `<p-popover>` carrying the full cache breakdown (model, true context
+// window with the fresh/cached split, sent/received, cache read/write). Driven
+// through the same fake `TokenUsageSelector` pattern as Story 26-2: a
+// controllable `usage$` BehaviorSubject makes glyph / toggle / live-update /
+// empty-state deterministic. `p-popover` renders in place (no `appendTo`
+// override) so its content is queryable straight off `fixture.nativeElement`.
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
+  const AGENT = 'a-mgr';
+
+  function usage(partial: Partial<AgentTokenUsage>): AgentTokenUsage {
+    return {
+      lastContextWindow: 0,
+      lastRunId: 'run-1',
+      lastModelName: 'gpt-4o',
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
+      ...partial,
+    };
+  }
+
+  function setup(initial: AgentTokenUsage | undefined): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    usage$: BehaviorSubject<AgentTokenUsage | undefined>;
+  } {
+    const usage$ = new BehaviorSubject<AgentTokenUsage | undefined>(initial);
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: new BehaviorSubject<boolean>(true),
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        {
+          provide: TokenUsageSelector,
+          useValue: {
+            perAgent$: (_id: string) => usage$.asObservable(),
+          },
+        },
+        provideNoopAnimations(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, usage$ };
+  }
+
+  function pill(fixture: ComponentFixture<AkgentChatComponent>): HTMLButtonElement {
+    return (fixture.nativeElement as HTMLElement).querySelector(
+      '.usage-pill',
+    ) as HTMLButtonElement;
+  }
+
+  /** Each `.usage-popover-row`'s two cells joined with a single space (e.g.
+   *  "Cache read 4,000 / 9,000") — empty array when the popover isn't open. */
+  function popoverRows(fixture: ComponentFixture<AkgentChatComponent>): string[] {
+    const rows = (fixture.nativeElement as HTMLElement).querySelectorAll(
+      '.usage-popover-row',
+    );
+    return Array.from(rows).map((row) =>
+      Array.from(row.children)
+        .map((c) => (c.textContent ?? '').trim())
+        .join(' '),
+    );
+  }
+
+  it('shows the ⚡ glyph when cache tokens were used', () => {
+    const { fixture } = setup(usage({ totalCacheRead: 500, totalCacheWrite: 0 }));
+    fixture.detectChanges();
+    expect(pill(fixture).textContent).toContain('⚡');
+  });
+
+  it('shows no glyph when both cache totals are 0', () => {
+    const { fixture } = setup(usage({ totalCacheRead: 0, totalCacheWrite: 0 }));
+    fixture.detectChanges();
+    expect(pill(fixture).textContent).not.toContain('⚡');
+  });
+
+  it('clicking the trigger toggles open the popover with Model / Context-window-split / Sent / Received / Cache read+write', () => {
+    const { fixture } = setup(
+      usage({
+        lastContextWindow: 12_300,
+        lastCacheRead: 4_000,
+        lastCacheWrite: 300,
+        totalSent: 45_000,
+        totalReceived: 12_100,
+        totalCacheRead: 9_000,
+        totalCacheWrite: 300,
+        lastModelName: 'claude-opus-4-8',
+      }),
+    );
+    fixture.detectChanges();
+
+    // No popover content before the trigger is clicked.
+    expect(popoverRows(fixture)).toEqual([]);
+
+    pill(fixture).click();
+    fixture.detectChanges();
+
+    const rows = popoverRows(fixture);
+    expect(rows).toContain('Model claude-opus-4-8');
+    expect(rows).toContain('Context window 12,300 of which 4,300 cached');
+    expect(rows).toContain('Sent 45,000');
+    expect(rows).toContain('Received 12,100');
+    expect(rows).toContain('Cache read 4,000 / 9,000');
+    expect(rows).toContain('Cache write 300 / 300');
+  });
+
+  it('popover content updates live when usage$ re-emits a new value (no re-toggle needed)', () => {
+    const { fixture, usage$ } = setup(
+      usage({
+        lastContextWindow: 1_000,
+        totalSent: 1_000,
+        totalReceived: 200,
+      }),
+    );
+    fixture.detectChanges();
+    pill(fixture).click();
+    fixture.detectChanges();
+    expect(popoverRows(fixture)).toContain('Context window 1,000 of which 0 cached');
+
+    usage$.next(
+      usage({
+        lastContextWindow: 9_000,
+        lastCacheRead: 3_000,
+        totalSent: 10_000,
+        totalReceived: 2_200,
+      }),
+    );
+    fixture.detectChanges();
+
+    expect(popoverRows(fixture)).toContain('Context window 9,000 of which 3,000 cached');
+    expect(popoverRows(fixture)).toContain('Sent 10,000');
+  });
+
+  it('empty-state (usage$ → undefined) renders a disabled trigger with no popover to open', () => {
+    const { fixture } = setup(undefined);
+    fixture.detectChanges();
+
+    const trigger = pill(fixture);
+    expect(trigger.disabled).toBeTrue();
+    expect(popoverRows(fixture)).toEqual([]);
   });
 });
 

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1386,8 +1386,11 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
     );
     fixture.detectChanges();
 
-    // No popover content before the trigger is clicked.
+    // No popover content before the trigger is clicked, and the trigger
+    // announces itself as a closed disclosure control to assistive tech.
     expect(popoverRows(fixture)).toEqual([]);
+    expect(pill(fixture).getAttribute('aria-haspopup')).toBe('dialog');
+    expect(pill(fixture).getAttribute('aria-expanded')).toBe('false');
 
     pill(fixture).click();
     fixture.detectChanges();
@@ -1399,6 +1402,8 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
     expect(rows).toContain('Received 12,100');
     expect(rows).toContain('Cache read 4,000 / 9,000');
     expect(rows).toContain('Cache write 300 / 300');
+    // aria-expanded flips once the popover is actually open.
+    expect(pill(fixture).getAttribute('aria-expanded')).toBe('true');
   });
 
   it('popover content updates live when usage$ re-emits a new value (no re-toggle needed)', () => {

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -433,14 +433,22 @@ describe('AkgentChatComponent — head system block (Story 16-2)', () => {
       systemPromptEnvelope(AGENT, [{ dynamic_ref: null, content: 'A backstory' }]),
       systemPromptEnvelope(OTHER, [{ dynamic_ref: null, content: 'B backstory' }]),
     ]);
+    // Route the INITIAL `agentId` bind through Angular's own input-change
+    // tracking too: `setup()` assigns `agentId` via a raw property write,
+    // which Ivy's `NgOnChangesFeature` never observes, so without this the
+    // upcoming switch would be mis-detected as the *first* change.
+    fixture.componentRef.setInput('agentId', AGENT);
     fixture.detectChanges();
     expect(headBodies(fixture)).toEqual(['A backstory']);
 
     // The agent-tabs dropdown REUSES this component when switching members, so
     // ngOnInit does not re-run — ngOnChanges must re-point systemPrompt$ at the
     // new agent. Without the fix the head block stays pinned to 'A backstory'.
-    component.agentId = OTHER;
-    component.ngOnChanges({ agentId: new SimpleChange(AGENT, OTHER, false) });
+    // Story 30-3 (OnPush): `fixture.componentRef.setInput(...)` — not a bare
+    // `component.ngOnChanges(...)` call — is what a real host rebind does; it
+    // both dispatches `ngOnChanges` AND marks the component dirty the way
+    // Angular's own `@Input` diff detection would.
+    fixture.componentRef.setInput('agentId', OTHER);
     fixture.detectChanges();
 
     expect(headBodies(fixture)).toEqual(['B backstory']);
@@ -1247,9 +1255,19 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
     // Empty input → Submit disabled (existing rule unchanged).
     expect(submit.disabled).toBeTrue();
 
-    // Typing enables it (team is running in this harness).
-    component.userInput = 'hello';
+    // Typing enables it (team is running in this harness). Story 30-3
+    // (OnPush): a bare `component.userInput = 'hello'` field write is not an
+    // `@Input`, DOM event, or async-pipe emission — it would never mark the
+    // component dirty. Dispatch a real native `input` event on the textarea,
+    // the way `[(ngModel)]="userInput"` actually updates in production; the
+    // event fires from the component's OWN template, so Angular marks it
+    // dirty automatically (no explicit markForCheck needed, per AC2).
+    const textarea: HTMLTextAreaElement =
+      fixture.nativeElement.querySelector('textarea');
+    textarea.value = 'hello';
+    textarea.dispatchEvent(new Event('input'));
     fixture.detectChanges();
+    expect(component.userInput).toBe('hello');
     expect(submit.disabled).toBeFalse();
   });
 });
@@ -1576,5 +1594,139 @@ describe('AkgentChatComponent — folded compaction summary (Story 29-3)', () =>
     expect(allText).not.toContain('verbatim question two');
     expect(allText).not.toContain('verbatim question three');
     expect(allText).not.toContain(CONVERSATION_SUMMARY_PREFIX);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 30-3 — component-level OnPush on the usage-display host components.
+// AkgentChatComponent now runs under `ChangeDetectionStrategy.OnPush`; the
+// writes below (the `context$` and `currentTeamRunning$` subscriptions in
+// `ngOnInit`) come from MANUAL RxJS subscriptions, not the `async` pipe, so
+// only an explicit `ChangeDetectorRef.markForCheck()` at each site keeps them
+// repainting. A plain repeated `fixture.detectChanges()` call — with NO
+// further `@Input` change and NO DOM event between the emission and the
+// assertion — genuinely exercises the OnPush + `markForCheck()` plumbing
+// (verified by temporarily removing each `markForCheck()` call and confirming
+// these tests fail — see Dev Agent Record). These tests deliberately avoid
+// `fakeAsync`'s `tick()` between the emission and the assertion: flushing the
+// fake-timer queue re-arms Angular's zone-driven auto-refresh scheduler,
+// which repaints the view regardless of `markForCheck()` and would silently
+// mask a missing call — confirmed empirically (see Dev Agent Record).
+// ---------------------------------------------------------------------------
+describe('AkgentChatComponent — OnPush regression (Story 30-3)', () => {
+  const AGENT = 'a-mgr';
+
+  function setup(): {
+    fixture: ComponentFixture<AkgentChatComponent>;
+    component: AkgentChatComponent;
+    running$: BehaviorSubject<boolean>;
+  } {
+    const running$ = new BehaviorSubject<boolean>(true);
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AkgentChatComponent],
+      providers: [
+        {
+          provide: ApiService,
+          useValue: {
+            sendMessage: jasmine.createSpy('sendMessage').and.resolveTo(undefined),
+          },
+        },
+        {
+          provide: UtilService,
+          useValue: { copyToClipboard: () => {}, formatJSON: (v: any) => v },
+        },
+        {
+          provide: ContextService,
+          useValue: {
+            currentTeamRunning$: running$,
+            currentProcessId$: new BehaviorSubject<string>('proc-1'),
+          },
+        },
+        MessageLogService,
+        PerAgentStoreRegistry,
+        {
+          provide: IngestionService,
+          useFactory: (registry: PerAgentStoreRegistry) => ({
+            commands: { snapshot: (_id: string) => undefined },
+            systemPrompt: registry.register<SystemPromptValue>({
+              name: 'systemPrompt',
+              match: systemPromptMatch,
+              reduce: systemPromptReduce,
+            }),
+          }),
+          deps: [PerAgentStoreRegistry],
+        },
+        SystemPromptSelector,
+        NEUTRAL_TOKEN_USAGE_SELECTOR,
+        provideNoopAnimations(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(AkgentChatComponent);
+    const component = fixture.componentInstance;
+    component.context$ = new BehaviorSubject<any[]>([]);
+    component.agentId = AGENT;
+    component.agentName = '@' + AGENT;
+    return { fixture, component, running$ };
+  }
+
+  /** Install a mock trace-scroll element with controllable geometry (mirrors
+   *  the "follow mode" describe block's helper above). */
+  function installScroll(
+    component: AkgentChatComponent,
+    scrollHeight: number,
+    clientHeight: number,
+    scrollTop = 0,
+  ): void {
+    (component as any).traceScroll = {
+      nativeElement: {
+        scrollHeight,
+        clientHeight,
+        scrollTop,
+        scrollTo(o: { top: number }) {
+          this.scrollTop = o.top;
+        },
+      },
+    };
+  }
+
+  it('AC4: a mid-stream context$ emission (no @Input change, no DOM event) renders an added trace row', fakeAsync(() => {
+    const { fixture, component } = setup();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('first reply');
+
+    // Pushing onto `context$` is NOT an @Input *reference* change (it's the
+    // same BehaviorSubject instance) and not a DOM event — only the manual
+    // `ngOnInit` subscription + its `markForCheck()` can repaint this. Assert
+    // BEFORE flushing the pending post-render setTimeout (below) so this test
+    // isolates the subscription's OWN `markForCheck()` from the *different*
+    // AC2 site inside `updateContext()`'s trailing setTimeout.
+    component.context$.next([{ type: 'ai', name: 'x', content: 'first reply' }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('first reply');
+
+    tick(0); // flush the pending post-render setTimeout (fakeAsync requires it)
+  }));
+
+  it('AC4: a mid-stream currentTeamRunning$ emission (no @Input change, no DOM event) updates the status pill', () => {
+    const { fixture, component, running$ } = setup();
+    fixture.detectChanges();
+
+    installScroll(component, 2000, 500, 0); // newest message far below the fold
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector('.jump-to-latest'),
+    ).toBeNull();
+
+    // Emitting on `currentTeamRunning$` is NOT an @Input change and not a DOM
+    // event — only the manual `ngOnInit` subscription + its `markForCheck()`
+    // can repaint the pill.
+    running$.next(false); // process stops — following exits, pill recomputed
+    fixture.detectChanges();
+    const pill = (fixture.nativeElement as HTMLElement).querySelector(
+      '.jump-to-latest',
+    );
+    expect(pill?.textContent).toContain('Messages');
   });
 });

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1061,6 +1061,10 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
       lastModelName: 'gpt-4o',
       totalSent: 0,
       totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
       ...partial,
     };
   }

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -17,6 +17,7 @@ import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { FieldsetModule } from 'primeng/fieldset';
 import { FloatLabelModule } from 'primeng/floatlabel';
+import { PopoverModule } from 'primeng/popover';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { TableModule } from 'primeng/table';
 import { TextareaModule } from 'primeng/textarea';
@@ -61,6 +62,7 @@ import { CopyButtonComponent } from '../../../../../shared/components/copy-butto
     TextareaModule,
     FloatLabelModule,
     ButtonModule,
+    PopoverModule,
     ProgressSpinnerModule,
     MentionModule,
     CapitalizePipe,

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -1,4 +1,6 @@
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   inject,
@@ -71,6 +73,7 @@ import { CopyButtonComponent } from '../../../../../shared/components/copy-butto
   ],
   templateUrl: './akgent-chat.component.html',
   styleUrl: './akgent-chat.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AkgentChatComponent implements OnInit, OnChanges {
   // The single trace scroll region (head system block + conversation). Auto
@@ -101,6 +104,11 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   // this subtree, so the usage pill reads THIS team's per-agent totals.
   private tokenUsageSelector: TokenUsageSelector = inject(TokenUsageSelector);
   private destroyRef = inject(DestroyRef);
+  // Story 30-3 — OnPush: the component's template-bound state is also mutated
+  // from manual RxJS subscriptions and setTimeout continuations (below), none
+  // of which Angular re-checks automatically under OnPush. markForCheck() at
+  // each such site keeps those paths repainting.
+  private cdr = inject(ChangeDetectorRef);
 
   context: any[] = [];
 
@@ -163,6 +171,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
         const el = this.traceScroll?.nativeElement;
         if (el) el.scrollTop = 0;
         this.updateIndicator();
+        this.cdr.markForCheck();
       }, 0);
     }
   }
@@ -180,6 +189,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     this.context$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((ctx) => {
       this.isLoading = false;
       this.updateContext(ctx);
+      this.cdr.markForCheck();
     });
 
     // "Auto scrolling" only applies to a RUNNING process — exit follow + refresh
@@ -189,6 +199,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
       .subscribe((running) => {
         if (!running) this.following = false;
         this.updateIndicator();
+        this.cdr.markForCheck();
       });
   }
 
@@ -477,6 +488,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     setTimeout(() => {
       if (this.following) this.scrollToBottom();
       this.updateIndicator();
+      this.cdr.markForCheck();
     }, 0);
   }
 
@@ -497,10 +509,14 @@ export class AkgentChatComponent implements OnInit, OnChanges {
       );
     } catch (error) {
       this.isLoading = false;
+      this.cdr.markForCheck();
     }
+    // Resumes in a later task after the `await` — the originating click
+    // event's CD pass has already closed, so mark explicitly.
     this.userInput = '';
     this.scrollToBottom();
     this.updateIndicator();
+    this.cdr.markForCheck();
   }
 
   /** Stable row identity for the trace table. Without it, p-table is given a

--- a/src/app/components/process/components/team-tabs/tree/tree.component.html
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.html
@@ -52,6 +52,8 @@
         totals.totalCacheRead === 0 &&
         totals.totalCacheWrite === 0
       "
+      aria-haspopup="dialog"
+      [attr.aria-expanded]="teamUsageOp.overlayVisible"
       (click)="teamUsageOp.toggle($event)"
     >
       Team total ↑{{ totals.totalSent | tokenCount }} ↓{{

--- a/src/app/components/process/components/team-tabs/tree/tree.component.html
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.html
@@ -27,15 +27,50 @@
       </ng-template>
     </p-tree>
   </div>
-  <!-- Epic 26 (ADR-022 §Decision 6): team-wide token total. ↑ = sent = Σ input;
-       ↓ = received = Σ output. Always rendered (empty team → ↑0 ↓0). -->
-  <div
-    *ngIf="teamTotals$ | async as totals"
-    class="team-total-footer"
-  >
-    Team total ↑{{ totals.totalSent | tokenCount }} ↓{{
-      totals.totalReceived | tokenCount
-    }}
-  </div>
+  <!--
+    ADR-024 §Decision 3 — team-wide token-usage trigger, same interactive
+    treatment as the member-chat pill (supersedes ADR-022 §Decision 6's
+    non-interactive footer). ↑ = sent = Σ input; ↓ = received = Σ output.
+    `teamTotals$` NEVER emits `undefined` (`sumTotals` always returns a
+    zero-filled object for an empty team) — the "no data" case here is
+    ALL-ZERO totals, not a missing value, so the trigger is disabled when every
+    total is `0` rather than gated on an `undefined` branch. Toggles its OWN
+    `<p-popover>` (independent of the member-chat one) breaking down the
+    team-wide cache read/write.
+  -->
+  <ng-container *ngIf="teamTotals$ | async as totals">
+    <button
+      type="button"
+      class="team-total-footer"
+      [attr.aria-label]="
+        'Team token usage: sent ' + (totals.totalSent | number) +
+        ', received ' + (totals.totalReceived | number)
+      "
+      [disabled]="
+        totals.totalSent === 0 &&
+        totals.totalReceived === 0 &&
+        totals.totalCacheRead === 0 &&
+        totals.totalCacheWrite === 0
+      "
+      (click)="teamUsageOp.toggle($event)"
+    >
+      Team total ↑{{ totals.totalSent | tokenCount }} ↓{{
+        totals.totalReceived | tokenCount
+      }}
+      <span *ngIf="totals.totalCacheRead + totals.totalCacheWrite > 0">⚡</span>
+    </button>
+    <p-popover #teamUsageOp>
+      <div class="usage-popover">
+        <div class="usage-popover-row">
+          <span class="usage-popover-label">Cache read</span>
+          <span>{{ totals.totalCacheRead | number }}</span>
+        </div>
+        <div class="usage-popover-row">
+          <span class="usage-popover-label">Cache write</span>
+          <span>{{ totals.totalCacheWrite | number }}</span>
+        </div>
+      </div>
+    </p-popover>
+  </ng-container>
   <app-human-request [nodes]="nodes"></app-human-request>
 </div>

--- a/src/app/components/process/components/team-tabs/tree/tree.component.scss
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.scss
@@ -12,18 +12,50 @@
   flex: 1;
 }
 
-// Epic 26 (ADR-022 §Decision 6): slim, muted, non-interactive team-total strip.
-// Muted colour matches the member-chat usage pill (Story 26.2); tabular-nums
-// keeps the digits steady on live update.
+// ADR-024 §Decision 3: slim, muted team-total strip — now an interactive
+// `<button>` (supersedes ADR-022 §Decision 6's non-interactive footer). Muted
+// colour matches the member-chat usage pill (Story 30-2); tabular-nums keeps
+// the digits steady on live update. `:disabled` (empty team, AC 6) reverts to
+// the `default` cursor — inert, nothing to open.
 .team-total-footer {
   flex: 0 0 auto;
+  width: 100%;
   padding: 4px 8px;
+  border: none;
   border-top: 1px solid #e2e8f0;
+  font: inherit;
   font-size: 0.8rem;
   color: #64748b;
+  text-align: left;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
-  cursor: default;
+  background: none;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+// ADR-024 §Decision 3 — the popover's key/value breakdown, shared layout with
+// the member-chat pill's popover (akgent-chat.component.scss).
+.usage-popover {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  min-width: 14rem;
+
+  .usage-popover-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .usage-popover-label {
+    color: #64748b;
+    font-weight: 600;
+  }
 }
 
 .human-node {

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -45,7 +45,12 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
   }
 
   function setup(
-    initial: TeamTokenTotals = { totalSent: 0, totalReceived: 0 },
+    initial: TeamTokenTotals = {
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    },
   ): ComponentFixture<TreeComponent> {
     totals$ = new BehaviorSubject<TeamTokenTotals>(initial);
     nodes$ = new BehaviorSubject<NodeInterface[]>([]);
@@ -107,7 +112,12 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
   }
 
   it('(a) renders the populated `Team total ↑X ↓Y` BETWEEN the tree and app-human-request', () => {
-    const fixture = setup({ totalSent: 57_000, totalReceived: 12_500 });
+    const fixture = setup({
+      totalSent: 57_000,
+      totalReceived: 12_500,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     fixture.detectChanges();
 
     // tokenCount: 57_000 → "57.0k", 12_500 → "12.5k".
@@ -138,19 +148,34 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
   });
 
   it('(b) live update: a fresh `teamTotals$` emission re-renders the ↑/↓ sums', () => {
-    const fixture = setup({ totalSent: 1_000, totalReceived: 200 });
+    const fixture = setup({
+      totalSent: 1_000,
+      totalReceived: 200,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     fixture.detectChanges();
     expect(footerText(fixture)).toBe('Team total ↑1.0k ↓200');
 
     // A new LlmUsageEvent landed for some agent → the selector re-emits a larger
     // structural sum; the async pipe re-renders without any imperative refresh.
-    totals$.next({ totalSent: 73_400, totalReceived: 18_900 });
+    totals$.next({
+      totalSent: 73_400,
+      totalReceived: 18_900,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     fixture.detectChanges();
     expect(footerText(fixture)).toBe('Team total ↑73.4k ↓18.9k');
   });
 
   it('(c) empty team (`{0,0}`) renders the `Team total ↑0 ↓0` fallback', () => {
-    const fixture = setup({ totalSent: 0, totalReceived: 0 });
+    const fixture = setup({
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     fixture.detectChanges();
 
     // The zero-totals object IS the empty state — the footer is still rendered.
@@ -159,7 +184,12 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
   });
 
   it('(d) resolves the SHARED selector instance (no self-provider) and leaves the tree behavior intact', () => {
-    const fixture = setup({ totalSent: 100, totalReceived: 50 });
+    const fixture = setup({
+      totalSent: 100,
+      totalReceived: 50,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     const component = fixture.componentInstance;
 
     // The component must NOT re-provide TokenUsageSelector — it resolves the

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -111,7 +111,7 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     return (footer(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
 
-  it('(a) renders the populated `Team total ↑X ↓Y` BETWEEN the tree and app-human-request', () => {
+  it('(a) renders the populated `Team total ↑X ↓Y` as an interactive trigger, BETWEEN the tree and app-human-request', () => {
     const fixture = setup({
       totalSent: 57_000,
       totalReceived: 12_500,
@@ -123,9 +123,11 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     // tokenCount: 57_000 → "57.0k", 12_500 → "12.5k".
     expect(footerText(fixture)).toBe('Team total ↑57.0k ↓12.5k');
 
-    // Non-interactive: a <div>, not a <button>; no click handler / routerLink.
+    // ADR-024 §Decision 3 — interactive: a keyboard-focusable <button>, enabled
+    // (there's usage, so there's a popover to open).
     const f = footer(fixture)!;
-    expect(f.tagName.toLowerCase()).toBe('div');
+    expect(f.tagName.toLowerCase()).toBe('button');
+    expect((f as HTMLButtonElement).disabled).toBeFalse();
 
     // DOM order: footer AFTER the tree region, BEFORE app-human-request, all
     // direct children of `.tree-component-container`.
@@ -169,7 +171,7 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     expect(footerText(fixture)).toBe('Team total ↑73.4k ↓18.9k');
   });
 
-  it('(c) empty team (`{0,0}`) renders the `Team total ↑0 ↓0` fallback', () => {
+  it('(c) empty team (`{0,0}`) renders the `Team total ↑0 ↓0` fallback with an inert (disabled) trigger', () => {
     const fixture = setup({
       totalSent: 0,
       totalReceived: 0,
@@ -178,9 +180,11 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     });
     fixture.detectChanges();
 
-    // The zero-totals object IS the empty state — the footer is still rendered.
+    // The zero-totals object IS the empty state — the footer is still rendered,
+    // but AC 6 disables it: no usage yet, nothing to open.
     expect(footer(fixture)).not.toBeNull();
     expect(footerText(fixture)).toBe('Team total ↑0 ↓0');
+    expect((footer(fixture) as unknown as HTMLButtonElement).disabled).toBeTrue();
   });
 
   it('(d) resolves the SHARED selector instance (no self-provider) and leaves the tree behavior intact', () => {
@@ -212,5 +216,163 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
 
     component.onNodeClick({ node: { data: makeNode('a-mgr') } });
     expect(handleSelection).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 30-2 (ADR-024 §Decision 3) — the team-tree footer becomes an
+// interactive trigger for its OWN `<p-popover>` breaking down the team-wide
+// cache read/write. Same fake-selector pattern as Story 26-3: a controllable
+// `totals$` BehaviorSubject makes glyph / toggle / live-update / empty-state
+// deterministic. `p-popover` renders in place (no `appendTo` override) so its
+// content is queryable straight off `fixture.nativeElement`.
+// ---------------------------------------------------------------------------
+describe('TreeComponent — team-total popover (Story 30-2)', () => {
+  let totals$: BehaviorSubject<TeamTokenTotals>;
+  let nodes$: BehaviorSubject<NodeInterface[]>;
+
+  function setup(
+    initial: TeamTokenTotals = {
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    },
+  ): ComponentFixture<TreeComponent> {
+    totals$ = new BehaviorSubject<TeamTokenTotals>(initial);
+    nodes$ = new BehaviorSubject<NodeInterface[]>([]);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TreeComponent],
+      providers: [
+        {
+          provide: TokenUsageSelector,
+          useValue: {
+            teamTotals$: totals$.asObservable(),
+            perAgent$: (_id: string) => of(undefined),
+          },
+        },
+        {
+          provide: GraphDataService,
+          useValue: {
+            nodes$,
+            edges$: new BehaviorSubject<unknown[]>([]),
+            categories$: new BehaviorSubject<unknown[]>([]),
+            categoryService: { COLORS: ['#fff', '#000'] },
+            set isLoading(_v: boolean) {
+              /* swallowed — buildTree side effect, irrelevant to the footer */
+            },
+          },
+        },
+        {
+          provide: SelectionService,
+          useValue: {
+            handleSelection: jasmine.createSpy('handleSelection'),
+            userRequest$: new BehaviorSubject<unknown>({}),
+            modalVisible$: new BehaviorSubject<boolean>(false),
+            onSave: jasmine.createSpy('onSave'),
+          },
+        },
+        { provide: ApiService, useValue: {} },
+        provideNoopAnimations(),
+      ],
+    });
+
+    return TestBed.createComponent(TreeComponent);
+  }
+
+  function footer(fixture: ComponentFixture<TreeComponent>): HTMLButtonElement {
+    return (fixture.nativeElement as HTMLElement).querySelector(
+      '.team-total-footer',
+    ) as HTMLButtonElement;
+  }
+
+  /** Each `.usage-popover-row`'s two cells joined with a single space (e.g.
+   *  "Cache read 4,000") — empty array when the popover isn't open. */
+  function popoverRows(fixture: ComponentFixture<TreeComponent>): string[] {
+    const rows = (fixture.nativeElement as HTMLElement).querySelectorAll(
+      '.usage-popover-row',
+    );
+    return Array.from(rows).map((row) =>
+      Array.from(row.children)
+        .map((c) => (c.textContent ?? '').trim())
+        .join(' '),
+    );
+  }
+
+  it('shows the ⚡ glyph when team cache tokens were used', () => {
+    const fixture = setup({
+      totalSent: 1_000,
+      totalReceived: 200,
+      totalCacheRead: 500,
+      totalCacheWrite: 0,
+    });
+    fixture.detectChanges();
+    expect(footer(fixture).textContent).toContain('⚡');
+  });
+
+  it('shows no glyph when both team cache totals are 0', () => {
+    const fixture = setup({
+      totalSent: 1_000,
+      totalReceived: 200,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
+    fixture.detectChanges();
+    expect(footer(fixture).textContent).not.toContain('⚡');
+  });
+
+  it('clicking the trigger toggles open the popover with team-wide Cache read / Cache write', () => {
+    const fixture = setup({
+      totalSent: 57_000,
+      totalReceived: 12_500,
+      totalCacheRead: 9_000,
+      totalCacheWrite: 1_200,
+    });
+    fixture.detectChanges();
+
+    // No popover content before the trigger is clicked.
+    expect(popoverRows(fixture)).toEqual([]);
+
+    footer(fixture).click();
+    fixture.detectChanges();
+
+    const rows = popoverRows(fixture);
+    expect(rows).toContain('Cache read 9,000');
+    expect(rows).toContain('Cache write 1,200');
+  });
+
+  it('popover content updates live when teamTotals$ re-emits a new value (no re-toggle needed)', () => {
+    const fixture = setup({
+      totalSent: 1_000,
+      totalReceived: 200,
+      totalCacheRead: 300,
+      totalCacheWrite: 0,
+    });
+    fixture.detectChanges();
+    footer(fixture).click();
+    fixture.detectChanges();
+    expect(popoverRows(fixture)).toContain('Cache read 300');
+
+    totals$.next({
+      totalSent: 5_000,
+      totalReceived: 900,
+      totalCacheRead: 4_400,
+      totalCacheWrite: 250,
+    });
+    fixture.detectChanges();
+
+    expect(popoverRows(fixture)).toContain('Cache read 4,400');
+    expect(popoverRows(fixture)).toContain('Cache write 250');
+  });
+
+  it('empty team (all-zero totals) renders a disabled trigger with no popover to open', () => {
+    const fixture = setup();
+    fixture.detectChanges();
+
+    const trigger = footer(fixture);
+    expect(trigger.disabled).toBeTrue();
+    expect(popoverRows(fixture)).toEqual([]);
   });
 });

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -332,8 +332,11 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
     });
     fixture.detectChanges();
 
-    // No popover content before the trigger is clicked.
+    // No popover content before the trigger is clicked, and the trigger
+    // announces itself as a closed disclosure control to assistive tech.
     expect(popoverRows(fixture)).toEqual([]);
+    expect(footer(fixture).getAttribute('aria-haspopup')).toBe('dialog');
+    expect(footer(fixture).getAttribute('aria-expanded')).toBe('false');
 
     footer(fixture).click();
     fixture.detectChanges();
@@ -341,6 +344,8 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
     const rows = popoverRows(fixture);
     expect(rows).toContain('Cache read 9,000');
     expect(rows).toContain('Cache write 1,200');
+    // aria-expanded flips once the popover is actually open.
+    expect(footer(fixture).getAttribute('aria-expanded')).toBe('true');
   });
 
   it('popover content updates live when teamTotals$ re-emits a new value (no re-toggle needed)', () => {

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -381,3 +381,98 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
     expect(popoverRows(fixture)).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story 30-3 — component-level OnPush on the usage-display host components.
+// TreeComponent now runs under `ChangeDetectionStrategy.OnPush`; the `nodes$`
+// subscription in `ngOnInit` mutates `treeNodes` (the critical path — it
+// rebuilds the visible `<p-tree>`) from a MANUAL RxJS subscription, not the
+// `async` pipe, so only an explicit `ChangeDetectorRef.markForCheck()` keeps
+// it repainting. A plain repeated `fixture.detectChanges()` call — with NO
+// further `@Input` change and NO DOM event between the emission and the
+// assertion — genuinely exercises the OnPush + `markForCheck()` plumbing
+// (verified by temporarily removing the `markForCheck()` call and confirming
+// this test fails — see Dev Agent Record). No `fakeAsync`/`tick()` here: the
+// `nodes$` subscription is fully synchronous, and flushing the fake-timer
+// queue would re-arm Angular's zone-driven auto-refresh scheduler, which
+// repaints the view regardless of `markForCheck()` — confirmed empirically
+// while designing the member-chat regression tests (see Dev Agent Record).
+// ---------------------------------------------------------------------------
+describe('TreeComponent — OnPush regression (Story 30-3)', () => {
+  let nodes$: BehaviorSubject<NodeInterface[]>;
+
+  function makeNode(name: string): NodeInterface {
+    return {
+      name,
+      role: 'Agent',
+      actorName: name,
+      parentId: '',
+      squadId: 's1',
+      symbol: 'roundRect',
+      category: 0,
+      userMessage: false,
+    };
+  }
+
+  function setup(): ComponentFixture<TreeComponent> {
+    nodes$ = new BehaviorSubject<NodeInterface[]>([]);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TreeComponent],
+      providers: [
+        {
+          provide: TokenUsageSelector,
+          useValue: {
+            teamTotals$: new BehaviorSubject<TeamTokenTotals>({
+              totalSent: 0,
+              totalReceived: 0,
+              totalCacheRead: 0,
+              totalCacheWrite: 0,
+            }),
+            perAgent$: (_id: string) => of(undefined),
+          },
+        },
+        {
+          provide: GraphDataService,
+          useValue: {
+            nodes$,
+            edges$: new BehaviorSubject<unknown[]>([]),
+            categories$: new BehaviorSubject<unknown[]>([]),
+            categoryService: { COLORS: ['#fff', '#000'] },
+            set isLoading(_v: boolean) {
+              /* swallowed — buildTree side effect, irrelevant to this test */
+            },
+          },
+        },
+        {
+          provide: SelectionService,
+          useValue: {
+            handleSelection: jasmine.createSpy('handleSelection'),
+            userRequest$: new BehaviorSubject<unknown>({}),
+            modalVisible$: new BehaviorSubject<boolean>(false),
+            onSave: jasmine.createSpy('onSave'),
+          },
+        },
+        { provide: ApiService, useValue: {} },
+        provideNoopAnimations(),
+      ],
+    });
+
+    return TestBed.createComponent(TreeComponent);
+  }
+
+  it('AC4: a mid-stream nodes$ emission (no @Input change, no DOM event) re-renders the tree node labels', () => {
+    const fixture = setup();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('a [Mgr]');
+
+    // A source emission on the injected service's observable — not an @Input,
+    // not a DOM event — only the manual `ngOnInit` subscription + its
+    // `markForCheck()` can repaint this.
+    nodes$.next([makeNode('a-mgr')]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('a [Mgr]');
+  });
+});

--- a/src/app/components/process/components/team-tabs/tree/tree.component.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { TreeNode } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
+import { PopoverModule } from 'primeng/popover';
 import { TabViewModule } from 'primeng/tabview';
 import { TextareaModule } from 'primeng/textarea';
 import { TreeModule } from 'primeng/tree';
@@ -30,6 +31,7 @@ import { EdgeInterface, NodeInterface } from '../../../models/types';
     DialogModule,
     FormsModule,
     ButtonModule,
+    PopoverModule,
     TabViewModule,
     TextareaModule,
     HumanRequestComponent,

--- a/src/app/components/process/components/team-tabs/tree/tree.component.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.ts
@@ -1,5 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, NgZone, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+  NgZone,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TreeNode } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -37,9 +45,13 @@ import { EdgeInterface, NodeInterface } from '../../../models/types';
     HumanRequestComponent,
     TokenCountPipe,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TreeComponent implements OnInit, OnDestroy {
   selectionService: SelectionService = inject(SelectionService);
+  // Story 30-3 — OnPush: the graph subscriptions below (ngOnInit) mutate
+  // template-bound state imperatively; markForCheck() keeps them repainting.
+  private cdr = inject(ChangeDetectorRef);
 
   // Epic 26 (ADR-022 §Decision 6): the team-wide token total shown in the
   // footer strip below the tree. Bare inject — resolves the SAME
@@ -70,14 +82,17 @@ export class TreeComponent implements OnInit, OnDestroy {
         this.nodes = nodes;
         this.treeNodes = this.buildTree(nodes);
         this.expandAll();
+        this.cdr.markForCheck();
       }
     );
     this.edgesSub = this.graphDataService.edges$.subscribe((updatedEdges) => {
       this.edges = updatedEdges;
+      this.cdr.markForCheck();
     });
     this.categoriesSub = this.graphDataService.categories$.subscribe(
       (updatedCats) => {
         this.categories = updatedCats;
+        this.cdr.markForCheck();
       }
     );
   }

--- a/src/app/components/process/event/per-agent-specs.spec.ts
+++ b/src/app/components/process/event/per-agent-specs.spec.ts
@@ -259,11 +259,15 @@ describe('tokenUsageSpec reducer (Epic 26 / ADR-022 §Decision 2-4)', () => {
       }),
     );
     expect(usage(service.tokenUsage, 'A')).toEqual({
-      lastContextWindow: 12_031,
+      lastContextWindow: 12_031, // no cache on this fixture — true window == input
       lastRunId: 'run-7',
       lastModelName: 'claude-opus',
       totalSent: 12_031,
       totalReceived: 412,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
   });
 
@@ -288,21 +292,105 @@ describe('tokenUsageSpec reducer (Epic 26 / ADR-022 §Decision 2-4)', () => {
       lastModelName: 'claude-haiku',
       totalSent: 1200, // 1000 + 200
       totalReceived: 150, // 100 + 50
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
   });
 
-  it('AC #6 multi-agent: independent entries; A never bleeds into B', () => {
+  it('AC #3/#4 cache-hit event: true lastContextWindow = input + cacheRead + cacheWrite, cache fields seeded', () => {
+    const { log, service } = configureBed();
+    log.append(
+      makeUsageEnvelope('A', {
+        run_id: 'run-8',
+        input_tokens: 500,
+        output_tokens: 60,
+        cache_read_tokens: 4_000,
+        cache_write_tokens: 1_000,
+      }),
+    );
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 5_500, // 500 + 4_000 + 1_000 — the TRUE prompt size
+      lastRunId: 'run-8',
+      lastModelName: 'claude-sonnet',
+      totalSent: 500,
+      totalReceived: 60,
+      totalCacheRead: 4_000,
+      totalCacheWrite: 1_000,
+      lastCacheRead: 4_000,
+      lastCacheWrite: 1_000,
+    });
+  });
+
+  it('AC #3 multi-event: sums cumulative cache totals and overwrites last-run cache with the newest event', () => {
     const { log, service } = configureBed();
     log.appendAll([
-      makeUsageEnvelope('A', { input_tokens: 100, output_tokens: 10 }),
-      makeUsageEnvelope('B', { input_tokens: 999, output_tokens: 88 }),
-      makeUsageEnvelope('A', { input_tokens: 5, output_tokens: 1 }),
+      makeUsageEnvelope('A', {
+        run_id: 'run-1',
+        input_tokens: 1_000,
+        output_tokens: 100,
+        cache_read_tokens: 200,
+        cache_write_tokens: 50,
+      }),
+      makeUsageEnvelope('A', {
+        run_id: 'run-2',
+        input_tokens: 300,
+        output_tokens: 40,
+        cache_read_tokens: 900,
+        cache_write_tokens: 0,
+      }),
+    ]);
+    expect(usage(service.tokenUsage, 'A')).toEqual({
+      lastContextWindow: 1_200, // 300 + 900 + 0 — newest event's true window
+      lastRunId: 'run-2',
+      lastModelName: 'claude-sonnet',
+      totalSent: 1_300,
+      totalReceived: 140,
+      totalCacheRead: 1_100, // 200 + 900
+      totalCacheWrite: 50, // 50 + 0
+      lastCacheRead: 900, // overwritten with the newest event
+      lastCacheWrite: 0, // overwritten with the newest event
+    });
+  });
+
+  it('AC #6 multi-agent: independent entries (including cache); A never bleeds into B', () => {
+    const { log, service } = configureBed();
+    log.appendAll([
+      makeUsageEnvelope('A', {
+        input_tokens: 100,
+        output_tokens: 10,
+        cache_read_tokens: 20,
+        cache_write_tokens: 5,
+      }),
+      makeUsageEnvelope('B', {
+        input_tokens: 999,
+        output_tokens: 88,
+        cache_read_tokens: 300,
+        cache_write_tokens: 10,
+      }),
+      makeUsageEnvelope('A', {
+        input_tokens: 5,
+        output_tokens: 1,
+        cache_read_tokens: 2,
+        cache_write_tokens: 0,
+      }),
     ]);
     expect(usage(service.tokenUsage, 'A')).toEqual(
-      jasmine.objectContaining({ totalSent: 105, totalReceived: 11 }),
+      jasmine.objectContaining({
+        totalSent: 105,
+        totalReceived: 11,
+        totalCacheRead: 22,
+        totalCacheWrite: 5,
+      }),
     );
     expect(usage(service.tokenUsage, 'B')).toEqual(
-      jasmine.objectContaining({ totalSent: 999, totalReceived: 88 }),
+      jasmine.objectContaining({
+        totalSent: 999,
+        totalReceived: 88,
+        totalCacheRead: 300,
+        totalCacheWrite: 10,
+      }),
     );
   });
 
@@ -357,6 +445,10 @@ describe('tokenUsageReduce (pure reducer)', () => {
       lastModelName: 'claude-sonnet',
       totalSent: 300,
       totalReceived: 40,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
   });
 
@@ -367,6 +459,10 @@ describe('tokenUsageReduce (pure reducer)', () => {
       lastModelName: 'claude-sonnet',
       totalSent: 300,
       totalReceived: 40,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     };
     const next = tokenUsageReduce(prev, envelope(7, 3));
     expect(next).toEqual(
@@ -385,6 +481,10 @@ describe('tokenUsageReduce (pure reducer)', () => {
       lastModelName: 'm',
       totalSent: 1,
       totalReceived: 1,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     };
     expect(tokenUsageReduce(prev, makeUnrelatedEnvelope('x'))).toBe(prev);
   });
@@ -398,7 +498,7 @@ describe('tokenUsageReduce (pure reducer)', () => {
         __model__: 'akgentic.llm.event.LlmUsageEvent',
         run_id: 'run-x',
         model_name: 'm',
-        // input_tokens / output_tokens deliberately absent
+        // input_tokens / output_tokens / cache_read_tokens / cache_write_tokens deliberately absent
       },
     } as unknown as AkgenticMessage;
     const next = tokenUsageReduce(undefined, malformed);
@@ -407,6 +507,10 @@ describe('tokenUsageReduce (pure reducer)', () => {
         lastContextWindow: 0,
         totalSent: 0,
         totalReceived: 0,
+        totalCacheRead: 0,
+        totalCacheWrite: 0,
+        lastCacheRead: 0,
+        lastCacheWrite: 0,
       }),
     );
   });
@@ -637,9 +741,13 @@ describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)
     lastModelName: 'claude-opus',
     totalSent: 50_000,
     totalReceived: 12_000,
+    totalCacheRead: 15_000,
+    totalCacheWrite: 3_000,
+    lastCacheRead: 4_000,
+    lastCacheWrite: 1_000,
   };
 
-  it('AC #7 compaction sets lastContextWindow = tokens_after, leaving totals + labels untouched', () => {
+  it('AC #7 compaction sets lastContextWindow = tokens_after, leaving totals + labels + cache counters untouched', () => {
     const next = tokenUsageReduce(
       PREV,
       makeCompactionEnvelope('A', {
@@ -654,6 +762,10 @@ describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)
       lastModelName: 'claude-opus',
       totalSent: 50_000,
       totalReceived: 12_000,
+      totalCacheRead: 15_000,
+      totalCacheWrite: 3_000,
+      lastCacheRead: 4_000,
+      lastCacheWrite: 1_000,
     });
   });
 
@@ -665,7 +777,7 @@ describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)
     expect(next).toBe(PREV);
   });
 
-  it('AC #7 compaction before any usage seeds from zero (window only, totals stay 0)', () => {
+  it('AC #7 compaction before any usage seeds from zero (window only, totals + cache stay 0)', () => {
     const next = tokenUsageReduce(
       undefined,
       makeCompactionEnvelope('A', {
@@ -680,10 +792,14 @@ describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)
       lastModelName: '',
       totalSent: 0,
       totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
   });
 
-  it('AC #8 clear resets lastContextWindow to 0, keeping totals + labels', () => {
+  it('AC #8 clear resets lastContextWindow to 0, keeping totals + labels + cache counters', () => {
     const next = tokenUsageReduce(PREV, makeClearEnvelope('A', 5));
     expect(next).toEqual({
       lastContextWindow: 0,
@@ -691,6 +807,10 @@ describe('tokenUsageReduce — fold compaction/clear (Epic 29 / ADR-010 §4/§8)
       lastModelName: 'claude-opus',
       totalSent: 50_000,
       totalReceived: 12_000,
+      totalCacheRead: 15_000,
+      totalCacheWrite: 3_000,
+      lastCacheRead: 4_000,
+      lastCacheWrite: 1_000,
     });
   });
 });
@@ -710,13 +830,17 @@ describe('tokenUsageSpec — context events via the real registry (Epic 29)', ()
         tokens_after: 6_000,
       }),
     ]);
-    // Compaction re-points the window; totals + labels unchanged (not a run).
+    // Compaction re-points the window; totals + labels + cache unchanged (not a run).
     expect(usage(service.tokenUsage, 'A')).toEqual({
       lastContextWindow: 6_000,
       lastRunId: 'r1',
       lastModelName: 'claude-sonnet',
       totalSent: 30_000,
       totalReceived: 9_000,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
     // The next real usage overrides the window AND accumulates totals.
     log.append(
@@ -732,6 +856,10 @@ describe('tokenUsageSpec — context events via the real registry (Epic 29)', ()
       lastModelName: 'claude-sonnet',
       totalSent: 36_500,
       totalReceived: 9_800,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+      lastCacheRead: 0,
+      lastCacheWrite: 0,
     });
   });
 

--- a/src/app/components/process/event/per-agent-specs.ts
+++ b/src/app/components/process/event/per-agent-specs.ts
@@ -471,17 +471,23 @@ export const systemPromptSpec: PerAgentSpec<SystemPromptValue> = {
 // ===========================================================================
 
 /**
- * Per-agent reduced token-usage value (Epic 26 / ADR-022 §Decision 2). Derived
- * by folding every `EventMessage(LlmUsageEvent)` for the agent (keyed by the
- * outer `sender.agent_id`, which IS the agent that ran the model). Terminology
+ * Per-agent reduced token-usage value (Epic 26 / ADR-022 §Decision 2, extended
+ * by Epic 30 / ADR-024 §Decision 1-2). Derived by folding every
+ * `EventMessage(LlmUsageEvent)` for the agent (keyed by the outer
+ * `sender.agent_id`, which IS the agent that ran the model). Terminology
  * (ADR-022 §Decision 4): `totalSent` Σ `input_tokens`, `totalReceived` Σ
- * `output_tokens`. `lastContextWindow` is the NEWEST event's `input_tokens`
- * (ADR-022 §Decision 3 — there is no context-window field on the wire, so the
- * most-recent prompt size is the proxy). `lastRunId` / `lastModelName` are labels
- * only. Cache / `requests` fields ride the wire but are excluded from v1.
+ * `output_tokens`. `lastContextWindow` is the NEWEST event's TRUE prompt size —
+ * `input_tokens + cache_read_tokens + cache_write_tokens` (ADR-024 §Decision 2;
+ * `input_tokens` alone is only the uncached portion on a cache hit).
+ * `lastCacheRead` / `lastCacheWrite` keep the fresh/cached split recoverable
+ * (`input = lastContextWindow − lastCacheRead − lastCacheWrite`); `totalCacheRead`
+ * / `totalCacheWrite` are the running Σ, mirroring `totalSent` / `totalReceived`.
+ * `lastRunId` / `lastModelName` are labels only. `requests` rides the wire but is
+ * excluded from v1.
  */
 export interface AgentTokenUsage {
-  /** input_tokens of the most-recent event (overwritten each event). */
+  /** input_tokens + cache_read_tokens + cache_write_tokens of the most-recent
+   *  event — the TRUE context window (overwritten each event). */
   lastContextWindow: number;
   /** run_id of that most-recent event (label only). */
   lastRunId: string;
@@ -491,6 +497,14 @@ export interface AgentTokenUsage {
   totalSent: number;
   /** running Σ of output_tokens across all this agent's events. */
   totalReceived: number;
+  /** running Σ of cache_read_tokens across all this agent's events. */
+  totalCacheRead: number;
+  /** running Σ of cache_write_tokens across all this agent's events. */
+  totalCacheWrite: number;
+  /** cache_read_tokens of the most-recent event (overwritten each event). */
+  lastCacheRead: number;
+  /** cache_write_tokens of the most-recent event (overwritten each event). */
+  lastCacheWrite: number;
 }
 
 /** Read the inner `LlmUsageEvent` off an `EventMessage`, or `undefined`. */
@@ -510,20 +524,28 @@ const ZERO_TOKEN_USAGE: AgentTokenUsage = {
   lastModelName: '',
   totalSent: 0,
   totalReceived: 0,
+  totalCacheRead: 0,
+  totalCacheWrite: 0,
+  lastCacheRead: 0,
+  lastCacheWrite: 0,
 };
 
 /**
  * Incremental per-message reducer (the store's `(prev, msg) => next` contract,
- * ADR-022 §Decision 2). NOT a stock factory:
- *   - `LlmUsageEvent` → accumulate (sum sent/received) AND overwrite (context
- *     window + labels); numeric reads coalesce a missing field to `0` (no NaN).
+ * ADR-022 §Decision 2, extended by ADR-024 §Decision 1-2). NOT a stock factory:
+ *   - `LlmUsageEvent` → accumulate (sum sent/received/cache) AND overwrite
+ *     (TRUE context window + last-run cache split + labels); numeric reads
+ *     coalesce a missing field to `0` (no NaN). `lastContextWindow` is
+ *     `input_tokens + cache_read_tokens + cache_write_tokens` — the real prompt
+ *     size, not just the uncached portion.
  *   - `LlmContextCompactedEvent` (Epic 29 / ADR-010 §4) → re-point
  *     `lastContextWindow` to `event.tokens_after` when it is a number; leave it
  *     unchanged when `tokens_after` is null/absent (defensive — no NaN, no reset).
  *   - `LlmContextClearedEvent` (§8) → reset `lastContextWindow` to `0`.
- * The two context events leave the cumulative I/O totals and run labels untouched
- * (neither is a model run) and seed from `prev ?? zero`. Every change returns a
- * FRESH object (OnPush safety); any other message passes `prev` through.
+ * The two context events leave the cumulative I/O + cache totals, last-run cache
+ * split, and run labels untouched (neither is a model run) and seed from
+ * `prev ?? ZERO_TOKEN_USAGE`. Every change returns a FRESH object (OnPush
+ * safety); any other message passes `prev` through.
  */
 export function tokenUsageReduce(
   prev: AgentTokenUsage | undefined,
@@ -533,12 +555,18 @@ export function tokenUsageReduce(
   if (ev !== undefined) {
     const input = ev.input_tokens ?? 0;
     const output = ev.output_tokens ?? 0;
+    const cacheRead = ev.cache_read_tokens ?? 0;
+    const cacheWrite = ev.cache_write_tokens ?? 0;
     return {
-      lastContextWindow: input,
+      lastContextWindow: input + cacheRead + cacheWrite,
       lastRunId: ev.run_id,
       lastModelName: ev.model_name,
       totalSent: (prev?.totalSent ?? 0) + input,
       totalReceived: (prev?.totalReceived ?? 0) + output,
+      totalCacheRead: (prev?.totalCacheRead ?? 0) + cacheRead,
+      totalCacheWrite: (prev?.totalCacheWrite ?? 0) + cacheWrite,
+      lastCacheRead: cacheRead,
+      lastCacheWrite: cacheWrite,
     };
   }
   if (!isEventMessage(msg)) return prev;

--- a/src/app/components/process/selectors/token-usage.selector.spec.ts
+++ b/src/app/components/process/selectors/token-usage.selector.spec.ts
@@ -31,6 +31,8 @@ function makeUsageEnvelope(
   agentId: string,
   input_tokens: number,
   output_tokens: number,
+  cache_read_tokens = 0,
+  cache_write_tokens = 0,
 ): AkgenticMessage {
   return {
     id: 'usage-' + agentId + '-' + envCounter++,
@@ -48,8 +50,8 @@ function makeUsageEnvelope(
       provider_name: 'anthropic',
       input_tokens,
       output_tokens,
-      cache_read_tokens: 0,
-      cache_write_tokens: 0,
+      cache_read_tokens,
+      cache_write_tokens,
       requests: 1,
     },
   } as unknown as AkgenticMessage;
@@ -143,26 +145,36 @@ describe('TokenUsageSelector.perAgent$ (AC #8)', () => {
 // ---------------------------------------------------------------------
 
 describe('TokenUsageSelector.teamTotals$ (AC #8)', () => {
-  it('empty team yields { totalSent: 0, totalReceived: 0 }', () => {
+  it('empty team yields { totalSent: 0, totalReceived: 0, totalCacheRead: 0, totalCacheWrite: 0 }', () => {
     const { selector } = configureBed();
     let received: TeamTokenTotals | undefined;
     const sub = selector.teamTotals$.subscribe((t) => (received = t));
-    expect(received).toEqual({ totalSent: 0, totalReceived: 0 });
+    expect(received).toEqual({
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     sub.unsubscribe();
   });
 
-  it('emits the structural sum across all agents', () => {
+  it('emits the structural sum across all agents, including cache totals', () => {
     const { log, selector } = configureBed();
     let received: TeamTokenTotals | undefined;
     const sub = selector.teamTotals$.subscribe((t) => (received = t));
 
     log.appendAll([
-      makeUsageEnvelope('A', 100, 10),
-      makeUsageEnvelope('B', 200, 20),
-      makeUsageEnvelope('A', 50, 5),
+      makeUsageEnvelope('A', 100, 10, 20, 5),
+      makeUsageEnvelope('B', 200, 20, 40, 0),
+      makeUsageEnvelope('A', 50, 5, 0, 10),
     ]);
 
-    expect(received).toEqual({ totalSent: 350, totalReceived: 35 });
+    expect(received).toEqual({
+      totalSent: 350,
+      totalReceived: 35,
+      totalCacheRead: 60, // 20 + 40 + 0
+      totalCacheWrite: 15, // 5 + 0 + 10
+    });
     sub.unsubscribe();
   });
 
@@ -176,8 +188,18 @@ describe('TokenUsageSelector.teamTotals$ (AC #8)', () => {
 
     // initial zeros + one usage change = 2 emissions; the unrelated tick adds none
     expect(emissions.length).toBe(2);
-    expect(emissions[0]).toEqual({ totalSent: 0, totalReceived: 0 });
-    expect(emissions[1]).toEqual({ totalSent: 100, totalReceived: 10 });
+    expect(emissions[0]).toEqual({
+      totalSent: 0,
+      totalReceived: 0,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
+    expect(emissions[1]).toEqual({
+      totalSent: 100,
+      totalReceived: 10,
+      totalCacheRead: 0,
+      totalCacheWrite: 0,
+    });
     sub.unsubscribe();
   });
 });

--- a/src/app/components/process/selectors/token-usage.selector.ts
+++ b/src/app/components/process/selectors/token-usage.selector.ts
@@ -4,17 +4,25 @@ import { distinctUntilChanged, map, Observable, shareReplay } from 'rxjs';
 import { AgentTokenUsage } from '../event/per-agent-specs';
 import { IngestionService } from '../event/ingestion.service';
 
-/** Headline team-wide totals (ADR-022 §Decision 2/4): Σ sent / Σ received. */
+/** Headline team-wide totals (ADR-022 §Decision 2/4, extended by ADR-024
+ *  §Decision 1): Σ sent / Σ received / Σ cache read / Σ cache write. */
 export interface TeamTokenTotals {
   totalSent: number;
   totalReceived: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
 }
 
 /** Structural equality of two totals (NFR / OnPush): the summed object is a
  *  fresh reference each frame, so the default reference comparator would never
  *  suppress no-op re-emissions. */
 function totalsEqual(a: TeamTokenTotals, b: TeamTokenTotals): boolean {
-  return a.totalSent === b.totalSent && a.totalReceived === b.totalReceived;
+  return (
+    a.totalSent === b.totalSent &&
+    a.totalReceived === b.totalReceived &&
+    a.totalCacheRead === b.totalCacheRead &&
+    a.totalCacheWrite === b.totalCacheWrite
+  );
 }
 
 /** Pure Σ over every agent's usage (ADR-022 §Decision 2): the team total is a
@@ -22,11 +30,15 @@ function totalsEqual(a: TeamTokenTotals, b: TeamTokenTotals): boolean {
 function sumTotals(all: ReadonlyMap<string, AgentTokenUsage>): TeamTokenTotals {
   let totalSent = 0;
   let totalReceived = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
   for (const usage of all.values()) {
     totalSent += usage.totalSent;
     totalReceived += usage.totalReceived;
+    totalCacheRead += usage.totalCacheRead;
+    totalCacheWrite += usage.totalCacheWrite;
   }
-  return { totalSent, totalReceived };
+  return { totalSent, totalReceived, totalCacheRead, totalCacheWrite };
 }
 
 /**
@@ -44,7 +56,8 @@ function sumTotals(all: ReadonlyMap<string, AgentTokenUsage>): TeamTokenTotals {
  *   `shareReplay({ bufferSize: 1, refCount: true })` with lazy current-value
  *   replay, so no extra pipeline is needed here.
  * - `teamTotals$` is a PURE sum over `tokenUsage.all$` (Σ every agent's
- *   `totalSent` / `totalReceived`) — NOT a separately stored aggregate. Because
+ *   `totalSent` / `totalReceived` / `totalCacheRead` / `totalCacheWrite`) — NOT
+ *   a separately stored aggregate. Because
  *   `ProcessComponent` + its scoped registry are destroyed/recreated on every
  *   team switch, `all$` holds exactly the CURRENT team's agents, so the total is
  *   correct by construction with no team-id bookkeeping. The sum is a fresh

--- a/src/app/protocol/message.types.ts
+++ b/src/app/protocol/message.types.ts
@@ -212,8 +212,9 @@ export interface LlmSystemPromptEvent {
  * / `CommandsAnnouncedEvent`. The serializer tags the dataclass with the
  * fully-qualified `__model__` and preserves integer token counts (no
  * stringification). Terminology (ADR-022 §Decision 4): `input_tokens` is "sent",
- * `output_tokens` is "received". `cache_*` and `requests` ride the wire but are
- * excluded from the v1 headline figures.
+ * `output_tokens` is "received". `cache_read_tokens` / `cache_write_tokens` fold
+ * into the true context-window figure (ADR-024 §Decision 2); `requests` still
+ * rides the wire unused.
  */
 export interface LlmUsageEvent {
   __model__: string; // contains 'LlmUsageEvent'


### PR DESCRIPTION
## Summary

Epic 30 (ADR-024) extends the Epic 26 token-usage feature (ADR-022) so the frontend stops discarding prompt-cache tokens: model the cache counters, report the true last-request context window, render the breakdown in interactive `p-popover`s (30-2), and bring the two host components onto genuine `OnPush` change detection (30-3). Frontend-only — no backend, protocol, or cross-submodule change.

## Stories

- [x] 30-1-cache-token-data-layer-and-true-context-window — extend `AgentTokenUsage`/`TeamTokenTotals` with cache counters, map `cache_read_tokens`/`cache_write_tokens` in `tokenUsageReduce` instead of discarding them, report the true context window (`input + cache_read + cache_write`) (Relates to #211)
- [x] 30-2-usage-popovers-member-chat-and-team-tree — replace the pill's `title` tooltip with an interactive PrimeNG `p-popover` (member chat + team-tree footer) rendering the cache breakdown (Relates to #213)
- [x] 30-3-component-onpush-usage-display-hosts — component-level `OnPush` + `markForCheck()` plumbing on `AkgentChatComponent`/`TreeComponent`, closing the epic's spec-compliance WARNING (Relates to #214)
- [ ] 30-4-fix-true-context-window-double-count — ADR-024 §Decision 2 correction (issue TBD, PENDING)

## Review status

- 30-1 review: **PASS** — no fixup commit needed. Adversarial review against all 7 ACs, the task list, and git-vs-story File List found no fix-worthy issues:
  - AC1-6 verified directly in the diff: `LlmUsageEvent.cache_read_tokens`/`cache_write_tokens` already typed `number`; `AgentTokenUsage`/`ZERO_TOKEN_USAGE` extended with the 4 cache fields; `tokenUsageReduce`'s `LlmUsageEvent` branch computes `lastContextWindow = input + cacheRead + cacheWrite` and accumulates/overwrites the cache counters exactly like the existing sent/received fields; the Epic 29 compaction/clear branches preserve the cache counters unchanged (they spread `prev ?? ZERO_TOKEN_USAGE`); `TeamTokenTotals`/`sumTotals`/`totalsEqual` extended as a pure sum.
  - The two out-of-File-List compile fixes (`tree.component.spec.ts`, `akgent-chat.component.spec.ts`) are legitimate, minimal (default the 4 new fields to `0`), and required because `AgentTokenUsage`/`TeamTokenTotals` are structural interfaces consumed by Story 26-2/26-3 tests.
  - Local gate independently re-run and confirmed: Karma `1169/1169 SUCCESS`; `npm run lint` clean; production build succeeds (pre-existing `lodash` CJS warning only); coverage Statements 84.02% / Lines 84.61% (≥80% floor) — Branches 73.35%/Functions 79.86% are a pre-existing repo-wide shortfall, not introduced here.
  - Git vs story File List: exact match, no discrepancies. No `ADR-NNN` assertions in test code (Golden Rule #8) — ADR references are in comments/`describe`/`it` labels only.
- 30-2 review: **1 fix applied** (accessibility). All 7 ACs verified directly in the diff against `1d09982`: member-chat pill and team-tree footer both replaced with keyboard-focusable `<button>`s (`aria-label`, `⚡` glyph on `cache > 0`, `tokenCount` for the compact totals) toggling their own `<p-popover>`; popovers render Model/Context-window-with-fresh-cached-split/Sent/Received/Cache-read/Cache-write (member chat) and Cache-read/Cache-write (team tree), all via the exact `| number` pipe; both empty-states (member chat `usage$ → undefined`, team tree all-zero totals) render the neutral text with the trigger `disabled`. Git vs story File List: exact match (8 files), no discrepancies. No `ADR-NNN` assertions in test code (Golden Rule #8).
  - **Fix (accessibility, MEDIUM):** neither trigger exposed `aria-haspopup`/`aria-expanded`, so assistive-tech users had no signal that the button opens a disclosure panel or of its open/closed state — a real gap given the story's own "accessibility is a hard requirement, not polish" framing (ADR-024 §Decision 3). Added `aria-haspopup="dialog"` + `[attr.aria-expanded]` bound to the popover's public `overlayVisible` on both triggers, with test coverage for the `false → true` flip on open (`5ac86e1`).
  - Noted, not fixed (LOW, accepted debt): the `.usage-popover`/`.usage-popover-row`/`.usage-popover-label` CSS block is byte-for-byte duplicated between `akgent-chat.component.scss` and `tree.component.scss`. No shared-SCSS partial convention exists anywhere in this codebase today (verified: zero `@use`/`@import` of partials under `src/app/**/*.scss`), so introducing one would be a new architectural pattern outside this story's declared File List — left as a future-cleanup candidate rather than fixed here.
  - Local gate independently re-run after the fixup and confirmed: Karma `1179/1179 SUCCESS`; `npm run lint` clean; production build succeeds (same pre-existing `lodash` CJS warning only); coverage Statements 84.02% / Lines 84.61% (≥80% floor) — Branches 73.35%/Functions 79.86% are the same pre-existing repo-wide shortfall, not introduced here.
- 30-3 review: **PASS** — no fixup commit needed. Reviewed the diff introduced by `7eba72a` in isolation.
  - AC1: both `AkgentChatComponent` and `TreeComponent` declare `changeDetection: ChangeDetectionStrategy.OnPush`, import `ChangeDetectionStrategy`, and inject `ChangeDetectorRef` (`cdr`); the async-pipe streams (`systemPrompt$`/`headRows$`/`usage$`/`teamTotals$`) are untouched.
  - AC2/AC3: verified all 8 enumerated `markForCheck()` sites are present and no extra/missing site — 5 in `AkgentChatComponent` (`context$` sub, `currentTeamRunning$` sub, `updateContext()`'s trailing `setTimeout`, `ngOnChanges()`'s member-switch `setTimeout`, `sendMessage()`'s post-await continuation + `catch`), 3 in `TreeComponent` (`nodes$`, `edges$`, `categories$` subs). The external `graphDataService.isLoading` write and the unused `NgZone` injection are correctly left untouched, matching the story's explicit "leave these alone" notes.
  - **AC4 (the story's core risk) — independently, empirically re-verified, not just re-derived from the dev's account.** Temporarily commented out `markForCheck()` at each of the three regression-tested sites (`tree.component.ts`'s `nodes$` sub; `akgent-chat.component.ts`'s `context$` and `currentTeamRunning$` subs), ran the Karma suite, and confirmed all three new regression tests genuinely **FAIL** without the plumbing (`tree.component.spec.ts` "AC4: a mid-stream nodes$ emission…"; `akgent-chat.component.spec.ts`'s two "AC4: …" tests) — then reverted and confirmed the full suite is green again (`git diff --stat` clean before/after). None of the three tests use `tick()` between the emission and the assertion (the trap the dev's account describes), so they are not silently defeated by zone re-arming. Verdict: the regression gate is real, not a false positive.
  - AC5: full pre-existing suite stays green (see local gate below). The two pre-existing specs adapted for OnPush (`agentId` switch now routed through `fixture.componentRef.setInput()` for *both* the initial bind and the switch — avoiding an Ivy `firstChange` misdetection that a partial fix would hit; and the Submit-disabled check now dispatches a real native `input` event on the textarea instead of a raw `component.userInput = …` field write, matching how `[(ngModel)]` actually updates in production) are legitimate fixes, not weakened assertions — both trace back to real OnPush semantics, not test-only workarounds.
  - Minor observation (LOW, not fix-worthy): in `sendMessage()`, the `catch` block's `markForCheck()` (akgent-chat.component.ts:512) is functionally redundant — the `catch` never returns/re-throws, so every path through it falls straight into the unconditional `markForCheck()` a few lines later (akgent-chat.component.ts:519) in the same synchronous continuation. Harmless (idempotent call), matches AC2's literal wording, and removing it wasn't attempted since AC2 explicitly calls for both sites — flagging for awareness only.
  - Local gate independently re-run and confirmed: Karma `1182/1182 SUCCESS`; `npm run lint` clean; production build succeeds (same pre-existing `lodash` CJS warning only); coverage Statements 83.99% / Lines 84.58% overall (≥80% floor) — Branches 73.3%/Functions 79.86% are the same pre-existing repo-wide shortfall, not introduced here.
  - Git vs story File List: exact match (4 files), no discrepancies. All changes confined to `packages/akgentic-frontend/src/app/`. No `ADR-NNN` assertions in test code (Golden Rule #8).

## Epic 30 status — NOT fully complete

30-1, 30-2, and 30-3 have landed. **Story 30-4 (`fix-true-context-window-double-count`) is still pending** — a tracked correction to the `lastContextWindow = input + cacheRead + cacheWrite` formula from 30-1 (ADR-024 §Decision 2). Do not treat this epic slice as closed until 30-4 lands.

## Scope guard

All changes are confined to `packages/akgentic-frontend/` (Golden Rule #4) — 30-1 touched 7 files (`ca7f197`), 30-2 touched 8 files (`1d09982`) plus a 4-file accessibility fixup (`5ac86e1`), 30-3 touched 4 files (`7eba72a`). All under `src/app/`. No backend, protocol, or other-submodule change.
