### PR TITLE
feat(akgentic-frontend): 30-4 fix true-context-window double-count

### DIFF
--- a/src/app/components/process/event/per-agent-specs.spec.ts
+++ b/src/app/components/process/event/per-agent-specs.spec.ts
@@ -299,28 +299,33 @@ describe('tokenUsageSpec reducer (Epic 26 / ADR-022 §Decision 2-4)', () => {
     });
   });
 
-  it('AC #3/#4 cache-hit event: true lastContextWindow = input + cacheRead + cacheWrite, cache fields seeded', () => {
+  it('AC #3/#4 cache-hit event: lastContextWindow === input_tokens (cache-inclusive total), cache fields seeded', () => {
     const { log, service } = configureBed();
     log.append(
       makeUsageEnvelope('A', {
         run_id: 'run-8',
-        input_tokens: 500,
+        input_tokens: 5_500, // cache-inclusive total: 4_000 read + 1_000 write + 500 fresh
         output_tokens: 60,
         cache_read_tokens: 4_000,
         cache_write_tokens: 1_000,
       }),
     );
-    expect(usage(service.tokenUsage, 'A')).toEqual({
-      lastContextWindow: 5_500, // 500 + 4_000 + 1_000 — the TRUE prompt size
+    const result = usage(service.tokenUsage, 'A');
+    expect(result).toEqual({
+      lastContextWindow: 5_500, // === input_tokens — already the full prompt, cache included
       lastRunId: 'run-8',
       lastModelName: 'claude-sonnet',
-      totalSent: 500,
+      totalSent: 5_500,
       totalReceived: 60,
       totalCacheRead: 4_000,
       totalCacheWrite: 1_000,
       lastCacheRead: 4_000,
       lastCacheWrite: 1_000,
     });
+    // fresh/cached split stays recoverable and non-negative.
+    expect(
+      result!.lastContextWindow - result!.lastCacheRead - result!.lastCacheWrite,
+    ).toBe(500);
   });
 
   it('AC #3 multi-event: sums cumulative cache totals and overwrites last-run cache with the newest event', () => {
@@ -335,17 +340,17 @@ describe('tokenUsageSpec reducer (Epic 26 / ADR-022 §Decision 2-4)', () => {
       }),
       makeUsageEnvelope('A', {
         run_id: 'run-2',
-        input_tokens: 300,
+        input_tokens: 1_200, // cache-inclusive total: 900 read + 0 write + 300 fresh
         output_tokens: 40,
         cache_read_tokens: 900,
         cache_write_tokens: 0,
       }),
     ]);
     expect(usage(service.tokenUsage, 'A')).toEqual({
-      lastContextWindow: 1_200, // 300 + 900 + 0 — newest event's true window
+      lastContextWindow: 1_200, // === newest input_tokens (already the full prompt)
       lastRunId: 'run-2',
       lastModelName: 'claude-sonnet',
-      totalSent: 1_300,
+      totalSent: 2_200, // 1_000 + 1_200
       totalReceived: 140,
       totalCacheRead: 1_100, // 200 + 900
       totalCacheWrite: 50, // 50 + 0

--- a/src/app/components/process/event/per-agent-specs.ts
+++ b/src/app/components/process/event/per-agent-specs.ts
@@ -477,17 +477,19 @@ export const systemPromptSpec: PerAgentSpec<SystemPromptValue> = {
  * `sender.agent_id`, which IS the agent that ran the model). Terminology
  * (ADR-022 §Decision 4): `totalSent` Σ `input_tokens`, `totalReceived` Σ
  * `output_tokens`. `lastContextWindow` is the NEWEST event's TRUE prompt size —
- * `input_tokens + cache_read_tokens + cache_write_tokens` (ADR-024 §Decision 2;
- * `input_tokens` alone is only the uncached portion on a cache hit).
+ * `input_tokens`, which pydantic-ai already reports as the FULL prompt, cache
+ * included (ADR-024 §Decision 2). `cache_read_tokens` / `cache_write_tokens` are
+ * a breakdown OF `input_tokens`, not additions to it, so the window is
+ * `input_tokens` alone — adding the cache counters would double-count.
  * `lastCacheRead` / `lastCacheWrite` keep the fresh/cached split recoverable
- * (`input = lastContextWindow − lastCacheRead − lastCacheWrite`); `totalCacheRead`
+ * (`fresh = lastContextWindow − lastCacheRead − lastCacheWrite`); `totalCacheRead`
  * / `totalCacheWrite` are the running Σ, mirroring `totalSent` / `totalReceived`.
  * `lastRunId` / `lastModelName` are labels only. `requests` rides the wire but is
  * excluded from v1.
  */
 export interface AgentTokenUsage {
-  /** input_tokens + cache_read_tokens + cache_write_tokens of the most-recent
-   *  event — the TRUE context window (overwritten each event). */
+  /** input_tokens of the most-recent event — the TRUE context window (already
+   *  the full prompt, cache included; overwritten each event). */
   lastContextWindow: number;
   /** run_id of that most-recent event (label only). */
   lastRunId: string;
@@ -536,8 +538,8 @@ const ZERO_TOKEN_USAGE: AgentTokenUsage = {
  *   - `LlmUsageEvent` → accumulate (sum sent/received/cache) AND overwrite
  *     (TRUE context window + last-run cache split + labels); numeric reads
  *     coalesce a missing field to `0` (no NaN). `lastContextWindow` is
- *     `input_tokens + cache_read_tokens + cache_write_tokens` — the real prompt
- *     size, not just the uncached portion.
+ *     `input_tokens` — already the full prompt (cache included), so the cache
+ *     counters are NOT added on top (that would double-count).
  *   - `LlmContextCompactedEvent` (Epic 29 / ADR-010 §4) → re-point
  *     `lastContextWindow` to `event.tokens_after` when it is a number; leave it
  *     unchanged when `tokens_after` is null/absent (defensive — no NaN, no reset).
@@ -558,7 +560,7 @@ export function tokenUsageReduce(
     const cacheRead = ev.cache_read_tokens ?? 0;
     const cacheWrite = ev.cache_write_tokens ?? 0;
     return {
-      lastContextWindow: input + cacheRead + cacheWrite,
+      lastContextWindow: input,
       lastRunId: ev.run_id,
       lastModelName: ev.model_name,
       totalSent: (prev?.totalSent ?? 0) + input,


### PR DESCRIPTION
## Story 30-4 — Fix true-context-window double-count

Reverts the ADR-024 §Decision 2 double-count introduced by Story 30-1: `tokenUsageReduce` set `lastContextWindow = input_tokens + cache_read_tokens + cache_write_tokens`, but pydantic-ai already normalizes `input_tokens` to the **full** prompt size (cache included) per the OpenTelemetry GenAI convention. `cache_read_tokens` / `cache_write_tokens` are a breakdown *of* `input_tokens`, not additions to it, so summing them double-counts the cached tokens. The window is now `lastContextWindow = input_tokens`.

Sources: pydantic-ai#4364 (maintainer-confirmed OTel compliance), langfuse#12306 (the `input_tokens=5 → 130213` repro), akgentic-llm ADR-06 Amendment 1.

### Stacking

- **Base is the epic branch `feat/211-epic-30-surface-prompt-cache-tokens-in-usage-displays`, not `master`.** The Epic 30 umbrella PR #212 is still open/unmerged, and `master` still carries the pre-30-1 (Epic 26) `AgentTokenUsage` with no cache fields — there is nothing to revert there. The 30-1 double-count and the four cache counters live only on `feat/211`, so 30-4 stacks on it.

### Changes (commit `87b9dcb`, both files under `packages/akgentic-frontend/src/`)

- `per-agent-specs.ts` — reducer `LlmUsageEvent` branch: `lastContextWindow: input + cacheRead + cacheWrite` → `lastContextWindow: input`. The `cacheRead` / `cacheWrite` locals stay (they still feed `lastCacheRead` / `lastCacheWrite` / `totalCacheRead` / `totalCacheWrite`). Three stale docstrings/comments corrected to state the window is `input_tokens`.
- `per-agent-specs.spec.ts` — the two cache-hit reducer specs made cache-inclusive/coherent: assert `lastContextWindow === input_tokens` (`5_500`) with a non-negative `fresh = window − lastCacheRead − lastCacheWrite === 500`; multi-event run-2 → `input_tokens: 1_200`, `totalSent: 2_200`.

### Unchanged (revert scope only)

`AgentTokenUsage` / `ZERO_TOKEN_USAGE` shape, all `total*` / `last*Cache*` accumulation, the last-run split, run labels, the Epic 29 compaction (`tokens_after`) / clear (`0`) branches, `token-usage.selector.ts` team sums, and both popover templates + the ⚡ glyph (they bind `lastContextWindow` + the cache split directly — the corrected value flows through with no template change).

### Local gate (no GitHub Actions CI for `akgentic-frontend`)

- Karma: `1182 SUCCESS`
- Lint: `eslint "src/**/*.ts"` — 0 findings
- Build: production bundle complete (only the pre-existing lodash CommonJS warning in the untouched `util.ts`)
- Coverage: statement/line ≥80% (Amelia: statements 84.11%, lines 84.67%)

Closes #215
