### PR TITLE
feat(akgentic-frontend): 30-5 usage-display cleanup — omit cache write, per-model team popover

### DIFF
--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.html
@@ -148,8 +148,10 @@
           `ctx <ctx> · ↑<sent> ↓<received>` (every number via `tokenCount`) plus a
           `⚡` glyph when any cache tokens were used — that toggles
           `<p-popover #usageOp>` with the full breakdown (model, true context
-          window with the fresh/cached split, sent/received, cache read/write, all
-          via the exact `| number` pipe). A never-run agent (`undefined`) renders
+          window with the fresh/cached split, sent/received, and cache read shown
+          as last/total — cache write is not surfaced since OpenAI reports cache
+          reads only — all via the exact `| number` pipe). A never-run agent
+          (`undefined`) renders
           the neutral `ctx — · ↑0 ↓0` with the trigger DISABLED — inert, no
           popover to open (the VIEW owns the empty-state, ADR-022 §OQ2).
         -->
@@ -180,8 +182,7 @@
               <div class="usage-popover-row">
                 <span class="usage-popover-label">Context window</span>
                 <span>
-                  {{ usage.lastContextWindow | number }} of which
-                  {{ usage.lastCacheRead + usage.lastCacheWrite | number }} cached
+                  {{ usage.lastContextWindow | number }} 
                 </span>
               </div>
               <div class="usage-popover-row">
@@ -193,12 +194,8 @@
                 <span>{{ usage.totalReceived | number }}</span>
               </div>
               <div class="usage-popover-row">
-                <span class="usage-popover-label">Cache read</span>
+                <span class="usage-popover-label">Cache ⚡</span>
                 <span>{{ usage.lastCacheRead | number }} / {{ usage.totalCacheRead | number }}</span>
-              </div>
-              <div class="usage-popover-row">
-                <span class="usage-popover-label">Cache write</span>
-                <span>{{ usage.lastCacheWrite | number }} / {{ usage.totalCacheWrite | number }}</span>
               </div>
             </div>
           </p-popover>

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.spec.ts
@@ -1274,8 +1274,10 @@ describe('AkgentChatComponent — token-usage pill (Story 26-2)', () => {
 
 // ---------------------------------------------------------------------------
 // Story 30-2 (ADR-024 §Decision 3) — the pill becomes an interactive trigger
-// for a `<p-popover>` carrying the full cache breakdown (model, true context
-// window with the fresh/cached split, sent/received, cache read/write). Driven
+// for a `<p-popover>` carrying the usage breakdown (model, context window,
+// sent/received, cache read as last/total under a "Cache ⚡" label). Cache write
+// is intentionally not surfaced (see story usage-display-cleanup: OpenAI reports
+// cache reads only). Driven
 // through the same fake `TokenUsageSelector` pattern as Story 26-2: a
 // controllable `usage$` BehaviorSubject makes glyph / toggle / live-update /
 // empty-state deterministic. `p-popover` renders in place (no `appendTo`
@@ -1389,7 +1391,7 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
     expect(pill(fixture).textContent).not.toContain('⚡');
   });
 
-  it('clicking the trigger toggles open the popover with Model / Context-window-split / Sent / Received / Cache read+write', () => {
+  it('clicking the trigger toggles open the popover with Model / Context window / Sent / Received / Cache (no Cache write row)', () => {
     const { fixture } = setup(
       usage({
         lastContextWindow: 12_300,
@@ -1415,11 +1417,12 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
 
     const rows = popoverRows(fixture);
     expect(rows).toContain('Model claude-opus-4-8');
-    expect(rows).toContain('Context window 12,300 of which 4,300 cached');
+    expect(rows).toContain('Context window 12,300');
     expect(rows).toContain('Sent 45,000');
     expect(rows).toContain('Received 12,100');
-    expect(rows).toContain('Cache read 4,000 / 9,000');
-    expect(rows).toContain('Cache write 300 / 300');
+    expect(rows).toContain('Cache ⚡ 4,000 / 9,000');
+    // Cache write is not surfaced (OpenAI reports cache reads only).
+    expect(rows.some((r) => r.startsWith('Cache write'))).toBeFalse();
     // aria-expanded flips once the popover is actually open.
     expect(pill(fixture).getAttribute('aria-expanded')).toBe('true');
   });
@@ -1435,7 +1438,7 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
     fixture.detectChanges();
     pill(fixture).click();
     fixture.detectChanges();
-    expect(popoverRows(fixture)).toContain('Context window 1,000 of which 0 cached');
+    expect(popoverRows(fixture)).toContain('Context window 1,000');
 
     usage$.next(
       usage({
@@ -1447,7 +1450,7 @@ describe('AkgentChatComponent — usage popover (Story 30-2)', () => {
     );
     fixture.detectChanges();
 
-    expect(popoverRows(fixture)).toContain('Context window 9,000 of which 3,000 cached');
+    expect(popoverRows(fixture)).toContain('Context window 9,000');
     expect(popoverRows(fixture)).toContain('Sent 10,000');
   });
 

--- a/src/app/components/process/components/team-tabs/tree/tree.component.html
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.html
@@ -28,48 +28,51 @@
     </p-tree>
   </div>
   <!--
-    ADR-024 §Decision 3 — team-wide token-usage trigger, same interactive
-    treatment as the member-chat pill (supersedes ADR-022 §Decision 6's
-    non-interactive footer). ↑ = sent = Σ input; ↓ = received = Σ output.
-    `teamTotals$` NEVER emits `undefined` (`sumTotals` always returns a
-    zero-filled object for an empty team) — the "no data" case here is
-    ALL-ZERO totals, not a missing value, so the trigger is disabled when every
-    total is `0` rather than gated on an `undefined` branch. Toggles its OWN
-    `<p-popover>` (independent of the member-chat one) breaking down the
-    team-wide cache read/write.
+    Team-wide token-usage footer. ↑ = sent = Σ input; ↓ = received = Σ output;
+    the parenthesised ⚡ figure between them is the team-wide cache read (Σ cached
+    input) shown only when non-zero. `teamTotals$` NEVER emits `undefined`
+    (`sumTotals` always returns a zero-filled object for an empty team) — the
+    "no data" case is ALL-ZERO totals, so the trigger is disabled when every
+    total is 0. Clicking the (enabled) footer toggles a popover breaking the
+    totals down BY MODEL (`teamByModel$`, grouped by each agent's current model).
+    Cache write is not surfaced (OpenAI reports cache reads only).
   -->
   <ng-container *ngIf="teamTotals$ | async as totals">
-    <button
-      type="button"
-      class="team-total-footer"
-      [attr.aria-label]="
-        'Team token usage: sent ' + (totals.totalSent | number) +
-        ', received ' + (totals.totalReceived | number)
-      "
-      [disabled]="
-        totals.totalSent === 0 &&
-        totals.totalReceived === 0 &&
-        totals.totalCacheRead === 0 &&
-        totals.totalCacheWrite === 0
-      "
-      aria-haspopup="dialog"
-      [attr.aria-expanded]="teamUsageOp.overlayVisible"
-      (click)="teamUsageOp.toggle($event)"
-    >
-      Team total ↑{{ totals.totalSent | tokenCount }} ↓{{
-        totals.totalReceived | tokenCount
-      }}
-      <span *ngIf="totals.totalCacheRead + totals.totalCacheWrite > 0">⚡</span>
-    </button>
+    <!-- Full-width strip; the popover anchors to the COMPACT inner trigger (not
+         the strip) so its caret lines up under the text, not the strip centre. -->
+    <div class="team-total-footer">
+      <button
+        type="button"
+        class="team-total-trigger"
+        [attr.aria-label]="
+          'Team token usage: sent ' + (totals.totalSent | number) +
+          ', cache read ' + (totals.totalCacheRead | number) +
+          ', received ' + (totals.totalReceived | number)
+        "
+        [disabled]="
+          totals.totalSent === 0 &&
+          totals.totalReceived === 0 &&
+          totals.totalCacheRead === 0 &&
+          totals.totalCacheWrite === 0
+        "
+        aria-haspopup="dialog"
+        [attr.aria-expanded]="teamUsageOp.overlayVisible"
+        (click)="teamUsageOp.toggle($event)"
+      >
+        Team total ↑{{ totals.totalSent | tokenCount }}
+        <span *ngIf="totals.totalCacheRead > 0">(⚡{{ totals.totalCacheRead | tokenCount }})</span>
+        — ↓{{ totals.totalReceived | tokenCount }}
+      </button>
+    </div>
     <p-popover #teamUsageOp>
       <div class="usage-popover">
-        <div class="usage-popover-row">
-          <span class="usage-popover-label">Cache read</span>
-          <span>{{ totals.totalCacheRead | number }}</span>
-        </div>
-        <div class="usage-popover-row">
-          <span class="usage-popover-label">Cache write</span>
-          <span>{{ totals.totalCacheWrite | number }}</span>
+        <div class="usage-popover-row" *ngFor="let m of teamByModel$ | async">
+          <span class="usage-popover-label">{{ m.modelName }}</span>
+          <span>
+            ↑{{ m.totalSent | tokenCount }}
+            <span *ngIf="m.totalCacheRead > 0">(⚡{{ m.totalCacheRead | tokenCount }})</span>
+            ↓{{ m.totalReceived | tokenCount }}
+          </span>
         </div>
       </div>
     </p-popover>

--- a/src/app/components/process/components/team-tabs/tree/tree.component.scss
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.scss
@@ -12,19 +12,24 @@
   flex: 1;
 }
 
-// ADR-024 §Decision 3: slim, muted team-total strip — now an interactive
-// `<button>` (supersedes ADR-022 §Decision 6's non-interactive footer). Muted
-// colour matches the member-chat usage pill (Story 30-2); tabular-nums keeps
-// the digits steady on live update. `:disabled` (empty team, AC 6) reverts to
-// the `default` cursor — inert, nothing to open.
+// Slim, muted team-total strip. The strip spans full width (top-border
+// separator, footer look); the popover TRIGGER inside it is compact (sized to
+// its text) so the popover's caret aligns under the text rather than the strip
+// centre. Muted colour matches the member-chat usage pill; tabular-nums keeps
+// the digits steady on live update.
 .team-total-footer {
   flex: 0 0 auto;
   width: 100%;
   padding: 4px 8px;
-  border: none;
   border-top: 1px solid #e2e8f0;
-  font: inherit;
   font-size: 0.8rem;
+}
+
+.team-total-trigger {
+  display: inline-block;
+  padding: 0;
+  border: none;
+  font: inherit;
   color: #64748b;
   text-align: left;
   white-space: nowrap;

--- a/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.spec.ts
@@ -7,6 +7,7 @@ import { ApiService } from '../../../../../core/http/api.service';
 import { GraphDataService } from '../../../selectors/graph.selector';
 import { SelectionService } from '../../../ui-state/selection.service';
 import {
+  ModelTokenTotals,
   TeamTokenTotals,
   TokenUsageSelector,
 } from '../../../selectors/token-usage.selector';
@@ -66,6 +67,7 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
           provide: TokenUsageSelector,
           useValue: {
             teamTotals$: totals$.asObservable(),
+            teamByModel$: of([]),
             perAgent$: (_id: string) => of(undefined),
           },
         },
@@ -98,17 +100,26 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     return TestBed.createComponent(TreeComponent);
   }
 
-  /** The footer strip element. */
+  /** The full-width footer strip (wrapper). */
   function footer(fixture: ComponentFixture<TreeComponent>): HTMLElement | null {
     return (fixture.nativeElement as HTMLElement).querySelector(
       '.team-total-footer',
     );
   }
 
-  /** Footer text with whitespace collapsed (glyphs/order are the contract,
+  /** The compact popover trigger button inside the strip. */
+  function trigger(
+    fixture: ComponentFixture<TreeComponent>,
+  ): HTMLButtonElement | null {
+    return (fixture.nativeElement as HTMLElement).querySelector(
+      '.team-total-trigger',
+    );
+  }
+
+  /** Trigger text with whitespace collapsed (glyphs/order are the contract,
    *  not exact spacing). */
   function footerText(fixture: ComponentFixture<TreeComponent>): string {
-    return (footer(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
+    return (trigger(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
 
   it('(a) renders the populated `Team total ↑X ↓Y` as an interactive trigger, BETWEEN the tree and app-human-request', () => {
@@ -120,14 +131,16 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     });
     fixture.detectChanges();
 
-    // tokenCount: 57_000 → "57.0k", 12_500 → "12.5k".
-    expect(footerText(fixture)).toBe('Team total ↑57.0k ↓12.5k');
+    // tokenCount: 57_000 → "57.0k", 12_500 → "12.5k". No cache read → no parens
+    // (the em-dash separator before ↓ is always present).
+    expect(footerText(fixture)).toBe('Team total ↑57.0k — ↓12.5k');
 
-    // ADR-024 §Decision 3 — interactive: a keyboard-focusable <button>, enabled
-    // (there's usage, so there's a popover to open).
-    const f = footer(fixture)!;
-    expect(f.tagName.toLowerCase()).toBe('button');
-    expect((f as HTMLButtonElement).disabled).toBeFalse();
+    // Interactive: a keyboard-focusable <button> trigger, enabled (usage →
+    // popover to open); the strip wrapper itself is a plain <div>.
+    expect(footer(fixture)!.tagName.toLowerCase()).toBe('div');
+    const t = trigger(fixture)!;
+    expect(t.tagName.toLowerCase()).toBe('button');
+    expect(t.disabled).toBeFalse();
 
     // DOM order: footer AFTER the tree region, BEFORE app-human-request, all
     // direct children of `.tree-component-container`.
@@ -157,7 +170,7 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
       totalCacheWrite: 0,
     });
     fixture.detectChanges();
-    expect(footerText(fixture)).toBe('Team total ↑1.0k ↓200');
+    expect(footerText(fixture)).toBe('Team total ↑1.0k — ↓200');
 
     // A new LlmUsageEvent landed for some agent → the selector re-emits a larger
     // structural sum; the async pipe re-renders without any imperative refresh.
@@ -168,7 +181,7 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
       totalCacheWrite: 0,
     });
     fixture.detectChanges();
-    expect(footerText(fixture)).toBe('Team total ↑73.4k ↓18.9k');
+    expect(footerText(fixture)).toBe('Team total ↑73.4k — ↓18.9k');
   });
 
   it('(c) empty team (`{0,0}`) renders the `Team total ↑0 ↓0` fallback with an inert (disabled) trigger', () => {
@@ -181,10 +194,11 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
     fixture.detectChanges();
 
     // The zero-totals object IS the empty state — the footer is still rendered,
-    // but AC 6 disables it: no usage yet, nothing to open.
+    // just showing all-zero sums (cache read 0 → no parens) and disabled (no
+    // usage → nothing to break down).
     expect(footer(fixture)).not.toBeNull();
-    expect(footerText(fixture)).toBe('Team total ↑0 ↓0');
-    expect((footer(fixture) as unknown as HTMLButtonElement).disabled).toBeTrue();
+    expect(footerText(fixture)).toBe('Team total ↑0 — ↓0');
+    expect(trigger(fixture)!.disabled).toBeTrue();
   });
 
   it('(d) resolves the SHARED selector instance (no self-provider) and leaves the tree behavior intact', () => {
@@ -220,26 +234,30 @@ describe('TreeComponent — team-total footer (Story 26-3)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Story 30-2 (ADR-024 §Decision 3) — the team-tree footer becomes an
-// interactive trigger for its OWN `<p-popover>` breaking down the team-wide
-// cache read/write. Same fake-selector pattern as Story 26-3: a controllable
-// `totals$` BehaviorSubject makes glyph / toggle / live-update / empty-state
-// deterministic. `p-popover` renders in place (no `appendTo` override) so its
-// content is queryable straight off `fixture.nativeElement`.
+// Team-total footer — the chip keeps `Team total ↑{sent} (⚡{cacheRead}) —
+// ↓{received}` (cache parens only when non-zero) and, when it carries usage,
+// toggles a `<p-popover>` breaking the totals down BY MODEL (`teamByModel$`,
+// one row per model: `{model} ↑{sent} (⚡{cacheRead}) ↓{received}`). Driveable
+// `totals$` + `byModel$` subjects make chip / toggle / live-update / empty-state
+// deterministic. `p-popover` renders in place (no `appendTo`) so its content is
+// queryable straight off `fixture.nativeElement`.
 // ---------------------------------------------------------------------------
-describe('TreeComponent — team-total popover (Story 30-2)', () => {
+describe('TreeComponent — team-total popover by model', () => {
   let totals$: BehaviorSubject<TeamTokenTotals>;
+  let byModel$: BehaviorSubject<ModelTokenTotals[]>;
   let nodes$: BehaviorSubject<NodeInterface[]>;
 
   function setup(
-    initial: TeamTokenTotals = {
+    initialTotals: TeamTokenTotals = {
       totalSent: 0,
       totalReceived: 0,
       totalCacheRead: 0,
       totalCacheWrite: 0,
     },
+    initialByModel: ModelTokenTotals[] = [],
   ): ComponentFixture<TreeComponent> {
-    totals$ = new BehaviorSubject<TeamTokenTotals>(initial);
+    totals$ = new BehaviorSubject<TeamTokenTotals>(initialTotals);
+    byModel$ = new BehaviorSubject<ModelTokenTotals[]>(initialByModel);
     nodes$ = new BehaviorSubject<NodeInterface[]>([]);
 
     TestBed.resetTestingModule();
@@ -250,6 +268,7 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
           provide: TokenUsageSelector,
           useValue: {
             teamTotals$: totals$.asObservable(),
+            teamByModel$: byModel$.asObservable(),
             perAgent$: (_id: string) => of(undefined),
           },
         },
@@ -282,58 +301,74 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
     return TestBed.createComponent(TreeComponent);
   }
 
+  // The popover trigger is the compact button inside the strip.
   function footer(fixture: ComponentFixture<TreeComponent>): HTMLButtonElement {
     return (fixture.nativeElement as HTMLElement).querySelector(
-      '.team-total-footer',
+      '.team-total-trigger',
     ) as HTMLButtonElement;
   }
 
-  /** Each `.usage-popover-row`'s two cells joined with a single space (e.g.
-   *  "Cache read 4,000") — empty array when the popover isn't open. */
+  function footerText(fixture: ComponentFixture<TreeComponent>): string {
+    return (footer(fixture)?.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  /** Each `.usage-popover-row`'s two cells (model label + usage line), inner
+   *  whitespace collapsed — empty array when the popover isn't open. */
   function popoverRows(fixture: ComponentFixture<TreeComponent>): string[] {
     const rows = (fixture.nativeElement as HTMLElement).querySelectorAll(
       '.usage-popover-row',
     );
     return Array.from(rows).map((row) =>
       Array.from(row.children)
-        .map((c) => (c.textContent ?? '').trim())
+        .map((c) => (c.textContent ?? '').replace(/\s+/g, ' ').trim())
         .join(' '),
     );
   }
 
-  it('shows the ⚡ glyph when team cache tokens were used', () => {
-    const fixture = setup({
-      totalSent: 1_000,
-      totalReceived: 200,
-      totalCacheRead: 500,
-      totalCacheWrite: 0,
-    });
+  // The two models whose totals sum to the user's headline chip example.
+  const GPT: ModelTokenTotals = {
+    modelName: 'gpt-5.4-2026-03-05',
+    totalSent: 12_000,
+    totalReceived: 100,
+    totalCacheRead: 10_000,
+    totalCacheWrite: 0,
+  };
+  const CLAUDE: ModelTokenTotals = {
+    modelName: 'claude-opus-4-8',
+    totalSent: 4_800,
+    totalReceived: 61,
+    totalCacheRead: 2_800,
+    totalCacheWrite: 0,
+  };
+  const HEADLINE: TeamTokenTotals = {
+    totalSent: 16_800,
+    totalReceived: 161,
+    totalCacheRead: 12_800,
+    totalCacheWrite: 0,
+  };
+
+  it('chip shows the cache read in parens (⚡-prefixed) between ↑ and ↓ when team cache tokens were used', () => {
+    const fixture = setup(HEADLINE, [GPT, CLAUDE]);
     fixture.detectChanges();
-    expect(footer(fixture).textContent).toContain('⚡');
+    // tokenCount: 16_800 → "16.8k", 12_800 → "12.8k", 161 → "161".
+    expect(footerText(fixture)).toBe('Team total ↑16.8k (⚡12.8k) — ↓161');
   });
 
-  it('shows no glyph when both team cache totals are 0', () => {
-    const fixture = setup({
-      totalSent: 1_000,
-      totalReceived: 200,
-      totalCacheRead: 0,
-      totalCacheWrite: 0,
-    });
+  it('chip omits the parens (and ⚡) when team cache read is 0', () => {
+    const fixture = setup(
+      { totalSent: 1_000, totalReceived: 200, totalCacheRead: 0, totalCacheWrite: 0 },
+      [{ modelName: 'gpt-5.4-2026-03-05', totalSent: 1_000, totalReceived: 200, totalCacheRead: 0, totalCacheWrite: 0 }],
+    );
     fixture.detectChanges();
+    expect(footerText(fixture)).toBe('Team total ↑1.0k — ↓200');
     expect(footer(fixture).textContent).not.toContain('⚡');
   });
 
-  it('clicking the trigger toggles open the popover with team-wide Cache read / Cache write', () => {
-    const fixture = setup({
-      totalSent: 57_000,
-      totalReceived: 12_500,
-      totalCacheRead: 9_000,
-      totalCacheWrite: 1_200,
-    });
+  it('clicking the trigger toggles open the popover with one row per model', () => {
+    const fixture = setup(HEADLINE, [GPT, CLAUDE]);
     fixture.detectChanges();
 
-    // No popover content before the trigger is clicked, and the trigger
-    // announces itself as a closed disclosure control to assistive tech.
+    // Closed disclosure control, no popover content yet.
     expect(popoverRows(fixture)).toEqual([]);
     expect(footer(fixture).getAttribute('aria-haspopup')).toBe('dialog');
     expect(footer(fixture).getAttribute('aria-expanded')).toBe('false');
@@ -342,42 +377,48 @@ describe('TreeComponent — team-total popover (Story 30-2)', () => {
     fixture.detectChanges();
 
     const rows = popoverRows(fixture);
-    expect(rows).toContain('Cache read 9,000');
-    expect(rows).toContain('Cache write 1,200');
-    // aria-expanded flips once the popover is actually open.
+    expect(rows).toContain('gpt-5.4-2026-03-05 ↑12.0k (⚡10.0k) ↓100');
+    expect(rows).toContain('claude-opus-4-8 ↑4.8k (⚡2.8k) ↓61');
     expect(footer(fixture).getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('popover content updates live when teamTotals$ re-emits a new value (no re-toggle needed)', () => {
-    const fixture = setup({
-      totalSent: 1_000,
-      totalReceived: 200,
-      totalCacheRead: 300,
-      totalCacheWrite: 0,
-    });
+  it('popover per-model rows update live when teamByModel$ re-emits (a cache-free model shows no parens)', () => {
+    const fixture = setup(HEADLINE, [GPT, CLAUDE]);
     fixture.detectChanges();
     footer(fixture).click();
     fixture.detectChanges();
-    expect(popoverRows(fixture)).toContain('Cache read 300');
+    expect(popoverRows(fixture)).toContain('gpt-5.4-2026-03-05 ↑12.0k (⚡10.0k) ↓100');
 
-    totals$.next({
-      totalSent: 5_000,
-      totalReceived: 900,
-      totalCacheRead: 4_400,
-      totalCacheWrite: 250,
-    });
+    byModel$.next([
+      { modelName: 'gpt-5.4-2026-03-05', totalSent: 20_000, totalReceived: 300, totalCacheRead: 15_000, totalCacheWrite: 0 },
+      { modelName: 'local-llama', totalSent: 1_000, totalReceived: 50, totalCacheRead: 0, totalCacheWrite: 0 },
+    ]);
     fixture.detectChanges();
 
-    expect(popoverRows(fixture)).toContain('Cache read 4,400');
-    expect(popoverRows(fixture)).toContain('Cache write 250');
+    const rows = popoverRows(fixture);
+    expect(rows).toContain('gpt-5.4-2026-03-05 ↑20.0k (⚡15.0k) ↓300');
+    // Cache-free model → no ⚡ parens.
+    expect(rows).toContain('local-llama ↑1.0k ↓50');
   });
 
-  it('empty team (all-zero totals) renders a disabled trigger with no popover to open', () => {
+  it('chip cache read updates live when teamTotals$ re-emits a new value', () => {
+    const fixture = setup(
+      { totalSent: 1_000, totalReceived: 200, totalCacheRead: 300, totalCacheWrite: 0 },
+      [{ modelName: 'gpt-5.4-2026-03-05', totalSent: 1_000, totalReceived: 200, totalCacheRead: 300, totalCacheWrite: 0 }],
+    );
+    fixture.detectChanges();
+    expect(footerText(fixture)).toBe('Team total ↑1.0k (⚡300) — ↓200');
+
+    totals$.next({ totalSent: 5_000, totalReceived: 900, totalCacheRead: 4_400, totalCacheWrite: 250 });
+    fixture.detectChanges();
+    expect(footerText(fixture)).toBe('Team total ↑5.0k (⚡4.4k) — ↓900');
+  });
+
+  it('empty team (all-zero totals) renders a disabled trigger with no popover rows to open', () => {
     const fixture = setup();
     fixture.detectChanges();
 
-    const trigger = footer(fixture);
-    expect(trigger.disabled).toBeTrue();
+    expect(footer(fixture).disabled).toBeTrue();
     expect(popoverRows(fixture)).toEqual([]);
   });
 });
@@ -430,6 +471,7 @@ describe('TreeComponent — OnPush regression (Story 30-3)', () => {
               totalCacheRead: 0,
               totalCacheWrite: 0,
             }),
+            teamByModel$: of([]),
             perAgent$: (_id: string) => of(undefined),
           },
         },

--- a/src/app/components/process/components/team-tabs/tree/tree.component.ts
+++ b/src/app/components/process/components/team-tabs/tree/tree.component.ts
@@ -60,6 +60,9 @@ export class TreeComponent implements OnInit, OnDestroy {
   // Bound via `async` in the template; never `undefined` (empty team → zeros).
   private readonly tokenUsageSelector = inject(TokenUsageSelector);
   readonly teamTotals$ = this.tokenUsageSelector.teamTotals$;
+  // Per-model breakdown feeding the footer popover (grouped by each agent's
+  // current model — see TokenUsageSelector.groupByModel approximation note).
+  readonly teamByModel$ = this.tokenUsageSelector.teamByModel$;
 
   treeNodes: TreeNode[] = []; // Correct initialization as an array of TreeNode
   expandedKeys: { [key: string]: boolean } = {};

--- a/src/app/components/process/selectors/token-usage.selector.spec.ts
+++ b/src/app/components/process/selectors/token-usage.selector.spec.ts
@@ -7,7 +7,11 @@ import { IngestionService } from '../event/ingestion.service';
 import { MessageLogService } from '../event/message-log.service';
 import { PerAgentStoreRegistry } from '../event/per-agent-store';
 import { AgentTokenUsage } from '../event/per-agent-specs';
-import { TeamTokenTotals, TokenUsageSelector } from './token-usage.selector';
+import {
+  ModelTokenTotals,
+  TeamTokenTotals,
+  TokenUsageSelector,
+} from './token-usage.selector';
 
 // ---------------------------------------------------------------------
 // Fixtures — EventMessage(LlmUsageEvent) envelopes driven through the REAL
@@ -33,6 +37,7 @@ function makeUsageEnvelope(
   output_tokens: number,
   cache_read_tokens = 0,
   cache_write_tokens = 0,
+  model_name = 'claude-sonnet',
 ): AkgenticMessage {
   return {
     id: 'usage-' + agentId + '-' + envCounter++,
@@ -46,7 +51,7 @@ function makeUsageEnvelope(
     event: {
       __model__: 'akgentic.llm.event.LlmUsageEvent',
       run_id: 'run-' + envCounter,
-      model_name: 'claude-sonnet',
+      model_name,
       provider_name: 'anthropic',
       input_tokens,
       output_tokens,
@@ -200,6 +205,69 @@ describe('TokenUsageSelector.teamTotals$ (AC #8)', () => {
       totalCacheRead: 0,
       totalCacheWrite: 0,
     });
+    sub.unsubscribe();
+  });
+});
+
+// ---------------------------------------------------------------------
+// teamByModel$ — per-model breakdown feeding the footer popover
+// ---------------------------------------------------------------------
+
+describe('TokenUsageSelector.teamByModel$', () => {
+  it('empty team yields an empty list', () => {
+    const { selector } = configureBed();
+    let received: ModelTokenTotals[] | undefined;
+    const sub = selector.teamByModel$.subscribe((v) => (received = v));
+    expect(received).toEqual([]);
+    sub.unsubscribe();
+  });
+
+  it('groups by model, merges agents on the same model, sorts by sent desc', () => {
+    const { log, selector } = configureBed();
+    let received: ModelTokenTotals[] | undefined;
+    const sub = selector.teamByModel$.subscribe((v) => (received = v));
+
+    log.appendAll([
+      // Two agents on gpt-5.4 (merge) + one on claude.
+      makeUsageEnvelope('A', 12_000, 100, 10_000, 0, 'gpt-5.4'),
+      makeUsageEnvelope('B', 4_800, 61, 2_800, 0, 'claude-opus-4-8'),
+      makeUsageEnvelope('C', 3_000, 20, 1_000, 0, 'gpt-5.4'),
+    ]);
+
+    // gpt-5.4 first (Σ sent 15_000 > claude 4_800); its two agents merged.
+    expect(received).toEqual([
+      {
+        modelName: 'gpt-5.4',
+        totalSent: 15_000,
+        totalReceived: 120,
+        totalCacheRead: 11_000,
+        totalCacheWrite: 0,
+      },
+      {
+        modelName: 'claude-opus-4-8',
+        totalSent: 4_800,
+        totalReceived: 61,
+        totalCacheRead: 2_800,
+        totalCacheWrite: 0,
+      },
+    ]);
+    sub.unsubscribe();
+  });
+
+  it('de-dupes: a log frame that changes no per-model total produces no new emission', () => {
+    const { log, selector } = configureBed();
+    const emissions: ModelTokenTotals[][] = [];
+    const sub = selector.teamByModel$.subscribe((v) => emissions.push(v));
+
+    log.append(makeUsageEnvelope('A', 100, 10, 0, 0, 'gpt-5.4')); // → emit
+    log.append(makeUnrelatedEnvelope('u1')); // no per-model change → NO emit
+
+    // initial [] + one real change = 2 emissions.
+    expect(emissions.length).toBe(2);
+    expect(emissions[0]).toEqual([]);
+    expect(emissions[1]).toEqual([
+      { modelName: 'gpt-5.4', totalSent: 100, totalReceived: 10, totalCacheRead: 0, totalCacheWrite: 0 },
+    ]);
     sub.unsubscribe();
   });
 });

--- a/src/app/components/process/selectors/token-usage.selector.ts
+++ b/src/app/components/process/selectors/token-usage.selector.ts
@@ -41,6 +41,63 @@ function sumTotals(all: ReadonlyMap<string, AgentTokenUsage>): TeamTokenTotals {
   return { totalSent, totalReceived, totalCacheRead, totalCacheWrite };
 }
 
+/** Team totals for ONE model — the same figures as `TeamTokenTotals`, tagged
+ *  with the model they belong to. */
+export interface ModelTokenTotals extends TeamTokenTotals {
+  modelName: string;
+}
+
+/** Group the team's usage by model and sum each group. Approximation note: the
+ *  store keeps only each agent's LATEST `model_name`, so an agent's cumulative
+ *  totals attribute to its current model — exact when an agent stays on one
+ *  model (the normal case), approximate if it switched mid-session. Agents that
+ *  have not run a model yet (`lastModelName === ''`) contribute nothing. Sorted
+ *  by sent desc (then name) for a stable, deterministic render order. */
+function groupByModel(
+  all: ReadonlyMap<string, AgentTokenUsage>,
+): ModelTokenTotals[] {
+  const byModel = new Map<string, ModelTokenTotals>();
+  for (const usage of all.values()) {
+    if (usage.lastModelName === '') continue;
+    const g = byModel.get(usage.lastModelName);
+    if (g) {
+      g.totalSent += usage.totalSent;
+      g.totalReceived += usage.totalReceived;
+      g.totalCacheRead += usage.totalCacheRead;
+      g.totalCacheWrite += usage.totalCacheWrite;
+    } else {
+      byModel.set(usage.lastModelName, {
+        modelName: usage.lastModelName,
+        totalSent: usage.totalSent,
+        totalReceived: usage.totalReceived,
+        totalCacheRead: usage.totalCacheRead,
+        totalCacheWrite: usage.totalCacheWrite,
+      });
+    }
+  }
+  return Array.from(byModel.values()).sort(
+    (a, b) => b.totalSent - a.totalSent || a.modelName.localeCompare(b.modelName),
+  );
+}
+
+/** Structural equality of two per-model lists (OnPush): the grouped array is a
+ *  fresh reference each frame, so a structural comparator suppresses no-op
+ *  re-emissions. Order is deterministic (`groupByModel` sorts), so positional
+ *  comparison is sound. */
+function modelListEqual(a: ModelTokenTotals[], b: ModelTokenTotals[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((x, i) => {
+    const y = b[i];
+    return (
+      x.modelName === y.modelName &&
+      x.totalSent === y.totalSent &&
+      x.totalReceived === y.totalReceived &&
+      x.totalCacheRead === y.totalCacheRead &&
+      x.totalCacheWrite === y.totalCacheWrite
+    );
+  });
+}
+
 /**
  * TokenUsageSelector — Epic 26 / Story 26-1 (ADR-022 §Decision 2).
  *
@@ -75,6 +132,16 @@ export class TokenUsageSelector {
     this.ingestion.tokenUsage.all$.pipe(
       map(sumTotals),
       distinctUntilChanged(totalsEqual),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+
+  /** Per-model breakdown of the team's usage (feeds the team-footer popover):
+   *  Σ per model, sorted sent-desc. Same scoping/derivation guarantees as
+   *  `teamTotals$` — pure over the scoped `all$`, structural dedupe, shareReplay. */
+  readonly teamByModel$: Observable<ModelTokenTotals[]> =
+    this.ingestion.tokenUsage.all$.pipe(
+      map(groupByModel),
+      distinctUntilChanged(modelListEqual),
       shareReplay({ bufferSize: 1, refCount: true }),
     );
 


### PR DESCRIPTION
## Story 30-5 — usage-display cleanup

Continuation of the Epic 30 usage-display work. OpenAI-family models report cache **reads** only — the provider exposes no cache-**write** count, so "Cache write" is always `0` for OpenAI runs (`genai-prices` only maps `cache_write` from Anthropic's `cache_creation_input_tokens`). This drops that noise and reshapes the displays.

### Member chat popover (`AkgentChatComponent`)
- Remove the `Cache write` row.
- Relabel the cache row to `Cache ⚡` (value `lastCacheRead / totalCacheRead`).
- Reduce the Context-window row to the bare figure (drop "of which N cached").

### Team footer (`TreeComponent`)
- Full-width strip `<div>` wrapping a **compact** `<button>` trigger, so the popover caret aligns under the text rather than the strip centre.
- Chip: `Team total ↑{sent} (⚡{cacheRead}) — ↓{received}` (parens only when cache read > 0); disabled on an all-zero (empty) team.
- Restored popover, now broken down **by model** — one `{model} ↑{sent} (⚡{cacheRead}) ↓{received}` row per model.

### Data layer (`TokenUsageSelector`)
- New derived `teamByModel$: Observable<ModelTokenTotals[]>` — groups the scoped usage by each agent's current model, sums per model, sorts by sent desc; structural dedupe + `shareReplay`. Reducer unchanged (still folds `totalCacheWrite` for Anthropic); the selector is only **extended**.
- Known approximation: the store keeps only each agent's latest model, so an agent that switched models mid-session attributes its totals to its current model — exact in the normal one-model-per-agent case.

### Notes
- Frontend-only (Golden Rule #4). Karma **1186/1186** green, ESLint clean.
- **Stacked** on `feat/215` (this branch depends on 30-1..30-4); base accordingly.

Closes #217
