### PR TITLE
feat(akgentic-frontend): 18-10 rename messageService alias to ingestionService

### DIFF
--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.spec.ts
@@ -14,8 +14,8 @@ import { ApiService } from '../../../../core/http/api.service';
 
 /**
  * Story 17-2 (ADR-014) — the agent-state panel and agent-chat context view are
- * now sourced from `messageService.state.forAgent(id)` /
- * `messageService.context.forAgent(id)` (PerAgentStore instances) instead of the
+ * now sourced from `ingestionService.state.forAgent(id)` /
+ * `ingestionService.context.forAgent(id)` (PerAgentStore instances) instead of the
  * deleted `stateDict$` / `contextDict$`. These specs verify the host wiring:
  * the local `state$` / `context$` bridge subjects reflect the store values, with
  * `undefined` mapped to the existing defaults (`null` / `[]`) so the template
@@ -24,7 +24,7 @@ import { ApiService } from '../../../../core/http/api.service';
 describe('AgentTabsComponent — store-backed state/context wiring (Story 17-2)', () => {
   let component: AgentTabsComponent;
   let log: MessageLogService;
-  let messageService: IngestionService;
+  let ingestionService: IngestionService;
   let selectedAkgent$: BehaviorSubject<Akgent | null>;
   let nodes$: BehaviorSubject<any[]>;
   let categories$: BehaviorSubject<any[]>;
@@ -113,13 +113,13 @@ describe('AgentTabsComponent — store-backed state/context wiring (Story 17-2)'
       ],
     });
 
-    messageService = TestBed.inject(IngestionService);
+    ingestionService = TestBed.inject(IngestionService);
     log = TestBed.inject(MessageLogService);
-    spyOn<any>(messageService, 'createWebSocket').and.returnValue(
+    spyOn<any>(ingestionService, 'createWebSocket').and.returnValue(
       fakeSocket as unknown as WebSocketSubject<any>,
     );
     // Wire the WS pipeline so the registry's log$ subscription is live.
-    await messageService.init('proc-1', true);
+    await ingestionService.init('proc-1', true);
 
     component = TestBed.createComponent(AgentTabsComponent).componentInstance;
     component.ngOnInit();

--- a/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
+++ b/src/app/components/process/components/agent-tabs/agent-tabs.component.ts
@@ -35,7 +35,7 @@ import { AkgentChatComponent } from './akgent-chat/akgent-chat.component';
 export class AgentTabsComponent implements OnInit {
   akgentService: AkgentService = inject(AkgentService);
   graphDataService: GraphDataService = inject(GraphDataService);
-  messageService: IngestionService = inject(IngestionService);
+  ingestionService: IngestionService = inject(IngestionService);
   private destroyRef = inject(DestroyRef);
 
   akgentId: string = '';
@@ -98,7 +98,7 @@ export class AgentTabsComponent implements OnInit {
           // `undefined` → the existing defaults (`[]` / `null`) so the template
           // guards (`(context$ | async)?.length`, `state$ | async`) behave
           // identically.
-          this.messageService.context
+          this.ingestionService.context
             .forAgent(akgent.agentId)
             .pipe(
               map((context) => context ?? []),
@@ -107,7 +107,7 @@ export class AgentTabsComponent implements OnInit {
             .subscribe((context) => {
               this.context$.next(context);
             });
-          this.messageService.state
+          this.ingestionService.state
             .forAgent(akgent.agentId)
             .pipe(
               map((state) => state ?? null),

--- a/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
+++ b/src/app/components/process/components/agent-tabs/akgent-chat/akgent-chat.component.ts
@@ -92,7 +92,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
   apiService: ApiService = inject(ApiService);
   utilService: UtilService = inject(UtilService);
   contextService: ContextService = inject(ContextService);
-  messageService: IngestionService = inject(IngestionService);
+  ingestionService: IngestionService = inject(IngestionService);
   private config = inject(ConfigService);
   // ADR-004 §5b: component-scoped selector provided on ProcessComponent.providers
   // (Story 16-1) — resolves the same MessageLogService instance as this subtree.
@@ -256,7 +256,7 @@ export class AkgentChatComponent implements OnInit, OnChanges {
     args: CommandDescriptor['args'];
   }[] {
     const descriptors =
-      this.messageService.commands.snapshot(this.agentId) ?? [];
+      this.ingestionService.commands.snapshot(this.agentId) ?? [];
     return descriptors
       // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
       // user-invocable — keep them out of the `/` dropdown.

--- a/src/app/components/process/components/chat/chat-panel.component.spec.ts
+++ b/src/app/components/process/components/chat/chat-panel.component.spec.ts
@@ -132,7 +132,7 @@ describe('ChatPanelComponent', () => {
     // stub mirrors the current surface — a `commands`-shaped object exposing
     // `snapshot(id)` (returns `[]` here: the empty-selection scenarios in this
     // spec short-circuit before any command lookup).
-    const messageService = {
+    const ingestionService = {
       commands: { snapshot: (_id: string) => [] as any[] },
       // Epic 18 (ADR-015 §2): the spinner state moved off ChatService onto
       // IngestionService; the component now reads `loadingProcess$` from here.
@@ -148,7 +148,7 @@ describe('ChatPanelComponent', () => {
         { provide: ApiService, useValue: apiService },
         { provide: AkgentService, useValue: akgentService },
         { provide: GraphDataService, useValue: graphDataService },
-        { provide: IngestionService, useValue: messageService },
+        { provide: IngestionService, useValue: ingestionService },
       ],
     }).compileComponents();
 

--- a/src/app/components/process/components/knowledge-graph/knowledge-graph.component.ts
+++ b/src/app/components/process/components/knowledge-graph/knowledge-graph.component.ts
@@ -32,7 +32,6 @@ import { CanvasRenderer } from 'echarts/renderers';
 import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 
 import { KGStateReducer } from '../../selectors/knowledge-graph.selector';
-import { IngestionService } from '../../event/ingestion.service';
 
 echarts.use([
   CanvasRenderer,
@@ -121,9 +120,8 @@ export class KnowledgeGraphComponent implements OnInit, OnDestroy {
 
   zone: NgZone = inject(NgZone);
   route: ActivatedRoute = inject(ActivatedRoute);
-  messageService: IngestionService = inject(IngestionService);
   // Story 6.2 (ADR-005 §Decision 4): subscribe to the pure selector instead
-  // of the former `messageService.knowledgeGraph$` passthrough (deleted).
+  // of the former ingestion knowledgeGraph$ passthrough (deleted).
   private readonly kgReducer: KGStateReducer = inject(KGStateReducer);
 
   currentProcessId: string = '';

--- a/src/app/components/process/components/team-tabs/graph/graph.component.ts
+++ b/src/app/components/process/components/team-tabs/graph/graph.component.ts
@@ -22,7 +22,6 @@ import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
 import { AkgentService } from '../../../../../core/ui/akgent.service';
 import { ApiService } from '../../../../../core/http/api.service';
 import { CategoryService } from '../../../../../core/ui/category.service';
-import { IngestionService } from '../../../event/ingestion.service';
 
 // Import the shared GraphDataService
 import { makeAgentNameUserFriendly } from '../../../../../shared/util/util';
@@ -62,7 +61,6 @@ export class GraphComponent {
   apiService: ApiService = inject(ApiService);
   akgentService: AkgentService = inject(AkgentService);
   categoryService: CategoryService = inject(CategoryService);
-  messageService: IngestionService = inject(IngestionService);
   graphDataService: GraphDataService = inject(GraphDataService);
   selectionService: SelectionService = inject(SelectionService);
 

--- a/src/app/components/process/components/user-input/user-input.component.spec.ts
+++ b/src/app/components/process/components/user-input/user-input.component.spec.ts
@@ -76,7 +76,7 @@ describe('ProcessUserInputComponent', () => {
     };
 
     commandsById = {};
-    const messageServiceStub = {
+    const ingestionServiceStub = {
       commands: {
         snapshot: (id: string): CommandDescriptor[] | undefined =>
           commandsById[id],
@@ -90,7 +90,7 @@ describe('ProcessUserInputComponent', () => {
         { provide: ChatService, useValue: chatServiceMock },
         { provide: ContextService, useValue: contextServiceStub },
         { provide: GraphDataService, useValue: graphDataService },
-        { provide: IngestionService, useValue: messageServiceStub },
+        { provide: IngestionService, useValue: ingestionServiceStub },
       ],
     }).compileComponents();
 

--- a/src/app/components/process/components/user-input/user-input.component.ts
+++ b/src/app/components/process/components/user-input/user-input.component.ts
@@ -45,7 +45,7 @@ export class ProcessUserInputComponent implements OnInit {
   chatService: ChatService = inject(ChatService);
   contextService: ContextService = inject(ContextService);
   graphDataService: GraphDataService = inject(GraphDataService);
-  messageService: IngestionService = inject(IngestionService);
+  ingestionService: IngestionService = inject(IngestionService);
   private config = inject(ConfigService);
   userInput: string = '';
   userInputEnterKeySubmit: boolean = this.config.userInputEnterKeySubmit;
@@ -265,7 +265,7 @@ export class ProcessUserInputComponent implements OnInit {
   }[] {
     const agentId = this.targetedAgentId();
     if (!agentId) return [];
-    const descriptors = this.messageService.commands.snapshot(agentId) ?? [];
+    const descriptors = this.ingestionService.commands.snapshot(agentId) ?? [];
     return descriptors
       // `_`-prefixed commands (e.g. `_expand_media_refs`) are internal, not
       // user-invocable — keep them out of the `/` dropdown.

--- a/src/app/components/process/process.component.spec.ts
+++ b/src/app/components/process/process.component.spec.ts
@@ -134,7 +134,7 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
     // Code review fix: `knowledgeGraphLoading$` deleted (dead state, never
     // `.next()`-ed and its `isLoading$` consumer was never read in the KG
     // component template — collapsed into the two-exceptions invariant purity).
-    const messageService = {
+    const ingestionService = {
       init: jasmine.createSpy('init').and.returnValue(Promise.resolve()),
     };
 
@@ -183,7 +183,7 @@ describe('ProcessComponent (Story 6.2 — log-driven presence)', () => {
         KGStateReducer,
         WorkspaceRegistryService,
         { provide: ContextService, useValue: contextService },
-        { provide: IngestionService, useValue: messageService },
+        { provide: IngestionService, useValue: ingestionService },
         { provide: AkgentService, useValue: akgentService },
         { provide: GraphDataService, useValue: graphDataService },
         { provide: ChatService, useValue: chatService },
@@ -360,7 +360,7 @@ function firstValue<T>(observable$: {
 }
 
 // =====================================================================
-// Story 10-2 — single-fetch navigation and messageService.init argument
+// Story 10-2 — single-fetch navigation and ingestionService.init argument
 // =====================================================================
 
 describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
@@ -380,7 +380,7 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
         .and.returnValue(Promise.resolve(options.fetchedTeam)),
     };
 
-    const messageService = {
+    const ingestionService = {
       init: jasmine.createSpy('init').and.returnValue(Promise.resolve()),
     };
 
@@ -416,7 +416,7 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
         KGStateReducer,
         WorkspaceRegistryService,
         { provide: ContextService, useValue: contextService },
-        { provide: IngestionService, useValue: messageService },
+        { provide: IngestionService, useValue: ingestionService },
         { provide: AkgentService, useValue: akgentService },
         { provide: GraphDataService, useValue: graphDataService },
         { provide: ChatService, useValue: chatService },
@@ -446,7 +446,7 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
       component,
       fixture,
       contextSpy: contextService,
-      messageSpy: messageService,
+      messageSpy: ingestionService,
       routerSpy: router,
     };
   }
@@ -461,19 +461,19 @@ describe('ProcessComponent (Story 10-2 — single-fetch navigation)', () => {
     expect(contextSpy.getCurrentTeam).toHaveBeenCalledWith('team-1', false);
   });
 
-  it('(AC6) messageService.init is called with (processId, true) for a running team', async () => {
+  it('(AC6) ingestionService.init is called with (processId, true) for a running team', async () => {
     const { messageSpy } = await setup({ fetchedTeam: makeTeam({ status: 'running' }) });
     expect(messageSpy.init).toHaveBeenCalledTimes(1);
     expect(messageSpy.init).toHaveBeenCalledWith('team-1', true);
   });
 
-  it('(AC6) messageService.init is called with (processId, false) for a stopped team', async () => {
+  it('(AC6) ingestionService.init is called with (processId, false) for a stopped team', async () => {
     const { messageSpy } = await setup({ fetchedTeam: makeTeam({ status: 'stopped' }) });
     expect(messageSpy.init).toHaveBeenCalledTimes(1);
     expect(messageSpy.init).toHaveBeenCalledWith('team-1', false);
   });
 
-  it('(AC6) null team short-circuits: router.navigate([/]) is called and messageService.init is NOT', async () => {
+  it('(AC6) null team short-circuits: router.navigate([/]) is called and ingestionService.init is NOT', async () => {
     const { messageSpy, routerSpy } = await setup({ fetchedTeam: null });
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
     expect(messageSpy.init).not.toHaveBeenCalled();

--- a/src/app/components/process/process.component.ts
+++ b/src/app/components/process/process.component.ts
@@ -99,7 +99,7 @@ export class ProcessComponent implements OnDestroy {
 
   akgentService: AkgentService = inject(AkgentService);
   contextService: ContextService = inject(ContextService);
-  messageService: IngestionService = inject(IngestionService);
+  ingestionService: IngestionService = inject(IngestionService);
   graphDataService: GraphDataService = inject(GraphDataService);
   viewService: ViewService = inject(ViewService);
   toolPresenceService: ToolPresenceService = inject(ToolPresenceService);
@@ -213,7 +213,7 @@ export class ProcessComponent implements OnDestroy {
     // `StartMessage` / `StopMessage` on the replay + live streams. Workspace
     // presence remains static until a future story reactivates it.
 
-    await this.messageService.init(this.processId, isRunning(currentProcess));
+    await this.ingestionService.init(this.processId, isRunning(currentProcess));
   }
 
   ngOnDestroy() {

--- a/src/app/components/process/selectors/system-prompt.selector.ts
+++ b/src/app/components/process/selectors/system-prompt.selector.ts
@@ -45,11 +45,11 @@ export {
  */
 @Injectable()
 export class SystemPromptSelector {
-  private readonly messageService: IngestionService =
+  private readonly ingestionService: IngestionService =
     inject(IngestionService);
 
   latestSystemPrompt$(agentId: string): Observable<SystemPromptRow[]> {
-    return this.messageService.systemPrompt
+    return this.ingestionService.systemPrompt
       .forAgent(agentId)
       .pipe(map((value) => value?.rows ?? []));
   }


### PR DESCRIPTION
## Summary

Story 18-10 — standardise the `IngestionService` injection field name to `ingestionService`, retiring the legacy `messageService` alias so a field named `messageService` unambiguously means PrimeNG's toast `MessageService` everywhere it survives.

Pure identifier rename + two dead-code removals — **zero behavior change**.

## Changes

- **Live renames (5 sites):** `messageService: IngestionService` → `ingestionService`, and every `this.messageService.*` usage updated, in `process.component.ts`, `agent-tabs.component.ts`, `akgent-chat.component.ts`, `user-input.component.ts`, and `system-prompt.selector.ts`.
- **Dead-field removals (2 sites):** deleted the unused `IngestionService` injection (and its now-unused import) in `graph.component.ts` and `knowledge-graph.component.ts`; repaired the stale KG comment naming the deleted `messageService.knowledgeGraph$` passthrough.
- **Spec updates (4 files):** renamed `IngestionService` stubs/vars/bindings/comments/titles from `messageService`/`messageServiceStub` to `ingestionService`/`ingestionServiceStub`.
- **Untouched:** every field typed PrimeNG `MessageService` keeps the `messageService` name; `chat-panel` (`ingestionService`) and `token-usage.selector` (`ingestion`) were already correct and left as-is.

## Quality gate (local — NFR6, no remote CI gating)

- `npm run lint` → clean
- `npm run build` → SUCCESS (only the pre-existing lodash CommonJS warning)
- Karma headless (`ChromeHeadlessNoSandbox`) → **1186/1186 SUCCESS**, zero regressions vs. the Epic-18 baseline

## Review

Reviewed by Rex (adversarial code review): APPROVED, no fix-worthy issues. All ACs satisfied; all changes confined to `src/app/**`.

Closes #220
