### PR TITLE
fix(akgentic-frontend): epic 30 — cut API-key login over to POST with a body

### DIFF
--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -4,11 +4,12 @@ import { AuthService } from './auth.service';
 import { ConfigService } from '../config/config.service';
 
 /**
- * Specs for {@link AuthService.loginWithApiKey} (Stories 1.8, 1.9).
+ * Specs for {@link AuthService.loginWithApiKey} (Stories 1.8, 1.9, 30.1).
  *
  * The network boundary is the global `fetch`, which is stubbed via a Jasmine
- * spy — no real server is contacted. The backend returns a `200` JSON body
- * (`{"success": true, "user": {...}}`) on success; the body itself is the
+ * spy — no real server is contacted. The key travels in a `POST` JSON body
+ * (`{"apikey": "<key>"}`), never in the URL. The backend returns a `200` JSON
+ * body (`{"success": true, "user": {...}}`) on success; the body itself is the
  * success signal — no redirect is followed and no `/auth/me` round-trip is
  * issued.
  */
@@ -43,19 +44,31 @@ describe('AuthService', () => {
   });
 
   describe('loginWithApiKey — success path (AC #2, #4, #5)', () => {
-    it('calls /auth/login/apikey with the key URL-encoded and credentials: include', async () => {
+    it('POSTs the key in a JSON body to a URL that never carries it', async () => {
       // One call only — the 200 JSON body is the success signal, no /auth/me.
       fetchSpy.and.returnValue(
         Promise.resolve(makeResponse(true, { success: true, user: { user_id: 'u1', name: 'Op' } })),
       );
 
-      await firstValueFrom(service.loginWithApiKey('secret key/+&'));
+      const key = 'secret key/+&';
+      await firstValueFrom(service.loginWithApiKey(key));
 
       const loginCall = fetchSpy.calls.argsFor(0);
-      expect(loginCall[0]).toBe(
-        `${API}/auth/login/apikey?apikey=${encodeURIComponent('secret key/+&')}`,
-      );
-      expect((loginCall[1] as RequestInit).credentials).toBe('include');
+      const url = loginCall[0] as string;
+      const init = loginCall[1] as RequestInit;
+
+      // The key never reaches the URL — raw or URL-encoded.
+      expect(url).toBe(`${API}/auth/login/apikey`);
+      expect(url).not.toContain(key);
+      expect(url).not.toContain(encodeURIComponent(key));
+
+      expect(init.method).toBe('POST');
+      // Load-bearing: the backend binds the session via Set-Cookie.
+      expect(init.credentials).toBe('include');
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+      // Parse rather than string-match: key order in JSON.stringify is incidental.
+      expect(JSON.parse(init.body as string)).toEqual({ apikey: key });
     });
 
     it('reads the 200 JSON body so currentUser$ reflects the response user', async () => {

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -55,14 +55,16 @@ export class AuthService {
   /**
    * Authenticate with an API key against the backend.
    *
-   * Drives `GET /auth/login/apikey?apikey=<key>` with `credentials: 'include'`
-   * so the backend's `Set-Cookie` session response is stored by the browser.
-   * The same endpoint contract is exposed by both the Department and Enterprise
-   * tiers, so this single code path covers both — no tier-specific branching.
+   * Drives `POST /auth/login/apikey` with a JSON body (`{"apikey": "<key>"}`)
+   * and `credentials: 'include'` so the backend's `Set-Cookie` session response
+   * is stored by the browser. The same endpoint contract is exposed by both the
+   * Department and Enterprise tiers, so this single code path covers both — no
+   * tier-specific branching.
    *
-   * The API key is sent once as a query parameter and is NEVER persisted in the
-   * browser; the session cookie set by the backend is the sole post-login
-   * credential, exactly as on the OAuth path.
+   * The API key is sent once in the request body — never in the URL, where it
+   * would be captured by access logs, browser history, and `Referer` headers —
+   * and is NEVER persisted in the browser; the session cookie set by the backend
+   * is the sole post-login credential, exactly as on the OAuth path.
    *
    * On an HTTP `2xx` response the backend returns a `200` JSON body
    * (`{"success": true, "user": {...}}`) — no redirect. The JSON body itself
@@ -72,8 +74,13 @@ export class AuthService {
    * the caller can surface the message.
    */
   loginWithApiKey(apiKey: string): Observable<any> {
-    const url = `${this.config.api}/auth/login/apikey?apikey=${encodeURIComponent(apiKey)}`;
-    const options: RequestInit = { credentials: 'include' };
+    const url = `${this.config.api}/auth/login/apikey`;
+    const options: RequestInit = {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ apikey: apiKey }),
+    };
     return from(
       fetch(url, options).then(async (r) => {
         // A 401 (invalid/unknown/expired key) is not ok — error the observable.

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -57,9 +57,11 @@ export class AuthService {
    *
    * Drives `POST /auth/login/apikey` with a JSON body (`{"apikey": "<key>"}`)
    * and `credentials: 'include'` so the backend's `Set-Cookie` session response
-   * is stored by the browser. The same endpoint contract is exposed by both the
-   * Department and Enterprise tiers, so this single code path covers both — no
-   * tier-specific branching.
+   * is stored by the browser. One code path, no tier-specific branching: the
+   * endpoint is owned by the shared backend auth library, so every tier that
+   * adopts it serves the same contract. (Enterprise has not adopted it yet and
+   * still serves a legacy variant; that is tracked backend-side, and this client
+   * deliberately does not branch to accommodate it.)
    *
    * The API key is sent once in the request body — never in the URL, where it
    * would be captured by access logs, browser history, and `Referer` headers —


### PR DESCRIPTION
## Epic 30 — Cut API-key login over to POST with a body

The API key travelled in the URL query string (`GET /auth/login/apikey?apikey=<key>`), where it is captured un-recoverably by server access logs, browser history, `Referer` headers propagated to third-party origins, and APM/OTel URL tracing. This moves it into a `POST` JSON body. Response handling is unchanged.

`AuthService.loginWithApiKey()` now issues:

```
POST ${config.api}/auth/login/apikey
Content-Type: application/json
credentials: include
{"apikey": "<key>"}
```

`credentials: 'include'` is load-bearing — the backend binds the session server-side and returns a `Set-Cookie` the browser must store. The session cookie remains the sole post-login credential; the key is never persisted client-side.

### Stories

- [x] 30-1 — Send the API key in a POST body instead of a query parameter (Relates to #222)

### Review status

**Approved — no fixes required.** Reviewed the full diff against the story's acceptance criteria:

- The key reaches no URL on any code path — the fetch URL is the bare endpoint, with no query string and no path segment. Verified by reading the implementation, and guarded by a spec asserting the URL equals the bare endpoint and contains neither the raw nor the URL-encoded key.
- Request shape is `POST` + `credentials: 'include'` + `Content-Type: application/json` + `JSON.stringify({ apikey })`.
- The response handler is untouched: `!r.ok` throws `'Invalid API key'`; otherwise `await r.json()`, `user = body?.user ?? ANONYMOUS_USER`, name backfill from `email` / `user_id` / `'User'`, `currentUserSubject.next(user)`, return `user`. The 200-body, 401-error, no-session-on-401, and both no-persistence specs pass unmodified — confirming no drift.
- The awkward-key case (`'secret key/+&'`) was adapted rather than deleted. `encodeURIComponent` is gone from this path and `JSON.stringify` now owns the escaping; the spec asserts the key round-trips through the JSON body byte-identical via `JSON.parse`, not by string-matching the serialized form.
- No client-side key persistence added; no key-storage methods reintroduced.
- The stale `GET …?apikey=<key>` docstring lines were corrected to the POST form. The block describing the 200-JSON contract was already correct and was left alone.
- No test asserts on an `ADR-NNN` string.

Karma: 1186/1186 passing, matching the pre-review baseline.

### Scope guard

All changes stay inside `packages/akgentic-frontend/`. Two files touched:

- `src/app/core/auth/auth.service.ts`
- `src/app/core/auth/auth.service.spec.ts`

`login.component.ts:82` (the OAuth provider path, `/auth/login/{provider}`) is a different and unaffected endpoint — untouched. `X-API-Key` header auth is a separate flow and is unaffected. No other submodule is touched.

### Deploy ordering

**This must deploy together with `akgentic-infra-auth` PR #26**, which adds `POST /auth/login/apikey`. Auth merges and releases first.

There is deliberately no GET fallback and no tier-branching, so shipping this frontend build against a backend that lacks the POST endpoint breaks API-key login.

Between the auth merge and this one the symptom is an **unchanged `404`** — expected, not a regression. (An earlier revision of this body said `405`; that was wrong and is retracted. A GET only *partially* matches the literal POST route, so Starlette falls through to `GET /login/{provider}`, matches `provider="apikey"`, and returns `404 "Unknown provider: apikey"` exactly as before the fix.) **Consequence for reviewers: verify the auth-side merge with a `POST`, not a browser or default `curl`** — a GET check looks identical to the original bug and will read as "the fix didn't land".

One live-verification note: `Content-Type: application/json` makes this a non-simple cross-origin request, so the browser now issues a CORS preflight (`OPTIONS`) that the query-string GET did not. The target tier's CORS config must allow `POST` and the `Content-Type` header on this route. This does not affect the specs (`fetch` is stubbed), but it is the most likely surprise during live testing.

